### PR TITLE
feat: add support for pickle serialization in Celery monitor closes #46

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Run Kanchi using pre-built images from Docker Hub. No repository cloning require
          # Optional: Logging and development
          LOG_LEVEL: ${LOG_LEVEL:-INFO}
          DEVELOPMENT_MODE: ${DEVELOPMENT_MODE:-false}
+         ENABLE_PICKLE_SERIALIZATION: ${ENABLE_PICKLE_SERIALIZATION:-false}
 
          # Optional: Frontend URLs
          NUXT_PUBLIC_API_URL: ${NUXT_PUBLIC_API_URL:-http://localhost:8765}
@@ -114,6 +115,7 @@ Run Kanchi using pre-built images from Docker Hub. No repository cloning require
    export DATABASE_URL=postgresql://user:pass@postgres-host:5432/kanchi
    export LOG_LEVEL=INFO
    export DEVELOPMENT_MODE=false
+   export ENABLE_PICKLE_SERIALIZATION=false
    export NUXT_PUBLIC_API_URL=http://your-kanchi-host:8765
    export NUXT_PUBLIC_WS_URL=ws://your-kanchi-host:8765/ws
 
@@ -142,6 +144,9 @@ Run Kanchi using pre-built images from Docker Hub. No repository cloning require
    # Token secrets (must be non-default in production)
    export SESSION_SECRET_KEY=$(openssl rand -hex 32)
    export TOKEN_SECRET_KEY=$(openssl rand -hex 32)
+
+# Pickle payloads (advanced; defaults to off)
+export ENABLE_PICKLE_SERIALIZATION=false
    ```
 
 3. **Start or update Kanchi in one command**
@@ -169,6 +174,10 @@ Run Kanchi using pre-built images from Docker Hub. No repository cloning require
 Kanchi expects a Celery broker (RabbitMQ or Redis) and (if desired) PostgreSQL to be managed separately—point `CELERY_BROKER_URL` and `DATABASE_URL` to the infrastructure you already run.
 
 Migrations run automatically on startup.
+
+### Pickle payloads (opt-in)
+
+Kanchi rejects pickle-serialized messages by default for safety. If your Celery producers emit `application/x-python-serialize`, set `ENABLE_PICKLE_SERIALIZATION=true` only when you fully trust all producers and the broker. See `pickle.md` for a short rundown.
 
 ### Authentication
 
@@ -262,5 +271,3 @@ npx swagger-typescript-api generate -p http://localhost:8765/openapi.json -o app
 ## License
 
 Licensed under [MIT](LICENSE)
-
-

--- a/agent/app.py
+++ b/agent/app.py
@@ -278,7 +278,10 @@ def start_monitor(config: Config):
         return
     
     logger.info(f"Starting Celery monitor with broker: {config.broker_url}")
-    app_state.monitor_instance = CeleryEventMonitor(config.broker_url)
+    app_state.monitor_instance = CeleryEventMonitor(
+        broker_url=config.broker_url,
+        allow_pickle_serialization=config.enable_pickle_serialization,
+    )
     
     app_state.monitor_instance.set_task_callback(app_state.event_handler.handle_task_event)
     app_state.monitor_instance.set_worker_callback(app_state.event_handler.handle_worker_event)

--- a/agent/config.py
+++ b/agent/config.py
@@ -62,6 +62,9 @@ class Config:
         default_factory=lambda: _split_csv(os.getenv('ALLOWED_EMAIL_PATTERNS'))
     )
 
+    # Serialization (disabled by default; enabling allows pickle deserialization)
+    enable_pickle_serialization: bool = _as_bool(os.getenv('ENABLE_PICKLE_SERIALIZATION', 'false'))
+
     # Basic auth credentials (optional)
     basic_auth_username: Optional[str] = os.getenv('BASIC_AUTH_USERNAME')
     basic_auth_password: Optional[str] = os.getenv('BASIC_AUTH_PASSWORD')


### PR DESCRIPTION
- Introduced ENABLE_PICKLE_SERIALIZATION environment variable to control pickle deserialization.
- Updated CeleryEventMonitor to accept a flag for enabling pickle serialization.
- Enhanced README with instructions on using pickle serialization safely.

This feature allows users to opt-in to pickle deserialization when they trust all message producers.