### PR TITLE
fix: preserve routing metadata when later Celery events omit it

### DIFF
--- a/agent/services/task_service.py
+++ b/agent/services/task_service.py
@@ -52,7 +52,9 @@ class TaskService:
             self._log_payload_truncation(task_event, args, kwargs, task_event.result)
 
             # Ensure the in-memory event (used for WebSocket broadcast) carries the
-            # inherited args/kwargs so downstream consumers don't lose them.
+            # inherited data so downstream consumers don't lose it.
+            task_event.routing_key = routing_key
+            task_event.queue = queue
             task_event.args = args
             task_event.kwargs = kwargs
 
@@ -493,7 +495,12 @@ class TaskService:
 
     def _inherit_queue_info(self, task_event: TaskEvent) -> Tuple[str, str]:
         """
-        Inherit queue information from previous task-sent event if not present.
+        Inherit routing metadata from earlier events in the same task lifecycle.
+
+        Celery does not guarantee that every task event repeats the original queue
+        and routing information. Later lifecycle events such as task-succeeded may
+        omit queue or fall back to routing_key="default". In those cases we keep
+        the most recent meaningful routing metadata already seen for that task.
 
         Args:
             task_event: Task event to process
@@ -504,16 +511,36 @@ class TaskService:
         routing_key = task_event.routing_key
         queue = task_event.queue
 
-        if not routing_key or routing_key == 'default':
-            existing_sent_event = (
-                self.session.query(TaskEventDB)
-                .filter_by(task_id=task_event.task_id, event_type=EventType.TASK_SENT.value)
-                .first()
-            )
+        routing_key_missing = not routing_key or routing_key == 'default'
+        queue_missing = not queue or queue == 'default'
 
-            if existing_sent_event and existing_sent_event.routing_key:
-                routing_key = existing_sent_event.routing_key
-                queue = existing_sent_event.queue
+        if not routing_key_missing and not queue_missing:
+            return routing_key, queue
+
+        existing_event = (
+            self.session.query(TaskEventDB)
+            .filter(TaskEventDB.task_id == task_event.task_id)
+            .filter(
+                or_(
+                    TaskEventDB.queue.isnot(None),
+                    and_(
+                        TaskEventDB.routing_key.isnot(None),
+                        TaskEventDB.routing_key != 'default'
+                    )
+                )
+            )
+            .order_by(TaskEventDB.timestamp.desc(), TaskEventDB.id.desc())
+            .first()
+        )
+
+        if not existing_event:
+            return routing_key, queue
+
+        if routing_key_missing and existing_event.routing_key:
+            routing_key = existing_event.routing_key
+
+        if queue_missing and existing_event.queue:
+            queue = existing_event.queue
 
         return routing_key, queue
 

--- a/agent/tests/unit/test_task_routing_inheritance.py
+++ b/agent/tests/unit/test_task_routing_inheritance.py
@@ -1,0 +1,90 @@
+import sys
+import types
+import unittest
+from datetime import datetime, timezone, timedelta
+
+sys.modules.setdefault("aiohttp", types.SimpleNamespace(ClientSession=None))
+
+from services.task_service import TaskService
+from tests.base import DatabaseTestCase
+
+
+class TestTaskRoutingInheritance(DatabaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.service = TaskService(self.session)
+        self.base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_inherits_queue_and_routing_key_from_previous_event(self):
+        task_id = "task-routing-1"
+
+        self.create_task_event_db(
+            task_id=task_id,
+            event_type="task-received",
+            timestamp=self.base_time,
+            routing_key="ws_callback",
+            queue="ws_callback",
+        )
+
+        success_event = self.create_task_event(
+            task_id=task_id,
+            event_type="task-succeeded",
+            timestamp=self.base_time + timedelta(seconds=5),
+            routing_key="default",
+            queue=None,
+        )
+
+        self.service.save_task_event(success_event)
+
+        saved_events = self.get_task_events_by_id(task_id)
+        latest_saved = max(saved_events, key=lambda event: event.timestamp)
+
+        self.assertEqual(success_event.routing_key, "ws_callback")
+        self.assertEqual(success_event.queue, "ws_callback")
+        self.assertEqual(latest_saved.routing_key, "ws_callback")
+        self.assertEqual(latest_saved.queue, "ws_callback")
+
+    def test_preserves_known_queue_when_only_routing_key_is_default(self):
+        task_id = "task-routing-2"
+
+        self.create_task_event_db(
+            task_id=task_id,
+            event_type="task-started",
+            timestamp=self.base_time,
+            routing_key="priority_jobs",
+            queue="priority_jobs",
+        )
+
+        success_event = self.create_task_event(
+            task_id=task_id,
+            event_type="task-succeeded",
+            timestamp=self.base_time + timedelta(seconds=10),
+            routing_key="default",
+            queue="priority_jobs",
+        )
+
+        self.service.save_task_event(success_event)
+
+        self.assertEqual(success_event.routing_key, "priority_jobs")
+        self.assertEqual(success_event.queue, "priority_jobs")
+
+    def test_keeps_original_values_when_no_prior_routing_metadata_exists(self):
+        task_id = "task-routing-3"
+
+        success_event = self.create_task_event(
+            task_id=task_id,
+            event_type="task-succeeded",
+            timestamp=self.base_time,
+            routing_key="default",
+            queue=None,
+        )
+
+        self.service.save_task_event(success_event)
+
+        self.assertEqual(success_event.routing_key, "default")
+        self.assertIsNone(success_event.queue)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- preserve queue/routing metadata across a task lifecycle when later Celery events omit it
- inherit from the most recent prior event with meaningful routing metadata instead of only checking `task-sent`
- update the in-memory event before broadcast so websocket consumers and DB snapshots stay consistent
- add regression coverage for missing-routing lifecycle events

## Problem
Some Celery setups emit later lifecycle events such as `task-received`, `task-started`, or `task-succeeded` with incomplete routing metadata:
- `queue = null`
- `routing_key = default`

Before this change, Kanchi only inherited routing metadata from a prior `task-sent` event. If that event was missing or unavailable, later events could overwrite the task snapshot with `default` / `null`, which broke queue labels and queue-based filtering.

## Solution
This PR broadens routing inheritance so Kanchi keeps the most recent meaningful routing metadata already seen for the task lifecycle.

That means:
- if a new event arrives with a real queue/routing key, Kanchi keeps it
- if a new event arrives with `queue = null` and/or `routing_key = default`, Kanchi backfills from the latest earlier event for that task that has meaningful routing metadata
- the normalized routing metadata is also written back onto the in-memory event before websocket broadcast

## Validation
### Automated tests
- added `agent/tests/unit/test_task_routing_inheritance.py`
- ran:
  - `python3 -m pytest tests/unit/test_task_routing_inheritance.py tests/unit/test_task_service_recent_failures.py`

### Real-app validation
Validated against a live local Celery worker plus Kanchi's actual monitor/event-handler/database save path.

Observed behavior from Celery for a routed task:
- `task-sent` carried the expected routing metadata
- later lifecycle events could arrive with `queue = null` and `routing_key = default`

Comparison:
- on `main`, the issue-shaped replay case still regressed to `default`/`null` when the best prior metadata was not on `task-sent`
- on this branch, the final stored/latest task snapshot preserved the original queue/routing metadata correctly

## Why this approach
This keeps Kanchi resilient to real Celery event streams without making assumptions that every lifecycle event repeats the original routing metadata.

Closes #88.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task routing metadata inheritance to correctly propagate queue and routing information from prior events in the task lifecycle.

* **Tests**
  * Added comprehensive unit tests validating task routing metadata assignment for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->