### PR TITLE
Fix delete workflow

### DIFF
--- a/frontend/app/pages/workflows/index.vue
+++ b/frontend/app/pages/workflows/index.vue
@@ -193,7 +193,7 @@
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogCancel @click="workflowToDelete = null">Cancel</AlertDialogCancel>
           <AlertDialogAction
             class="bg-status-error hover:bg-status-error-hover"
             @click="deleteWorkflow(workflowToDelete!)"


### PR DESCRIPTION
Hi there,

I found this while trying to delete a test workflow I created on my machine. This flag was setting the `workflowToDelete` as `null` before calling the `@click` so it would fail everything when pressing "Confirm".

I split the logic between cancel and confirm and seems to be working so far, there is probably something prettier in Vue.js, let me know .