### PR TITLE
Add new-vs-known failure classification

### DIFF
--- a/agent/api/task_routes.py
+++ b/agent/api/task_routes.py
@@ -160,6 +160,21 @@ def create_router(app_state) -> APIRouter:
         ),
         limit: int = 50,
         include_retried: bool = False,
+        novelty_status: Optional[str] = Query(
+            default=None,
+            description="Optional novelty filter: new, recurring, or regressed"
+        ),
+        novelty_lookback_hours: Optional[int] = Query(
+            default=None,
+            ge=1,
+            le=720,
+            description="How far back to inspect matching failure fingerprints"
+        ),
+        sort_by: Optional[str] = Query(
+            default=None,
+            description="Optional sort field. Use novelty to prioritize new and regressed failures."
+        ),
+        sort_order: str = Query(default="desc", pattern="^(asc|desc)$"),
         session: Session = Depends(get_db),
         active_env = Depends(get_active_env)
     ):
@@ -170,7 +185,11 @@ def create_router(app_state) -> APIRouter:
         failed_tasks = task_service.get_recent_failed_tasks(
             hours=lookback_hours,
             limit=limit,
-            exclude_retried=not include_retried
+            exclude_retried=not include_retried,
+            novelty_status=novelty_status,
+            novelty_lookback_hours=novelty_lookback_hours or config_service.get_task_issue_novelty_lookback_hours(),
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
         return failed_tasks
 

--- a/agent/api/task_routes.py
+++ b/agent/api/task_routes.py
@@ -3,7 +3,7 @@
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Literal, Optional
 from fastapi import APIRouter, Depends, HTTPException, Header, Query
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
@@ -160,7 +160,7 @@ def create_router(app_state) -> APIRouter:
         ),
         limit: int = 50,
         include_retried: bool = False,
-        novelty_status: Optional[str] = Query(
+        novelty_status: Optional[Literal["new", "recurring", "regressed"]] = Query(
             default=None,
             description="Optional novelty filter: new, recurring, or regressed"
         ),
@@ -170,7 +170,7 @@ def create_router(app_state) -> APIRouter:
             le=720,
             description="How far back to inspect matching failure fingerprints"
         ),
-        sort_by: Optional[str] = Query(
+        sort_by: Optional[Literal["novelty"]] = Query(
             default=None,
             description="Optional sort field. Use novelty to prioritize new and regressed failures."
         ),

--- a/agent/models.py
+++ b/agent/models.py
@@ -39,6 +39,13 @@ class TaskEvent(BaseModel):
     resolved: bool = False
     resolved_by: Optional[str] = None
     resolved_at: Optional[datetime] = None
+    failure_fingerprint: Optional[str] = None
+    failure_novelty_status: Optional[Literal['new', 'recurring', 'regressed']] = None
+    failure_novelty_rank: Optional[int] = None
+    failure_first_seen_at: Optional[datetime] = None
+    failure_last_seen_at: Optional[datetime] = None
+    failure_occurrence_count: int = 0
+    known_failure: bool = False
 
     model_config = {
         'from_attributes': True,
@@ -114,7 +121,14 @@ class TaskEvent(BaseModel):
         sanitized, _ = sanitize_payload(v)
         return sanitized if isinstance(sanitized, dict) else {}
 
-    @field_validator('timestamp', 'orphaned_at', 'resolved_at', mode='before')
+    @field_validator(
+        'timestamp',
+        'orphaned_at',
+        'resolved_at',
+        'failure_first_seen_at',
+        'failure_last_seen_at',
+        mode='before'
+    )
     @classmethod
     def validate_datetime(cls, v):
         if v is None:

--- a/agent/services/app_config_service.py
+++ b/agent/services/app_config_service.py
@@ -11,6 +11,7 @@ from models import AppSetting, AppSettingUpdate, AppConfigSnapshot, TaskIssueCon
 logger = logging.getLogger(__name__)
 
 TASK_ISSUE_LOOKBACK_KEY = "task_issue_summary.lookback_hours"
+TASK_ISSUE_NOVELTY_LOOKBACK_KEY = "task_issue_summary.novelty_lookback_hours"
 RETENTION_TASK_SUCCESSFUL_DAYS_KEY = "data_retention.task_successful_days"
 RETENTION_TASK_UNSUCCESSFUL_DAYS_KEY = "data_retention.task_unsuccessful_days"
 RETENTION_WORKER_EVENTS_DAYS_KEY = "data_retention.worker_events_days"
@@ -81,6 +82,15 @@ DEFAULT_SETTING_DEFINITIONS: Dict[str, Dict[str, Any]] = {
         "category": "data_retention",
         "min": 1,
         "max": 3650,
+    },
+    TASK_ISSUE_NOVELTY_LOOKBACK_KEY: {
+        "default": 168,
+        "value_type": "number",
+        "label": "Failure novelty lookback (hours)",
+        "description": "How far back Kanchi looks when deciding whether a failure fingerprint is new, recurring, or regressed.",
+        "category": "task_issue_summary",
+        "min": 1,
+        "max": 720,
     },
 }
 
@@ -285,6 +295,9 @@ class AppConfigService:
         if max_value is not None:
             numeric_value = min(max_value, numeric_value)
         return numeric_value
+
+    def get_task_issue_novelty_lookback_hours(self) -> int:
+        return self._get_bounded_number_setting(TASK_ISSUE_NOVELTY_LOOKBACK_KEY)
 
     def get_data_retention_config(self) -> DataRetentionConfig:
         """Return normalized data retention configuration."""

--- a/agent/services/task_service.py
+++ b/agent/services/task_service.py
@@ -19,6 +19,12 @@ from utils.payload_sanitizer import find_placeholder_paths
 
 logger = logging.getLogger(__name__)
 
+FAILURE_NOVELTY_PRIORITY = {
+    "new": 0,
+    "regressed": 1,
+    "recurring": 2,
+}
+
 
 def _ensure_utc(dt: Optional[datetime]) -> Optional[datetime]:
     if dt is None:
@@ -295,7 +301,11 @@ class TaskService:
         self,
         hours: int = 24,
         limit: int = 50,
-        exclude_retried: bool = True
+        exclude_retried: bool = True,
+        novelty_status: Optional[str] = None,
+        novelty_lookback_hours: int = 168,
+        sort_by: Optional[str] = None,
+        sort_order: str = "desc",
     ) -> List[TaskEvent]:
         """
         Get failed tasks in the last ``hours`` where the latest event is a failure.
@@ -357,8 +367,96 @@ class TaskService:
         events = [self._db_to_task_event(event_db) for event_db in events_db]
         self._bulk_enrich_with_retry_info(events)
         self._attach_resolution_info(events)
+        self._attach_failure_novelty_info(events, lookback_hours=novelty_lookback_hours)
+
+        normalized_novelty = (novelty_status or "").strip().lower() or None
+        if normalized_novelty:
+            events = [event for event in events if event.failure_novelty_status == normalized_novelty]
+
+        if sort_by == "novelty":
+            if sort_order == "asc":
+                events = sorted(
+                    events,
+                    key=lambda event: (
+                        FAILURE_NOVELTY_PRIORITY.get(event.failure_novelty_status or "recurring", 99),
+                        _ensure_utc(event.timestamp) or datetime.min.replace(tzinfo=timezone.utc),
+                    ),
+                )
+            else:
+                events = sorted(
+                    events,
+                    key=lambda event: (
+                        FAILURE_NOVELTY_PRIORITY.get(event.failure_novelty_status or "recurring", 99),
+                        -((_ensure_utc(event.timestamp) or datetime(1970, 1, 1, tzinfo=timezone.utc)).timestamp()),
+                    ),
+                )
 
         return events
+
+    def _normalize_failure_fingerprint(self, event: TaskEvent) -> Optional[str]:
+        if event.event_type != EventType.TASK_FAILED.value:
+            return None
+
+        name = (event.task_name or "unknown").strip().lower()
+        queue = (event.routing_key or event.queue or "default").strip().lower()
+        exception = " ".join((event.exception or "unknown-error").strip().lower().split())
+        exception = exception[:500]
+        return f"{name}|{queue}|{exception}"
+
+    def _attach_failure_novelty_info(self, events: List[TaskEvent], lookback_hours: int = 168) -> None:
+        failed_events = [event for event in events if event.event_type == EventType.TASK_FAILED.value]
+        if not failed_events:
+            return
+
+        for event in failed_events:
+            event.failure_fingerprint = self._normalize_failure_fingerprint(event)
+
+        fingerprints = {event.failure_fingerprint for event in failed_events if event.failure_fingerprint}
+        if not fingerprints:
+            return
+
+        lookback_since = datetime.now(timezone.utc) - timedelta(hours=max(1, lookback_hours))
+        history_query = self.session.query(TaskEventDB).filter(
+            TaskEventDB.event_type == EventType.TASK_FAILED.value,
+            TaskEventDB.timestamp >= lookback_since,
+        )
+
+        env_filtered_query = self.session.query(TaskEventDB.task_id)
+        env_filtered_query = EnvironmentFilter.apply(env_filtered_query, self.active_env)
+        env_conditions = env_filtered_query.whereclause
+        if env_conditions is not None:
+            history_query = history_query.filter(env_conditions)
+
+        history = [self._db_to_task_event(row) for row in history_query.all()]
+        self._attach_resolution_info(history)
+
+        by_fingerprint: Dict[str, List[TaskEvent]] = {}
+        for item in history:
+            fingerprint = self._normalize_failure_fingerprint(item)
+            if fingerprint in fingerprints:
+                by_fingerprint.setdefault(fingerprint, []).append(item)
+
+        for fingerprint_events in by_fingerprint.values():
+            fingerprint_events.sort(key=lambda item: _ensure_utc(item.timestamp) or datetime.min.replace(tzinfo=timezone.utc))
+
+        for event in failed_events:
+            fingerprint = event.failure_fingerprint
+            related = by_fingerprint.get(fingerprint or "", [])
+            prior = [item for item in related if item.task_id != event.task_id and (_ensure_utc(item.timestamp) or datetime.min.replace(tzinfo=timezone.utc)) < (_ensure_utc(event.timestamp) or datetime.min.replace(tzinfo=timezone.utc))]
+            if not prior:
+                event.failure_novelty_status = "new"
+            elif any(item.resolved for item in prior):
+                event.failure_novelty_status = "regressed"
+            else:
+                event.failure_novelty_status = "recurring"
+
+            event.failure_novelty_rank = FAILURE_NOVELTY_PRIORITY.get(event.failure_novelty_status or "recurring")
+            event.failure_occurrence_count = len(prior) + 1
+            ordered_history = prior + [event]
+            if ordered_history:
+                event.failure_first_seen_at = min((_ensure_utc(item.timestamp) for item in ordered_history if item.timestamp), default=None)
+                event.failure_last_seen_at = max((_ensure_utc(item.timestamp) for item in ordered_history if item.timestamp), default=None)
+            event.known_failure = any(item.resolved for item in prior) or event.failure_novelty_status in {"recurring", "regressed"}
 
     def create_retry_relationship(
         self,

--- a/agent/services/task_service.py
+++ b/agent/services/task_service.py
@@ -357,9 +357,12 @@ class TaskService:
                 or_(TaskEventDB.has_retries.is_(False), TaskEventDB.has_retries.is_(None))
             )
 
+        normalized_novelty = (novelty_status or "").strip().lower() or None
+        needs_novelty_post_processing = normalized_novelty is not None or sort_by == "novelty"
+
         query = query.order_by(TaskEventDB.timestamp.desc())
 
-        if limit and limit > 0:
+        if limit and limit > 0 and not needs_novelty_post_processing:
             query = query.limit(limit)
 
         events_db = query.all()
@@ -369,7 +372,6 @@ class TaskService:
         self._attach_resolution_info(events)
         self._attach_failure_novelty_info(events, lookback_hours=novelty_lookback_hours)
 
-        normalized_novelty = (novelty_status or "").strip().lower() or None
         if normalized_novelty:
             events = [event for event in events if event.failure_novelty_status == normalized_novelty]
 
@@ -390,6 +392,9 @@ class TaskService:
                         -((_ensure_utc(event.timestamp) or datetime(1970, 1, 1, tzinfo=timezone.utc)).timestamp()),
                     ),
                 )
+
+        if limit and limit > 0 and needs_novelty_post_processing:
+            events = events[:limit]
 
         return events
 
@@ -443,9 +448,10 @@ class TaskService:
             fingerprint = event.failure_fingerprint
             related = by_fingerprint.get(fingerprint or "", [])
             prior = [item for item in related if item.task_id != event.task_id and (_ensure_utc(item.timestamp) or datetime.min.replace(tzinfo=timezone.utc)) < (_ensure_utc(event.timestamp) or datetime.min.replace(tzinfo=timezone.utc))]
+            latest_prior = prior[-1] if prior else None
             if not prior:
                 event.failure_novelty_status = "new"
-            elif any(item.resolved for item in prior):
+            elif latest_prior and latest_prior.resolved:
                 event.failure_novelty_status = "regressed"
             else:
                 event.failure_novelty_status = "recurring"

--- a/agent/services/task_service.py
+++ b/agent/services/task_service.py
@@ -449,9 +449,17 @@ class TaskService:
             related = by_fingerprint.get(fingerprint or "", [])
             prior = [item for item in related if item.task_id != event.task_id and (_ensure_utc(item.timestamp) or datetime.min.replace(tzinfo=timezone.utc)) < (_ensure_utc(event.timestamp) or datetime.min.replace(tzinfo=timezone.utc))]
             latest_prior = prior[-1] if prior else None
+            latest_prior_resolved_before_event = False
+            if latest_prior and latest_prior.resolved:
+                latest_resolution = _ensure_utc(latest_prior.resolved_at)
+                event_timestamp = _ensure_utc(event.timestamp)
+                latest_prior_resolved_before_event = bool(
+                    latest_resolution and event_timestamp and latest_resolution <= event_timestamp
+                )
+
             if not prior:
                 event.failure_novelty_status = "new"
-            elif latest_prior and latest_prior.resolved:
+            elif latest_prior_resolved_before_event:
                 event.failure_novelty_status = "regressed"
             else:
                 event.failure_novelty_status = "recurring"

--- a/agent/tests/unit/test_task_service_recent_failures.py
+++ b/agent/tests/unit/test_task_service_recent_failures.py
@@ -89,6 +89,86 @@ class TestTaskServiceRecentFailedTasks(DatabaseTestCase):
         self.assertEqual(len(ordered_ids), 2)
         self.assertEqual(ordered_ids, ["failed-0", "failed-1"])
 
+    def test_classifies_new_recurring_and_regressed_failures(self):
+        base_exception = "ValueError: boom"
+
+        self.create_task_event_db(
+            task_id="prior-recurring",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(hours=30),
+            exception=base_exception,
+        )
+        self.create_task_event_db(
+            task_id="prior-regressed",
+            task_name="tasks.other",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(hours=28),
+            exception="TimeoutError: upstream",
+        )
+        self.service.set_task_resolution("prior-regressed", resolved_by="tester")
+        self.create_task_event_db(
+            task_id="current-new",
+            task_name="tasks.brand_new",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=20),
+            exception="LookupError: never seen",
+        )
+        self.create_task_event_db(
+            task_id="current-recurring",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=10),
+            exception=base_exception,
+        )
+        self.create_task_event_db(
+            task_id="current-regressed",
+            task_name="tasks.other",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=5),
+            exception="TimeoutError: upstream",
+        )
+
+        results = self.service.get_recent_failed_tasks(hours=24, novelty_lookback_hours=168, sort_by="novelty")
+        by_id = {task.task_id: task for task in results}
+
+        self.assertEqual(by_id["current-new"].failure_novelty_status, "new")
+        self.assertEqual(by_id["current-recurring"].failure_novelty_status, "recurring")
+        self.assertEqual(by_id["current-regressed"].failure_novelty_status, "regressed")
+        self.assertEqual(results[0].task_id, "current-new")
+        self.assertEqual(results[1].task_id, "current-regressed")
+
+    def test_filters_by_novelty_status(self):
+        self.create_task_event_db(
+            task_id="prior-known",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(hours=30),
+            exception="RuntimeError: repeated",
+        )
+        self.create_task_event_db(
+            task_id="current-known",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=15),
+            exception="RuntimeError: repeated",
+        )
+        self.create_task_event_db(
+            task_id="current-new",
+            task_name="tasks.unique",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=5),
+            exception="KeyError: fresh",
+        )
+
+        results = self.service.get_recent_failed_tasks(
+            hours=24,
+            novelty_status="new",
+            novelty_lookback_hours=168,
+        )
+
+        self.assertEqual([task.task_id for task in results], ["current-new"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/agent/tests/unit/test_task_service_recent_failures.py
+++ b/agent/tests/unit/test_task_service_recent_failures.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import datetime, timezone, timedelta
 
+from database import TaskResolutionDB
 from services.task_service import TaskService
 from tests.base import DatabaseTestCase
 
@@ -107,6 +108,19 @@ class TestTaskServiceRecentFailedTasks(DatabaseTestCase):
             exception="TimeoutError: upstream",
         )
         self.service.set_task_resolution("prior-regressed", resolved_by="tester")
+        resolution = (
+            self.session.query(TaskResolutionDB)
+            .filter(TaskResolutionDB.task_id == "prior-regressed")
+            .one()
+        )
+        resolution.resolved_at = self.now - timedelta(hours=20)
+        self.service._update_task_latest_resolution(
+            "prior-regressed",
+            True,
+            "tester",
+            resolution.resolved_at,
+        )
+        self.session.commit()
         self.create_task_event_db(
             task_id="current-new",
             task_name="tasks.brand_new",

--- a/agent/tests/unit/test_task_service_recent_failures.py
+++ b/agent/tests/unit/test_task_service_recent_failures.py
@@ -169,6 +169,67 @@ class TestTaskServiceRecentFailedTasks(DatabaseTestCase):
 
         self.assertEqual([task.task_id for task in results], ["current-new"])
 
+    def test_novelty_sorting_applies_before_limit(self):
+        self.create_task_event_db(
+            task_id="recent-recurring-prior",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(hours=30),
+            exception="RuntimeError: repeated",
+        )
+        self.create_task_event_db(
+            task_id="recent-recurring-current",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=3),
+            exception="RuntimeError: repeated",
+        )
+        self.create_task_event_db(
+            task_id="slightly-older-new",
+            task_name="tasks.unique",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=6),
+            exception="LookupError: fresh",
+        )
+
+        results = self.service.get_recent_failed_tasks(
+            hours=24,
+            limit=1,
+            novelty_lookback_hours=168,
+            sort_by="novelty",
+        )
+
+        self.assertEqual([task.task_id for task in results], ["slightly-older-new"])
+
+    def test_regressed_only_when_latest_prior_occurrence_was_resolved(self):
+        self.create_task_event_db(
+            task_id="prior-resolved",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(hours=10),
+            exception="RuntimeError: repeated",
+        )
+        self.service.set_task_resolution("prior-resolved", resolved_by="tester")
+        self.create_task_event_db(
+            task_id="prior-unresolved",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(hours=2),
+            exception="RuntimeError: repeated",
+        )
+        self.create_task_event_db(
+            task_id="current-failure",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=5),
+            exception="RuntimeError: repeated",
+        )
+
+        results = self.service.get_recent_failed_tasks(hours=24, novelty_lookback_hours=168)
+        by_id = {task.task_id: task for task in results}
+
+        self.assertEqual(by_id["current-failure"].failure_novelty_status, "recurring")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/frontend/app/components/TaskIssueSummary.vue
+++ b/frontend/app/components/TaskIssueSummary.vue
@@ -334,7 +334,7 @@ import PythonValueViewer from '~/components/PythonValueViewer.vue'
 import { IconButton, Select } from '~/components/common'
 import TaskDetailsSection from '~/components/common/TaskDetailsSection.vue'
 import { ChevronDown, ChevronRight, Loader2, AlertTriangle, ChevronsLeft, ChevronLeft, ChevronsRight, CheckCircle2 } from 'lucide-vue-next'
-import type { TaskEventResponse } from '~/services/apiClient'
+import type { TaskEventResponse, TaskFailureNoveltyResponse } from '~/services/apiClient'
 import { useTaskStatus } from '~/composables/useTaskStatus'
 import type { ParsedFilter } from '~/composables/useFilterParser'
 
@@ -456,6 +456,8 @@ const matchesSearch = (task: TaskEventResponse) => {
   )
 }
 
+const getFailureNovelty = (task: TaskEventResponse) => (task as TaskFailureNoveltyResponse).failure_novelty_status ?? ''
+
 const getFieldCandidates = (task: TaskEventResponse, field: string): string[] => {
   switch (field) {
     case 'state': {
@@ -470,6 +472,8 @@ const getFieldCandidates = (task: TaskEventResponse, field: string): string[] =>
       return [task.routing_key ?? 'default']
     case 'id':
       return [task.task_id ?? '']
+    case 'novelty':
+      return [getFailureNovelty(task)]
     default:
       return ['']
   }

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -41,6 +41,15 @@
           @item-action="handleFailedRetryAction"
           @lookback-change="handleLookbackChange"
         >
+          <template #meta-badges="{ task }">
+            <Badge
+              v-if="failureNoveltyLabel(task)"
+              :variant="failureNoveltyBadgeVariant(task)"
+              class="text-[11px] px-2 py-0.5 capitalize"
+            >
+              {{ failureNoveltyLabel(task) }}
+            </Badge>
+          </template>
           <template #actions="{ task }">
 
             <div class="flex items-center gap-2">
@@ -218,7 +227,7 @@ import type { ParsedFilter } from '~/composables/useFilterParser'
 import type { TimeRange } from '~/components/TimeRangeFilter.vue'
 import { useUrlQuerySync } from '~/composables/useUrlQuerySync'
 import type { UrlQueryState } from '~/composables/useUrlQuerySync'
-import type { TaskEventResponse } from '~/services/apiClient'
+import type { TaskEventResponse, TaskFailureNoveltyResponse } from '~/services/apiClient'
 import {ChevronRight, RefreshCw, Check, Loader2} from 'lucide-vue-next'
 import {IconButton} from "~/components/common";
 
@@ -319,6 +328,23 @@ const retryLoadingIds = computed(() => {
 })
 
 const resolutionLoadingIds = ref<string[]>([])
+
+const failureNoveltyLabel = (task: TaskEventResponse) => {
+  return (task as TaskFailureNoveltyResponse).failure_novelty_status ?? ''
+}
+
+const failureNoveltyBadgeVariant = (task: TaskEventResponse) => {
+  switch (failureNoveltyLabel(task)) {
+    case 'new':
+      return 'destructive'
+    case 'regressed':
+      return 'pending'
+    case 'recurring':
+      return 'secondary'
+    default:
+      return 'outline'
+  }
+}
 
 const isTaskResolved = (task: TaskEventResponse) => {
   return Boolean((task as TaskEventResponse & { resolved?: boolean }).resolved)

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -8,6 +8,17 @@ import type {
   WorkerInfo
 } from '../src/types/api'
 
+export type FailureNoveltyStatus = 'new' | 'recurring' | 'regressed'
+export type TaskFailureNoveltyResponse = TaskEventResponse & {
+  failure_fingerprint?: string | null
+  failure_novelty_status?: FailureNoveltyStatus | null
+  failure_novelty_rank?: number | null
+  failure_first_seen_at?: string | null
+  failure_last_seen_at?: string | null
+  failure_occurrence_count?: number | null
+  known_failure?: boolean
+}
+
 export type AuthProvider = 'google' | 'github'
 
 export interface UserInfoDTO {
@@ -369,7 +380,15 @@ class ApiService {
     return response.data
   }
 
-  async getRecentFailedTasks(params?: { hours?: number; limit?: number; include_retried?: boolean }): Promise<TaskEventResponse[]> {
+  async getRecentFailedTasks(params?: {
+    hours?: number
+    limit?: number
+    include_retried?: boolean
+    novelty_status?: FailureNoveltyStatus
+    novelty_lookback_hours?: number
+    sort_by?: 'novelty'
+    sort_order?: 'asc' | 'desc'
+  }): Promise<TaskFailureNoveltyResponse[]> {
     const response = await this.api.request({
       path: '/api/tasks/failed/recent',
       method: 'GET',

--- a/frontend/app/stores/failedTasks.ts
+++ b/frontend/app/stores/failedTasks.ts
@@ -179,6 +179,14 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     }
   }
 
+  async function refreshFailedTasksFromLiveUpdate() {
+    try {
+      await fetchFailedTasks({ hours: lookbackHours.value })
+    } catch {
+      // keep the live event visible even if the background refresh fails
+    }
+  }
+
   function updateFromLiveEvent(event: TaskFailureNoveltyResponse) {
     const environmentStore = useEnvironmentStore()
     const { matchesEnvironment } = useEnvironmentMatcher()
@@ -207,6 +215,7 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
 
       upsertFailedTask(event)
       pruneExpired()
+      void refreshFailedTasksFromLiveUpdate()
       return
     }
 

--- a/frontend/app/stores/failedTasks.ts
+++ b/frontend/app/stores/failedTasks.ts
@@ -23,6 +23,15 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
   const error = ref<string | null>(null)
   const lastFetchedAt = ref<Date | null>(null)
   const lookbackHours = ref(DEFAULT_LOOKBACK_HOURS)
+  const lastQuery = ref<{
+    hours: number
+    limit?: number
+    includeRetried?: boolean
+    noveltyStatus?: FailureNoveltyStatus
+    noveltyLookbackHours?: number
+  }>({
+    hours: DEFAULT_LOOKBACK_HOURS,
+  })
   const lookbackWindowMs = computed(() => lookbackHours.value * 60 * 60 * 1000)
 
   const totalFailedTasks = computed(() => failedTasks.value.length)
@@ -129,6 +138,13 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
 
       const effectiveHours = options?.hours ?? lookbackHours.value
       setLookbackHours(effectiveHours)
+      lastQuery.value = {
+        hours: effectiveHours,
+        limit: options?.limit,
+        includeRetried: options?.includeRetried,
+        noveltyStatus: options?.noveltyStatus,
+        noveltyLookbackHours: options?.noveltyLookbackHours,
+      }
 
       const response = await apiService.getRecentFailedTasks({
         hours: effectiveHours,
@@ -140,7 +156,9 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
         sort_order: 'desc',
       })
 
-      const filtered = response.filter(task => !shouldExclude(task))
+      const filtered = options?.includeRetried
+        ? response
+        : response.filter(task => !shouldExclude(task))
       setTasks(filtered)
       pruneExpired()
       lastFetchedAt.value = new Date()
@@ -181,7 +199,13 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
 
   async function refreshFailedTasksFromLiveUpdate() {
     try {
-      await fetchFailedTasks({ hours: lookbackHours.value })
+      await fetchFailedTasks({
+        hours: lookbackHours.value,
+        limit: lastQuery.value.limit,
+        includeRetried: lastQuery.value.includeRetried,
+        noveltyStatus: lastQuery.value.noveltyStatus,
+        noveltyLookbackHours: lastQuery.value.noveltyLookbackHours,
+      })
     } catch {
       // keep the live event visible even if the background refresh fails
     }

--- a/frontend/app/stores/failedTasks.ts
+++ b/frontend/app/stores/failedTasks.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed, readonly } from 'vue'
 import { useApiService } from '../services/apiClient'
-import type { TaskEventResponse } from '../services/apiClient'
+import type { FailureNoveltyStatus, TaskFailureNoveltyResponse } from '../services/apiClient'
 
 const DEFAULT_LOOKBACK_HOURS = 24
 const MIN_LOOKBACK_HOURS = 1
@@ -18,7 +18,7 @@ function parseTimestamp(timestamp?: string | null): number | null {
 export const useFailedTasksStore = defineStore('failedTasks', () => {
   const apiService = useApiService()
 
-  const failedTasks = ref<TaskEventResponse[]>([])
+  const failedTasks = ref<TaskFailureNoveltyResponse[]>([])
   const isLoading = ref(false)
   const error = ref<string | null>(null)
   const lastFetchedAt = ref<Date | null>(null)
@@ -28,15 +28,32 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
   const totalFailedTasks = computed(() => failedTasks.value.length)
   const latestFailedTask = computed(() => failedTasks.value[0] || null)
 
-  function sortTasks(tasks: TaskEventResponse[]): TaskEventResponse[] {
+  function noveltyPriority(task: TaskFailureNoveltyResponse): number {
+    switch (task.failure_novelty_status) {
+      case 'new':
+        return 0
+      case 'regressed':
+        return 1
+      case 'recurring':
+        return 2
+      default:
+        return 3
+    }
+  }
+
+  function sortTasks(tasks: TaskFailureNoveltyResponse[]): TaskFailureNoveltyResponse[] {
     return [...tasks].sort((a, b) => {
+      const noveltyDiff = noveltyPriority(a) - noveltyPriority(b)
+      if (noveltyDiff !== 0) {
+        return noveltyDiff
+      }
       const aTime = parseTimestamp(a.timestamp) ?? 0
       const bTime = parseTimestamp(b.timestamp) ?? 0
       return bTime - aTime
     })
   }
 
-  function setTasks(tasks: TaskEventResponse[]) {
+  function setTasks(tasks: TaskFailureNoveltyResponse[]) {
     failedTasks.value = sortTasks(tasks)
   }
 
@@ -48,7 +65,7 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     })
   }
 
-  function upsertFailedTask(task: TaskEventResponse) {
+  function upsertFailedTask(task: TaskFailureNoveltyResponse) {
     if (!task.task_id) {
       return
     }
@@ -77,11 +94,11 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
         resolved,
         resolved_by: resolved_by ?? null,
         resolved_at: normalizedResolvedAt,
-      } as TaskEventResponse & { resolved?: boolean; resolved_by?: string | null; resolved_at?: string | null }
+      } as TaskFailureNoveltyResponse
     })
   }
 
-  function shouldExclude(task: TaskEventResponse): boolean {
+  function shouldExclude(task: TaskFailureNoveltyResponse): boolean {
     if (task.has_retries) {
       return true
     }
@@ -99,7 +116,13 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     lookbackHours.value = Math.max(MIN_LOOKBACK_HOURS, hours)
   }
 
-  async function fetchFailedTasks(options?: { hours?: number; limit?: number; includeRetried?: boolean }) {
+  async function fetchFailedTasks(options?: {
+    hours?: number
+    limit?: number
+    includeRetried?: boolean
+    noveltyStatus?: FailureNoveltyStatus
+    noveltyLookbackHours?: number
+  }) {
     try {
       isLoading.value = true
       error.value = null
@@ -110,7 +133,11 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
       const response = await apiService.getRecentFailedTasks({
         hours: effectiveHours,
         limit: options?.limit,
-        include_retried: options?.includeRetried ?? false
+        include_retried: options?.includeRetried ?? false,
+        novelty_status: options?.noveltyStatus,
+        novelty_lookback_hours: options?.noveltyLookbackHours,
+        sort_by: 'novelty',
+        sort_order: 'desc',
       })
 
       const filtered = response.filter(task => !shouldExclude(task))
@@ -152,7 +179,7 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     }
   }
 
-  function updateFromLiveEvent(event: TaskEventResponse) {
+  function updateFromLiveEvent(event: TaskFailureNoveltyResponse) {
     const environmentStore = useEnvironmentStore()
     const { matchesEnvironment } = useEnvironmentMatcher()
 

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,18 @@
 /** @type {import('tailwindcss').Config} */
+const withOpacity = (cssVariable: string) => ({ opacityValue }: { opacityValue?: string }) => {
+  if (opacityValue === undefined) {
+    return `var(${cssVariable})`
+  }
+
+  const opacity = Number.parseFloat(opacityValue)
+
+  if (Number.isNaN(opacity)) {
+    return `var(${cssVariable})`
+  }
+
+  return `color-mix(in srgb, var(${cssVariable}) ${opacity * 100}%, transparent)`
+}
+
 export default {
   content: [
     "./app/**/*.{js,vue,ts}",
@@ -19,90 +33,90 @@ export default {
       colors: {
         // Backgrounds using CSS variables
         background: {
-          base: 'var(--bg-base)',
-          surface: 'var(--bg-surface)',
-          raised: 'var(--bg-raised)',
+          base: withOpacity('--bg-base'),
+          surface: withOpacity('--bg-surface'),
+          raised: withOpacity('--bg-raised'),
           overlay: 'hsl(0, 0%, 18%, 0.8)',
           // Interactive states
-          hover: 'var(--bg-hover)',
-          'hover-subtle': 'var(--bg-hover-subtle)',
-          active: 'var(--bg-active)',
-          selected: 'var(--bg-selected)'
+          hover: withOpacity('--bg-hover'),
+          'hover-subtle': withOpacity('--bg-hover-subtle'),
+          active: withOpacity('--bg-active'),
+          selected: withOpacity('--bg-selected')
         },
         // Text colors using CSS variables
         text: {
-          primary: 'var(--text-primary)',
-          secondary: 'var(--text-secondary)',
-          muted: 'var(--text-muted)',
-          disabled: 'var(--text-disabled)'
+          primary: withOpacity('--text-primary'),
+          secondary: withOpacity('--text-secondary'),
+          muted: withOpacity('--text-muted'),
+          disabled: withOpacity('--text-disabled')
         },
         // Card and borders
         card: {
-          base: 'var(--bg-surface)',
-          border: 'var(--border)',
+          base: withOpacity('--bg-surface'),
+          border: withOpacity('--border'),
         },
         // Border colors
         border: {
-          DEFAULT: 'var(--border)',
-          highlight: 'var(--highlight)',
-          subtle: 'var(--border-subtle)'
+          DEFAULT: withOpacity('--border'),
+          highlight: withOpacity('--highlight'),
+          subtle: withOpacity('--border-subtle')
         },
         // Primary/Brand colors
         primary: {
-          DEFAULT: 'var(--primary)',
-          hover: 'var(--primary-hover)',
-          bg: 'var(--primary-bg)',
-          border: 'var(--primary-border)'
+          DEFAULT: withOpacity('--primary'),
+          hover: withOpacity('--primary-hover'),
+          bg: withOpacity('--primary-bg'),
+          border: withOpacity('--primary-border')
         },
         // Semantic status colors using CSS variables
         status: {
           // Success states
           success: {
-            DEFAULT: 'var(--status-success)',
-            bg: 'var(--status-success-bg)',
-            border: 'var(--status-success-border)',
+            DEFAULT: withOpacity('--status-success'),
+            bg: withOpacity('--status-success-bg'),
+            border: withOpacity('--status-success-border'),
             hover: 'hsl(158,100%,13%)'
           },
           // Error states
           error: {
-            DEFAULT: 'var(--status-error)',
-            bg: 'var(--status-error-bg)',
-            border: 'var(--status-error-border)',
+            DEFAULT: withOpacity('--status-error'),
+            bg: withOpacity('--status-error-bg'),
+            border: withOpacity('--status-error-border'),
             hover: 'hsl(347, 77%, 18%)'
           },
           // Warning states
           warning: {
-            DEFAULT: 'var(--status-warning)',
-            bg: 'var(--status-warning-bg)',
-            border: 'var(--status-warning-border)',
+            DEFAULT: withOpacity('--status-warning'),
+            bg: withOpacity('--status-warning-bg'),
+            border: withOpacity('--status-warning-border'),
             hover: 'hsl(45, 85%, 18%)'
           },
           // Info states
           info: {
-            DEFAULT: 'var(--status-info)',
-            bg: 'var(--status-info-bg)',
-            border: 'var(--status-info-border)',
+            DEFAULT: withOpacity('--status-info'),
+            bg: withOpacity('--status-info-bg'),
+            border: withOpacity('--status-info-border'),
             hover: 'hsl(199, 89%, 18%)'
           },
           // Retry states
           retry: {
-            DEFAULT: 'var(--status-retry)',
-            bg: 'var(--status-retry-bg)',
-            border: 'var(--status-retry-border)',
+            DEFAULT: withOpacity('--status-retry'),
+            bg: withOpacity('--status-retry-bg'),
+            border: withOpacity('--status-retry-border'),
             hover: 'hsl(24, 95%, 18%)'
           },
           // Neutral states
           neutral: {
-            DEFAULT: 'var(--status-neutral)',
-            bg: 'var(--status-neutral-bg)',
-            border: 'var(--status-neutral-border)',
+            DEFAULT: withOpacity('--status-neutral'),
+            bg: withOpacity('--status-neutral-bg'),
+            border: withOpacity('--status-neutral-border'),
             hover: 'hsl(215, 20%, 18%)'
           },
           // Special states
           special: {
-            DEFAULT: 'var(--status-special)',
-            bg: 'var(--status-special-bg)',
-            border: 'var(--status-special-border)',
+            DEFAULT: withOpacity('--status-special'),
+            bg: withOpacity('--status-special-bg'),
+            border: withOpacity('--status-special-border'),
             hover: 'hsl(263, 70%, 18%)'
           }
         }


### PR DESCRIPTION
## Summary
- classify recent failed tasks as new, recurring, or regressed based on historical failure fingerprints
- expose novelty metadata plus novelty filter/sort options on the recent failures API
- surface novelty badges in the dashboard and prioritize novel failures in the failed tasks summary

## Testing
- python3 -m pytest tests/unit/test_task_service_recent_failures.py tests/unit/test_app_config_service.py
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failed tasks display novelty badges (new, recurring, regressed) and expose novelty metadata.
  * Filter failed tasks by novelty status and sort by novelty (asc/desc).
  * Configurable lookback window for novelty tracking; live UI updates refresh to reflect novelty changes.

* **Tests**
  * Added unit tests covering novelty classification, filtering, sorting, limit behavior, and regression/recurrence edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->