### PR TITLE
Issue 81: Mask sensitive URL

### DIFF
--- a/agent/app.py
+++ b/agent/app.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 
-from config import Config
+from config import Config, mask_sensitive_url
 from database import DatabaseManager
 from connection_manager import ConnectionManager
 from event_handler import EventHandler
@@ -241,7 +241,7 @@ async def initialize_application():
         )
 
     app_state.db_manager = DatabaseManager(config.database_url)
-    logger.info(f"Running database migrations for: {config.database_url}")
+    logger.info(f"Running database migrations for: {mask_sensitive_url(config.database_url)}")
     app_state.db_manager.run_migrations()
     logger.info(f"Database migrations completed")
 
@@ -293,7 +293,7 @@ def start_monitor(config: Config):
         logger.warning("Monitor already running")
         return
     
-    logger.info(f"Starting Celery monitor with broker: {config.broker_url}")
+    logger.info(f"Starting Celery monitor with broker: {mask_sensitive_url(config.broker_url)}")
     app_state.monitor_instance = CeleryEventMonitor(
         broker_url=config.broker_url,
         allow_pickle_serialization=config.enable_pickle_serialization,

--- a/agent/config.py
+++ b/agent/config.py
@@ -2,6 +2,7 @@ import os
 import secrets
 from dataclasses import dataclass, field
 from typing import List, Optional
+from urllib.parse import urlparse, urlunparse
 
 
 def _as_bool(value: Optional[str], default: bool = False) -> bool:
@@ -20,6 +21,27 @@ def _split_csv(value: Optional[str]) -> List[str]:
         if item:
             parts.append(item)
     return parts
+
+
+def mask_sensitive_url(url: str) -> str:
+    """Mask password in URLs for safe logging."""
+    if not url:
+        return url
+    try:
+        parsed = urlparse(url)
+        if parsed.password:
+            netloc = parsed.hostname
+            if parsed.port:
+                netloc = f"{parsed.hostname}:{parsed.port}"
+            if parsed.username:
+                netloc = f"{parsed.username}:******@{netloc}"
+            else:
+                netloc = f"******@{netloc}"
+            masked = parsed._replace(netloc=netloc)
+            return urlunparse(masked)
+    except Exception:
+        pass
+    return url
 
 
 @dataclass

--- a/agent/config.py
+++ b/agent/config.py
@@ -37,7 +37,7 @@ def mask_sensitive_url(url: Optional[str]) -> Optional[str]:
             if ":" in hostname:
                 hostname = f"[{hostname}]"
             if parsed.port:
-                hostname = f"{parsed.hostname}:{parsed.port}"
+                hostname = f"{hostname}:{parsed.port}"
             if parsed.username:
                 hostname = f"{parsed.username}:******@{hostname}"
             else:

--- a/agent/config.py
+++ b/agent/config.py
@@ -33,14 +33,16 @@ def mask_sensitive_url(url: Optional[str]) -> Optional[str]:
     try:
         parsed = urlparse(url)
         if parsed.password:
-            netloc = parsed.hostname
+            hostname = parsed.hostname or ""
+            if ":" in hostname:
+                hostname = f"[{hostname}]"
             if parsed.port:
-                netloc = f"{parsed.hostname}:{parsed.port}"
+                hostname = f"{parsed.hostname}:{parsed.port}"
             if parsed.username:
-                netloc = f"{parsed.username}:******@{netloc}"
+                hostname = f"{parsed.username}:******@{hostname}"
             else:
-                netloc = f"******@{netloc}"
-            masked = parsed._replace(netloc=netloc)
+                hostname = f"******@{hostname}"
+            masked = parsed._replace(netloc=hostname)
             return urlunparse(masked)
     except Exception:
         logger.warning("Failed to mask sensitive URL; raw URL will be used.")

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,8 +1,11 @@
 import os
+import logging
 import secrets
 from dataclasses import dataclass, field
 from typing import List, Optional
 from urllib.parse import urlparse, urlunparse
+
+logger = logging.getLogger(__name__)
 
 
 def _as_bool(value: Optional[str], default: bool = False) -> bool:
@@ -40,7 +43,7 @@ def mask_sensitive_url(url: Optional[str]) -> Optional[str]:
             masked = parsed._replace(netloc=netloc)
             return urlunparse(masked)
     except Exception:
-        pass
+        logger.warning("Failed to mask sensitive URL; raw URL will be used.")
     return url
 
 

--- a/agent/config.py
+++ b/agent/config.py
@@ -23,7 +23,7 @@ def _split_csv(value: Optional[str]) -> List[str]:
     return parts
 
 
-def mask_sensitive_url(url: str) -> str:
+def mask_sensitive_url(url: Optional[str]) -> Optional[str]:
     """Mask password in URLs for safe logging."""
     if not url:
         return url

--- a/agent/main.py
+++ b/agent/main.py
@@ -6,7 +6,7 @@ For backwards compatibility, this can still be used but FastAPI app is recommend
 import argparse
 import logging
 import uvicorn
-from config import Config
+from config import Config, mask_sensitive_url
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ def main():
         config.log_level = args.log_level
     
     logger.info(f"Starting Celery Event Monitor server on {config.ws_host}:{config.ws_port}")
-    logger.info(f"Monitoring Celery broker: {config.broker_url}")
+    logger.info(f"Monitoring Celery broker: {mask_sensitive_url(config.broker_url)}")
     logger.info(f"Web interface: http://{config.ws_host}:{config.ws_port}")
     logger.info(f"WebSocket endpoint: ws://{config.ws_host}:{config.ws_port}/ws")
     

--- a/agent/monitor.py
+++ b/agent/monitor.py
@@ -9,6 +9,7 @@ from celery import Celery
 from models import TaskEvent, WorkerEvent
 from models import TaskProgressEvent, TaskStepsEvent
 from constants import EventType
+from config import mask_sensitive_url
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +168,7 @@ class CeleryEventMonitor:
 
     def start_monitoring(self):
         """Start monitoring Celery events."""
-        logger.info(f"Starting Celery event monitor - Broker: {self.broker_url}")
+        logger.info(f"Starting Celery event monitor - Broker: {mask_sensitive_url(self.broker_url)}")
 
         self.state = self.app.events.State()
 


### PR DESCRIPTION
This is a PR for issue #81 , it will mask sensitive information for both DB and broker URLs.

I tested it on my python314 branch with the following output on a postgres setup:

```
2026-02-18 14:11:45,877 [BACKEND] INFO - Running database migrations for: postgresql+psycopg://kanchi:******@localhost:5432/kanchi
2026-02-18 14:11:45,994 [BACKEND] INFO - Starting Celery monitor with broker: amqps://my-staging:******@my-host.cloudamqp.com:5671/myvhost
2026-02-18 14:11:45,997 [BACKEND] INFO - Starting Celery event monitor - Broker: amqps://my-staging:******@my-host.cloudamqp.com:5671/myvhost
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database and message-broker credentials are now redacted in startup and migration logs to prevent sensitive information exposure.
  * Startup logs that previously revealed full connection URLs now display masked versions.

* **New Features**
  * Added a shared utility to consistently mask sensitive URL components in application logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->