### PR TITLE
Fix dependency on migration

### DIFF
--- a/agent/alembic/versions/c0a2f2d2fe85_add_workflow_circuit_breaker_support.py
+++ b/agent/alembic/versions/c0a2f2d2fe85_add_workflow_circuit_breaker_support.py
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 revision: str = 'c0a2f2d2fe85'
 down_revision: Union[str, None] = '9b011bf1de45'
 branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = 'a1b2c3d4e5f6'
 
 
 def upgrade() -> None:


### PR DESCRIPTION
Hi there,

When I cloned the project and ran the docker compose command line I got the following error in the logs:

```
kanchi-1  | 2025-10-29 06:57:13,756 - alembic.runtime.migration - INFO - Running upgrade 9b011bf1de45 -> c0a2f2d2fe85, Add circuit breaker support for workflows
kanchi-1  | ERROR:    Traceback (most recent call last):
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1967, in _exec_single_context
kanchi-1  |     self.dialect.do_execute(
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 951, in do_execute
kanchi-1  |     cursor.execute(statement, parameters)
kanchi-1  | sqlite3.OperationalError: no such table: workflows
kanchi-1  | 
kanchi-1  | The above exception was the direct cause of the following exception:
kanchi-1  | 
kanchi-1  | Traceback (most recent call last):
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 677, in lifespan
kanchi-1  |     async with self.lifespan_context(app) as maybe_state:
kanchi-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
kanchi-1  |   File "/usr/local/lib/python3.12/contextlib.py", line 210, in __aenter__
kanchi-1  |     return await anext(self.gen)
kanchi-1  |            ^^^^^^^^^^^^^^^^^^^^^
kanchi-1  |   File "/app/agent/app.py", line 47, in lifespan
kanchi-1  |     await initialize_application()
kanchi-1  |   File "/app/agent/app.py", line 218, in initialize_application
kanchi-1  |     app_state.db_manager.run_migrations()
kanchi-1  |   File "/app/agent/database.py", line 540, in run_migrations
kanchi-1  |     command.upgrade(alembic_cfg, 'head')
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/alembic/command.py", line 406, in upgrade
kanchi-1  |     script.run_env()
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/alembic/script/base.py", line 586, in run_env
kanchi-1  |     util.load_python_file(self.dir, "env.py")
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/alembic/util/pyfiles.py", line 95, in load_python_file
kanchi-1  |     module = load_module_py(module_id, path)
kanchi-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/alembic/util/pyfiles.py", line 113, in load_module_py
kanchi-1  |     spec.loader.exec_module(module)  # type: ignore
kanchi-1  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
kanchi-1  |   File "<frozen importlib._bootstrap_external>", line 999, in exec_module
kanchi-1  |   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
kanchi-1  |   File "/app/agent/alembic/env.py", line 90, in <module>
kanchi-1  |     run_migrations_online()
kanchi-1  |   File "/app/agent/alembic/env.py", line 84, in run_migrations_online
kanchi-1  |     context.run_migrations()
kanchi-1  |   File "<string>", line 8, in run_migrations
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/alembic/runtime/environment.py", line 946, in run_migrations
kanchi-1  |     self.get_context().run_migrations(**kw)
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/alembic/runtime/migration.py", line 623, in run_migrations
kanchi-1  |     step.migration_fn(**kw)
kanchi-1  |   File "/app/agent/alembic/versions/c0a2f2d2fe85_add_workflow_circuit_breaker_support.py", line 23, in upgrade
kanchi-1  |     op.add_column('workflows', sa.Column('circuit_breaker_config', sa.JSON(), nullable=True))
kanchi-1  |   File "<string>", line 8, in add_column
kanchi-1  |   File "<string>", line 3, in add_column
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/alembic/operations/ops.py", line 2156, in add_column
kanchi-1  |     return operations.invoke(op)
kanchi-1  |            ^^^^^^^^^^^^^^^^^^^^^
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/alembic/operations/base.py", line 442, in invoke
kanchi-1  |     return fn(self, operation)
kanchi-1  |            ^^^^^^^^^^^^^^^^^^^
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/alembic/operations/toimpl.py", line 183, in add_column
kanchi-1  |     operations.impl.add_column(table_name, column, schema=schema, **kw)
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/alembic/ddl/impl.py", line 374, in add_column
kanchi-1  |     self._exec(base.AddColumn(table_name, column, schema=schema))
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/alembic/ddl/impl.py", line 247, in _exec
kanchi-1  |     return conn.execute(construct, params)
kanchi-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1419, in execute
kanchi-1  |     return meth(
kanchi-1  |            ^^^^^
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/sqlalchemy/sql/ddl.py", line 187, in _execute_on_connection
kanchi-1  |     return connection._execute_ddl(
kanchi-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1530, in _execute_ddl
kanchi-1  |     ret = self._execute_context(
kanchi-1  |           ^^^^^^^^^^^^^^^^^^^^^^
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1846, in _execute_context
kanchi-1  |     return self._exec_single_context(
kanchi-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1986, in _exec_single_context
kanchi-1  |     self._handle_dbapi_exception(
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 2355, in _handle_dbapi_exception
kanchi-1  |     raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1967, in _exec_single_context
kanchi-1  |     self.dialect.do_execute(
kanchi-1  |   File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 951, in do_execute
kanchi-1  |     cursor.execute(statement, parameters)
kanchi-1  | sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: workflows
kanchi-1  | [SQL: ALTER TABLE workflows ADD COLUMN circuit_breaker_config JSON]
kanchi-1  | (Background on this error at: https://sqlalche.me/e/20/e3q8)
kanchi-1  | 
kanchi-1  | ERROR:    Application startup failed. Exiting.
```

So I added a dependency on the circruit breaker migration to the migration creating the worklow table. I am not an expert on Alembic, but I did solve my problem.

Please let me know if it works for you