### PR TITLE
Add ARM64 platform support to Docker workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Fixes #30 by enabling multi-platform builds for both linux/amd64 and linux/arm64. This allows the Docker image to be pulled and run on ARM64 systems without manifest errors.