### PR TITLE
Pin @vue/devtools-kit to 7.7.5 to fix breaking change

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,6 @@
         "@radix-ui/colors": "^3.0.0",
         "@tailwindcss/vite": "^4.1.13",
         "@tanstack/vue-table": "^8.21.3",
-        "@vue/devtools-kit": "^7.7.5",
         "@vueuse/core": "^13.9.0",
         "autoprefixer": "^10.4.21",
         "class-variance-authority": "^0.7.1",
@@ -35,6 +34,7 @@
       },
       "devDependencies": {
         "@apidevtools/swagger-parser": "^12.0.0",
+        "@vue/devtools-kit": "^7.7.5",
         "axios": "^1.12.1",
         "openapi-typescript": "^7.9.1",
         "swagger-typescript-api": "^13.2.10"
@@ -4220,6 +4220,7 @@
       "version": "7.7.5",
       "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.5.tgz",
       "integrity": "sha512-S9VAVJYVAe4RPx2JZb9ZTEi0lqTySz2CBeF0wHT5D3dkTLnT9yMMGegKNl4b2EIELwLSkcI9bl2qp0/jW+upqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/devtools-shared": "^7.7.5",
@@ -4235,6 +4236,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vue/devtools-shared": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,6 @@
     "@radix-ui/colors": "^3.0.0",
     "@tailwindcss/vite": "^4.1.13",
     "@tanstack/vue-table": "^8.21.3",
-    "@vue/devtools-kit": "^7.7.5",
     "@vueuse/core": "^13.9.0",
     "autoprefixer": "^10.4.21",
     "class-variance-authority": "^0.7.1",
@@ -41,6 +40,7 @@
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^12.0.0",
+    "@vue/devtools-kit": "^7.7.5",
     "axios": "^1.12.1",
     "openapi-typescript": "^7.9.1",
     "swagger-typescript-api": "^13.2.10"


### PR DESCRIPTION
Hi @czyber I got an error when pulling + `npm install` and `make dev` the latest version of Kanchi:

<img width="1216" height="526" alt="Screenshot_20251212_134743" src="https://github.com/user-attachments/assets/d7112c22-12ee-46ab-92ad-616b1cff8771" />

Seems like it is coming from the latest version of `@vue/devtools-kit` (7.7.7) which introduced a breaking change in `getTimelineLayersStateFromStorage`, so i brought it back to 7.7.5 and its working again now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a development dependency to improve framework debugging and developer tooling. No changes to user-facing features or runtime behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->