### PR TITLE
fix: enhance _json_safe method to handle Enum types #43

### DIFF
--- a/agent/services/workflow_service.py
+++ b/agent/services/workflow_service.py
@@ -4,6 +4,7 @@ import logging
 import uuid
 from datetime import date, datetime, timezone, timedelta
 from typing import Any, Dict, List, Optional, Set
+from enum import Enum
 
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
@@ -88,6 +89,9 @@ class WorkflowService:
 
         if isinstance(value, uuid.UUID):
             return str(value)
+
+        if isinstance(value, Enum):
+            return value.value
 
         if isinstance(value, dict):
             return {key: self._json_safe(val) for key, val in value.items()}

--- a/agent/tests/unit/test_workflow_service_json_safe.py
+++ b/agent/tests/unit/test_workflow_service_json_safe.py
@@ -1,0 +1,35 @@
+import json
+from enum import Enum
+
+from services.workflow_service import WorkflowService
+
+
+class _DummyEnum(str, Enum):
+    FOO = "foo"
+
+
+class _PlainObject:
+    def __init__(self):
+        self.value = "bar"
+
+
+def test_json_safe_handles_enums_and_plain_objects():
+    svc = WorkflowService(None)  # Session is unused in _json_safe
+
+    payload = {
+        "enum": _DummyEnum.FOO,
+        "plain": _PlainObject(),
+        "nested": {"things": [_DummyEnum.FOO]},
+    }
+
+    sanitized = svc._json_safe(payload)
+
+    # Enum should become its value
+    assert sanitized["enum"] == "foo"
+    # Plain object should be reduced to its __dict__ contents
+    assert sanitized["plain"] == {"value": "bar"}
+    # Nested enums should also be converted
+    assert sanitized["nested"]["things"] == ["foo"]
+
+    # And the whole structure must be JSON serializable
+    json.dumps(sanitized)


### PR DESCRIPTION
- Updated the _json_safe method in WorkflowService to convert Enum instances to their values.
- Added unit tests to verify that Enums and plain objects are correctly processed and serialized to JSON.