### PR TITLE
fix(monitor): reconnect on broker disconnect with exponential backoff

### DIFF
--- a/agent/app.py
+++ b/agent/app.py
@@ -59,8 +59,10 @@ async def lifespan(app: FastAPI):
         app_state.health_monitor.stop()
     if app_state.connection_manager:
         await app_state.connection_manager.stop_background_broadcaster()
+    if app_state.monitor_instance:
+        app_state.monitor_instance.stop()
     if app_state.monitor_thread and app_state.monitor_thread.is_alive():
-        logger.info("Shutting down monitor thread")
+        logger.info("Monitor thread signalled to stop (daemon; exits with process)")
 
 
 def create_app() -> FastAPI:

--- a/agent/monitor.py
+++ b/agent/monitor.py
@@ -1,6 +1,7 @@
 """Simplified Celery event monitor."""
 
 import logging
+import time
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Optional
 
@@ -12,6 +13,10 @@ from constants import EventType
 from config import mask_sensitive_url
 
 logger = logging.getLogger(__name__)
+
+_RECONNECT_BASE_DELAY = 1    # seconds
+_RECONNECT_MAX_DELAY  = 60   # seconds
+_RECONNECT_MULTIPLIER = 2
 
 
 class CeleryEventMonitor:
@@ -44,6 +49,7 @@ class CeleryEventMonitor:
         self.progress_callback: Optional[Callable] = None
         self.steps_callback: Optional[Callable] = None
         self.workers: Dict[str, Dict[str, Any]] = {}
+        self._stop = False
 
     def set_task_callback(self, callback: Callable[[TaskEvent], None]):
         """Set callback for task events."""
@@ -166,42 +172,82 @@ class CeleryEventMonitor:
         """Get current worker states."""
         return self.workers.copy()
 
+    def stop(self):
+        """Signal the monitor loop to stop reconnecting and exit cleanly."""
+        self._stop = True
+
+    def _run_once(self):
+        """Open one broker connection and capture events until it closes."""
+        with self.app.connection() as connection:
+            handlers = {
+                EventType.TASK_SENT.value: self._handle_task_event,
+                EventType.TASK_RECEIVED.value: self._handle_task_event,
+                EventType.TASK_STARTED.value: self._handle_task_event,
+                EventType.TASK_SUCCEEDED.value: self._handle_task_event,
+                EventType.TASK_FAILED.value: self._handle_task_event,
+                EventType.TASK_RETRIED.value: self._handle_task_event,
+                EventType.TASK_REVOKED.value: self._handle_task_event,
+                EventType.WORKER_ONLINE.value: lambda event: self._handle_worker_event(
+                    event, EventType.WORKER_ONLINE.value
+                ),
+                EventType.WORKER_OFFLINE.value: lambda event: self._handle_worker_event(
+                    event, EventType.WORKER_OFFLINE.value
+                ),
+                EventType.WORKER_HEARTBEAT.value: lambda event: self._handle_worker_event(
+                    event, EventType.WORKER_HEARTBEAT.value
+                ),
+                EventType.TASK_PROGRESS.value: self._handle_progress_event,
+                EventType.TASK_STEPS.value: self._handle_steps_event,
+            }
+            recv = self.app.events.Receiver(connection, handlers=handlers)
+            logger.info("Monitoring Celery events...")
+            recv.capture(limit=None, timeout=None, wakeup=True)
+
     def start_monitoring(self):
-        """Start monitoring Celery events."""
-        logger.info(f"Starting Celery event monitor - Broker: {mask_sensitive_url(self.broker_url)}")
+        """Start monitoring Celery events, reconnecting automatically on broker disconnects.
 
-        self.state = self.app.events.State()
+        Uses exponential backoff (1s → 60s) between reconnect attempts so that
+        a flapping broker does not spin the thread at full speed.  The loop only
+        exits when ``stop()`` is called or a ``KeyboardInterrupt`` is received.
+        """
+        logger.info(
+            "Starting Celery event monitor - Broker: %s",
+            mask_sensitive_url(self.broker_url),
+        )
+        delay = _RECONNECT_BASE_DELAY
 
-        try:
-            with self.app.connection() as connection:
-                handlers = {
-                    EventType.TASK_SENT.value: self._handle_task_event,
-                    EventType.TASK_RECEIVED.value: self._handle_task_event,
-                    EventType.TASK_STARTED.value: self._handle_task_event,
-                    EventType.TASK_SUCCEEDED.value: self._handle_task_event,
-                    EventType.TASK_FAILED.value: self._handle_task_event,
-                    EventType.TASK_RETRIED.value: self._handle_task_event,
-                    EventType.TASK_REVOKED.value: self._handle_task_event,
-                    EventType.WORKER_ONLINE.value: lambda event: self._handle_worker_event(
-                        event, EventType.WORKER_ONLINE.value
-                    ),
-                    EventType.WORKER_OFFLINE.value: lambda event: self._handle_worker_event(
-                        event, EventType.WORKER_OFFLINE.value
-                    ),
-                    EventType.WORKER_HEARTBEAT.value: lambda event: self._handle_worker_event(
-                        event, EventType.WORKER_HEARTBEAT.value
-                    ),
-                    EventType.TASK_PROGRESS.value: self._handle_progress_event,
-                    EventType.TASK_STEPS.value: self._handle_steps_event,
-                }
+        while not self._stop:
+            # Fresh State on every (re)connect: stale in-memory worker data is
+            # discarded and rebuilt from the first heartbeats after reconnection.
+            self.state = self.app.events.State()
+            try:
+                self._run_once()
+                # recv.capture() returns without raising only when the broker
+                # closed the connection cleanly (e.g. graceful broker restart).
+                # Reconnect just as we would for an error.
+                if not self._stop:
+                    logger.warning(
+                        "Event stream closed by broker; reconnecting in %ds...",
+                        _RECONNECT_BASE_DELAY,
+                    )
+            except KeyboardInterrupt:
+                logger.info("Monitoring stopped by user")
+                break
+            except Exception as exc:
+                if self._stop:
+                    break
+                logger.error(
+                    "Error in event monitoring, reconnecting in %ds: %s",
+                    delay,
+                    exc,
+                )
+            else:
+                # Clean close: reset backoff so the next reconnect is fast.
+                delay = _RECONNECT_BASE_DELAY
+                if not self._stop:
+                    time.sleep(delay)
+                continue
 
-                recv = self.app.events.Receiver(connection, handlers=handlers)
-
-                logger.info("Monitoring Celery events... Press Ctrl+C to stop")
-                recv.capture(limit=None, timeout=None, wakeup=True)
-
-        except KeyboardInterrupt:
-            logger.info("Monitoring stopped by user")
-        except Exception as e:
-            logger.error(f"Error in event monitoring: {e}", exc_info=True)
-            raise
+            if not self._stop:
+                time.sleep(delay)
+                delay = min(delay * _RECONNECT_MULTIPLIER, _RECONNECT_MAX_DELAY)

--- a/agent/tests/unit/test_monitor_reconnect.py
+++ b/agent/tests/unit/test_monitor_reconnect.py
@@ -1,0 +1,228 @@
+"""Tests for CeleryEventMonitor reconnect / backoff behaviour."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from monitor import (
+    CeleryEventMonitor,
+    _RECONNECT_BASE_DELAY,
+    _RECONNECT_MAX_DELAY,
+    _RECONNECT_MULTIPLIER,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_monitor(broker_url: str = "redis://localhost/0") -> CeleryEventMonitor:
+    """Return a monitor with a fully mocked Celery app."""
+    with patch("monitor.Celery") as mock_celery_cls:
+        mock_celery_cls.return_value = MagicMock()
+        monitor = CeleryEventMonitor(broker_url=broker_url)
+    return monitor
+
+
+# ---------------------------------------------------------------------------
+# stop() flag
+# ---------------------------------------------------------------------------
+
+class TestStopFlag:
+    def test_stop_sets_flag(self):
+        monitor = _make_monitor()
+        assert not monitor._stop
+        monitor.stop()
+        assert monitor._stop
+
+    def test_start_monitoring_exits_immediately_when_already_stopped(self):
+        monitor = _make_monitor()
+        monitor.stop()
+
+        run_once_calls = []
+
+        def fake_run_once():
+            run_once_calls.append(1)
+
+        monitor._run_once = fake_run_once
+        monitor.start_monitoring()
+
+        assert run_once_calls == [], "_run_once should never be called after stop()"
+
+
+# ---------------------------------------------------------------------------
+# Reconnect on error
+# ---------------------------------------------------------------------------
+
+class TestReconnectOnError:
+    def test_reconnects_after_broker_error(self):
+        """A connection error should not kill the loop; it should retry."""
+        monitor = _make_monitor()
+
+        call_count = {"n": 0}
+
+        def fake_run_once():
+            call_count["n"] += 1
+            if call_count["n"] < 3:
+                raise OSError("Connection closed by server.")
+            monitor.stop()  # clean exit after 3rd attempt
+
+        monitor._run_once = fake_run_once
+
+        with patch("monitor.time.sleep"):  # don't actually sleep
+            monitor.start_monitoring()
+
+        assert call_count["n"] == 3
+
+    def test_stop_during_sleep_exits_loop(self):
+        """Calling stop() while sleeping between retries should cause an exit."""
+        monitor = _make_monitor()
+        call_count = {"n": 0}
+
+        def fake_run_once():
+            call_count["n"] += 1
+            raise OSError("boom")
+
+        def fake_sleep(delay):
+            monitor.stop()  # simulate stop() being called from another thread
+
+        monitor._run_once = fake_run_once
+
+        with patch("monitor.time.sleep", side_effect=fake_sleep):
+            monitor.start_monitoring()
+
+        assert call_count["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Exponential backoff
+# ---------------------------------------------------------------------------
+
+class TestExponentialBackoff:
+    def test_backoff_increases_on_repeated_errors(self):
+        monitor = _make_monitor()
+        sleeps = []
+        call_count = {"n": 0}
+
+        def fake_run_once():
+            call_count["n"] += 1
+            if call_count["n"] >= 5:
+                monitor.stop()
+                return
+            raise OSError("error")
+
+        def fake_sleep(delay):
+            sleeps.append(delay)
+
+        monitor._run_once = fake_run_once
+
+        with patch("monitor.time.sleep", side_effect=fake_sleep):
+            monitor.start_monitoring()
+
+        # Delays should be non-decreasing and follow the multiplier
+        for i in range(1, len(sleeps)):
+            assert sleeps[i] >= sleeps[i - 1], "Backoff should not decrease"
+        assert sleeps[-1] <= _RECONNECT_MAX_DELAY, "Delay must not exceed the cap"
+
+    def test_backoff_capped_at_max(self):
+        monitor = _make_monitor()
+        sleeps = []
+        call_count = {"n": 0}
+
+        # Force enough failures to hit the cap
+        iterations = 20
+
+        def fake_run_once():
+            call_count["n"] += 1
+            if call_count["n"] > iterations:
+                monitor.stop()
+                return
+            raise OSError("error")
+
+        monitor._run_once = fake_run_once
+
+        with patch("monitor.time.sleep", side_effect=lambda d: sleeps.append(d)):
+            monitor.start_monitoring()
+
+        assert all(d <= _RECONNECT_MAX_DELAY for d in sleeps)
+
+    def test_backoff_resets_after_clean_close(self):
+        """After a clean connection close, the next sleep uses the base delay."""
+        monitor = _make_monitor()
+        sleeps = []
+        call_count = {"n": 0}
+
+        def fake_run_once():
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise OSError("error")  # triggers backoff increase
+            if call_count["n"] == 2:
+                raise OSError("error")  # triggers more backoff
+            if call_count["n"] == 3:
+                return  # clean close → resets backoff
+            monitor.stop()
+
+        monitor._run_once = fake_run_once
+
+        with patch("monitor.time.sleep", side_effect=lambda d: sleeps.append(d)):
+            monitor.start_monitoring()
+
+        # The clean close on attempt 3 triggers the else-branch which resets
+        # delay to base and sleeps once before looping.  That sleep (the last
+        # entry in sleeps[]) should be the base delay, not the backed-off value
+        # accumulated from attempts 1 and 2.
+        assert sleeps[-1] == _RECONNECT_BASE_DELAY
+
+
+# ---------------------------------------------------------------------------
+# State reset on reconnect
+# ---------------------------------------------------------------------------
+
+class TestStateReset:
+    def test_state_is_reset_on_each_reconnect(self):
+        """self.state must be a fresh Events.State on every connection attempt."""
+        monitor = _make_monitor()
+        states_seen = []
+        call_count = {"n": 0}
+
+        def fake_run_once():
+            states_seen.append(monitor.state)
+            call_count["n"] += 1
+            if call_count["n"] >= 3:
+                monitor.stop()
+                return
+            raise OSError("disconnected")
+
+        monitor._run_once = fake_run_once
+        monitor.app.events.State = MagicMock(side_effect=lambda: object())
+
+        with patch("monitor.time.sleep"):
+            monitor.start_monitoring()
+
+        assert len(states_seen) == 3
+        # Each attempt should have gotten a distinct State instance
+        assert len(set(id(s) for s in states_seen)) == 3, (
+            "state should be reset to a new object on each reconnect"
+        )
+
+
+# ---------------------------------------------------------------------------
+# KeyboardInterrupt exits cleanly
+# ---------------------------------------------------------------------------
+
+class TestKeyboardInterrupt:
+    def test_keyboard_interrupt_exits_without_reconnect(self):
+        monitor = _make_monitor()
+        call_count = {"n": 0}
+
+        def fake_run_once():
+            call_count["n"] += 1
+            raise KeyboardInterrupt
+
+        monitor._run_once = fake_run_once
+
+        with patch("monitor.time.sleep") as mock_sleep:
+            monitor.start_monitoring()
+
+        assert call_count["n"] == 1
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
## Problem

When the broker closes the connection (e.g. during a rolling restart or a transient network drop), `start_monitoring()` catches the exception, logs it, and re-raises — permanently killing the daemon thread. The process keeps running but silently stops receiving all Celery events: the task database freezes and workers appear offline indefinitely. The only recovery is a full process restart.

## Solution

- Extract the single-connection lifecycle into `_run_once()`
- Wrap `start_monitoring()` in a reconnect loop with exponential backoff (1s → 60s, capped) so broker drops are recovered automatically
- Reset `self.state` on each reconnect so stale in-memory worker data is discarded and rebuilt from fresh heartbeats
- Add `stop()` to allow the lifespan context manager to signal a clean exit
- Call `monitor_instance.stop()` during app shutdown

## Tests

9 new unit tests covering: stop flag, reconnect-on-error, backoff growth, backoff cap, backoff reset after clean close, state reset on reconnect, and `KeyboardInterrupt` exit.
