### PR TITLE
Add disclaimer under Raw Task Data section

### DIFF
--- a/frontend/app/pages/tasks/[id].vue
+++ b/frontend/app/pages/tasks/[id].vue
@@ -256,6 +256,9 @@
               <!-- Raw Task Data -->
               <div class="border border-border rounded-md p-5">
                 <h2 class="text-sm font-medium text-text-primary mb-4">Raw Task Data</h2>
+                <p class="text-xs text-text-muted mb-2">
+                  This is the internal representation of the task, not the original Celery task payload.
+                </p>
                 <pre class="text-xs font-mono bg-background-base border border-border rounded p-3 overflow-x-auto text-text-muted">{{ formatJson(task) }}</pre>
               </div>
             </div>


### PR DESCRIPTION
Fixes #64

Added a disclaimer below "Raw Task Data" clarifying that this is the internal representation of the task, not the original Celery task payload.
