### PR TITLE
feat: add incident summary cards for failure clusters

### DIFF
--- a/agent/api/task_routes.py
+++ b/agent/api/task_routes.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from services import TaskService, EnvironmentService, SessionService, AppConfigService, ProgressService
 from database import TaskEventDB
-from models import TaskEvent, TaskProgressSnapshot
+from models import TaskEvent, TaskProgressSnapshot, IncidentSummary
 from database import ensure_utc_isoformat
 from config import Config
 from security.auth import AuthenticatedUser
@@ -174,6 +174,24 @@ def create_router(app_state) -> APIRouter:
         )
         return failed_tasks
 
+
+    @router.get("/incidents/summaries", response_model=List[IncidentSummary])
+    async def get_incident_summaries(
+        hours: Optional[int] = Query(
+            default=None,
+            ge=1,
+            le=168,
+            description="Lookback window in hours (defaults to configured value)"
+        ),
+        limit: int = Query(default=12, ge=1, le=50),
+        session: Session = Depends(get_db),
+        active_env = Depends(get_active_env)
+    ):
+        """Get ranked incident summaries for current failure clusters."""
+        task_service = TaskService(session, active_env=active_env)
+        config_service = AppConfigService(session)
+        lookback_hours = hours if hours is not None else config_service.get_task_issue_lookback_hours()
+        return task_service.get_incident_summaries(hours=lookback_hours, limit=limit)
 
     @router.post("/tasks/{task_id}/resolve")
     async def resolve_task(

--- a/agent/models.py
+++ b/agent/models.py
@@ -208,6 +208,33 @@ class TaskProgressSnapshot(BaseModel):
     history: List[TaskProgressEvent] = Field(default_factory=list)
 
 
+class IncidentSummary(BaseModel):
+    """Compact failure-cluster summary for dashboard triage."""
+
+    incident_key: str
+    task_name: str
+    failure_count: int
+    unresolved_count: int
+    retried_task_count: int
+    retry_attempt_count: int
+    affected_workers: List[str] = Field(default_factory=list)
+    worker_count: int = 0
+    first_seen: datetime
+    last_seen: datetime
+    latest_task_id: str
+    latest_exception: Optional[str] = None
+    latest_status: str
+    severity: Literal['low', 'medium', 'high', 'critical']
+    urgency_score: int
+    recent_failure_count: int = 0
+
+    model_config = {
+        'json_encoders': {
+            datetime: lambda v: v.isoformat() if v else None
+        }
+    }
+
+
 class WorkerInfo(BaseModel):
     """Worker information model"""
     hostname: str

--- a/agent/services/task_service.py
+++ b/agent/services/task_service.py
@@ -12,7 +12,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 
 from database import TaskEventDB, RetryRelationshipDB, TaskLatestDB, TaskResolutionDB
-from models import TaskEvent
+from models import TaskEvent, IncidentSummary
 from constants import TaskState, EventType, STATE_TO_EVENT_MAP, ACTIVE_EVENT_TYPES
 from services.utils import EnvironmentFilter, GenericFilter, parse_filter_string
 from utils.payload_sanitizer import find_placeholder_paths
@@ -357,6 +357,143 @@ class TaskService:
         self._attach_resolution_info(events)
 
         return events
+
+    def get_incident_summaries(
+        self,
+        hours: int = 24,
+        limit: int = 12
+    ) -> List[IncidentSummary]:
+        """Aggregate current failed tasks into ranked dashboard incident summaries."""
+        since = datetime.now(timezone.utc) - timedelta(hours=hours)
+
+        latest_subquery = (
+            self.session.query(
+                TaskEventDB.task_id,
+                func.max(TaskEventDB.timestamp).label('max_timestamp')
+            )
+            .filter(TaskEventDB.timestamp >= since)
+        )
+
+        env_filtered_query = self.session.query(TaskEventDB.task_id)
+        env_filtered_query = EnvironmentFilter.apply(env_filtered_query, self.active_env)
+        env_conditions = env_filtered_query.whereclause
+
+        if env_conditions is not None:
+            latest_subquery = latest_subquery.filter(env_conditions)
+
+        latest_subquery = latest_subquery.group_by(TaskEventDB.task_id).subquery()
+
+        failed_events_db = (
+            self.session.query(TaskEventDB)
+            .join(
+                latest_subquery,
+                and_(
+                    TaskEventDB.task_id == latest_subquery.c.task_id,
+                    TaskEventDB.timestamp == latest_subquery.c.max_timestamp
+                )
+            )
+            .filter(
+                TaskEventDB.event_type == EventType.TASK_FAILED.value,
+                TaskEventDB.timestamp >= since
+            )
+            .order_by(TaskEventDB.timestamp.desc())
+            .all()
+        )
+
+        if not failed_events_db:
+            return []
+
+        resolved_task_ids = {
+            row[0]
+            for row in self.session.query(TaskResolutionDB.task_id)
+            .filter(TaskResolutionDB.task_id.in_([event.task_id for event in failed_events_db]))
+            .all()
+        }
+
+        now = datetime.now(timezone.utc)
+        recent_threshold = now - timedelta(hours=1)
+        grouped: Dict[str, Dict[str, Any]] = {}
+
+        for event in failed_events_db:
+            group_key = event.task_name or event.routing_key or event.task_id
+            timestamp = _ensure_utc(event.timestamp) or now
+            retried_by = json.loads(event.retried_by) if event.retried_by else []
+            retry_count = int(event.retry_count or 0)
+            has_retry_activity = bool(event.has_retries or retry_count > 0 or retried_by)
+            entry = grouped.setdefault(group_key, {
+                'incident_key': group_key,
+                'task_name': event.task_name or event.routing_key or 'unknown',
+                'failure_count': 0,
+                'unresolved_count': 0,
+                'retried_task_count': 0,
+                'retry_attempt_count': 0,
+                'affected_workers': set(),
+                'first_seen': timestamp,
+                'last_seen': timestamp,
+                'latest_task_id': event.task_id,
+                'latest_exception': event.exception,
+                'recent_failure_count': 0,
+            })
+
+            entry['failure_count'] += 1
+            if event.task_id not in resolved_task_ids:
+                entry['unresolved_count'] += 1
+            if has_retry_activity:
+                entry['retried_task_count'] += 1
+                entry['retry_attempt_count'] += max(retry_count, len(retried_by), 1)
+            if event.hostname:
+                entry['affected_workers'].add(event.hostname)
+            if timestamp < entry['first_seen']:
+                entry['first_seen'] = timestamp
+            if timestamp > entry['last_seen']:
+                entry['last_seen'] = timestamp
+                entry['latest_task_id'] = event.task_id
+                entry['latest_exception'] = event.exception
+            if timestamp >= recent_threshold:
+                entry['recent_failure_count'] += 1
+
+        summaries: List[IncidentSummary] = []
+        for entry in grouped.values():
+            worker_count = len(entry['affected_workers'])
+            age_minutes = max(int((now - entry['first_seen']).total_seconds() // 60), 0)
+            urgency = (
+                entry['unresolved_count'] * 20
+                + entry['recent_failure_count'] * 8
+                + worker_count * 6
+                + entry['retried_task_count'] * 4
+                + min(age_minutes // 30, 8) * 3
+            )
+            if entry['recent_failure_count'] >= 4 or entry['unresolved_count'] >= 5 or urgency >= 85:
+                severity = 'critical'
+            elif entry['unresolved_count'] >= 3 or urgency >= 40:
+                severity = 'high'
+            elif entry['unresolved_count'] >= 2 or urgency >= 20:
+                severity = 'medium'
+            else:
+                severity = 'low'
+
+            latest_status = 'recovering' if entry['retried_task_count'] > 0 else 'active'
+            summaries.append(IncidentSummary(
+                incident_key=entry['incident_key'],
+                task_name=entry['task_name'],
+                failure_count=entry['failure_count'],
+                unresolved_count=entry['unresolved_count'],
+                retried_task_count=entry['retried_task_count'],
+                retry_attempt_count=entry['retry_attempt_count'],
+                affected_workers=sorted(entry['affected_workers']),
+                worker_count=worker_count,
+                first_seen=entry['first_seen'],
+                last_seen=entry['last_seen'],
+                latest_task_id=entry['latest_task_id'],
+                latest_exception=entry['latest_exception'],
+                latest_status=latest_status,
+                severity=severity,
+                urgency_score=urgency,
+                recent_failure_count=entry['recent_failure_count'],
+            ))
+
+        summaries.sort(key=lambda summary: (-summary.urgency_score, -summary.last_seen.timestamp(), summary.task_name))
+        return summaries[:limit] if limit and limit > 0 else summaries
 
     def create_retry_relationship(
         self,

--- a/agent/tests/unit/test_task_service_incident_summaries.py
+++ b/agent/tests/unit/test_task_service_incident_summaries.py
@@ -1,0 +1,82 @@
+import unittest
+from datetime import datetime, timezone, timedelta
+
+from services.task_service import TaskService
+from tests.base import DatabaseTestCase
+
+
+class TestTaskServiceIncidentSummaries(DatabaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.service = TaskService(self.session)
+        self.now = datetime.now(timezone.utc)
+
+    def test_groups_failures_by_task_name_and_collects_retry_metadata(self):
+        self.create_task_event_db(
+            task_id='alpha-1',
+            task_name='tasks.alpha',
+            event_type='task-failed',
+            timestamp=self.now - timedelta(minutes=20),
+            hostname='worker-a',
+            has_retries=True,
+            retry_count=2,
+            retried_by='["alpha-r1", "alpha-r2"]',
+            exception='boom',
+        )
+        self.create_task_event_db(
+            task_id='alpha-2',
+            task_name='tasks.alpha',
+            event_type='task-failed',
+            timestamp=self.now - timedelta(minutes=5),
+            hostname='worker-b',
+            has_retries=False,
+            retry_count=0,
+            exception='still broken',
+        )
+
+        summaries = self.service.get_incident_summaries(hours=24)
+
+        self.assertEqual(len(summaries), 1)
+        summary = summaries[0]
+        self.assertEqual(summary.task_name, 'tasks.alpha')
+        self.assertEqual(summary.failure_count, 2)
+        self.assertEqual(summary.retried_task_count, 1)
+        self.assertEqual(summary.retry_attempt_count, 2)
+        self.assertEqual(summary.worker_count, 2)
+        self.assertEqual(summary.affected_workers, ['worker-a', 'worker-b'])
+        self.assertEqual(summary.latest_task_id, 'alpha-2')
+        self.assertEqual(summary.latest_exception, 'still broken')
+        self.assertEqual(summary.latest_status, 'recovering')
+        self.assertEqual(summary.recent_failure_count, 2)
+
+    def test_ranks_busier_incidents_ahead_of_smaller_clusters(self):
+        for index in range(4):
+            self.create_task_event_db(
+                task_id=f'critical-{index}',
+                task_name='tasks.critical',
+                event_type='task-failed',
+                timestamp=self.now - timedelta(minutes=10 + index),
+                hostname=f'worker-{index}',
+                exception='critical path failed',
+            )
+
+        self.create_task_event_db(
+            task_id='minor-1',
+            task_name='tasks.minor',
+            event_type='task-failed',
+            timestamp=self.now - timedelta(hours=2),
+            hostname='worker-z',
+            exception='minor issue',
+        )
+
+        summaries = self.service.get_incident_summaries(hours=24)
+
+        self.assertEqual([summary.task_name for summary in summaries], ['tasks.critical', 'tasks.minor'])
+        self.assertIn(summaries[0].severity, {'high', 'critical'})
+        self.assertIn(summaries[1].severity, {'low', 'medium'})
+        self.assertGreater(summaries[0].urgency_score, summaries[1].urgency_score)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/frontend/app/components/TaskIssueSummary.vue
+++ b/frontend/app/components/TaskIssueSummary.vue
@@ -360,6 +360,7 @@ const props = withDefaults(defineProps<{
   itemActionDisabledIds?: string[]
   hideWhenEmpty?: boolean
   ignoreResolved?: boolean
+  externalSearchQuery?: string | null
 }>(), {
   status: 'info',
   isLoading: false,
@@ -376,6 +377,7 @@ const props = withDefaults(defineProps<{
   itemActionDisabledIds: () => [],
   hideWhenEmpty: false,
   ignoreResolved: false,
+  externalSearchQuery: null,
   showLookbackSelector: false,
   lookbackHours: null,
 })
@@ -610,6 +612,11 @@ watch(() => props.limit, (next) => {
 watch(() => [props.tasks, props.ignoreResolved], () => {
   currentPage.value = 0
 })
+
+watch(() => props.externalSearchQuery, (value) => {
+  searchQuery.value = value ?? ''
+  currentPage.value = 0
+}, { immediate: true })
 
 watch(filteredTasks, () => {
   const maxPage = Math.max(0, Math.ceil(totalFiltered.value / pageSizeSafe.value) - 1)

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -283,7 +283,7 @@ import type { TimeRange } from '~/components/TimeRangeFilter.vue'
 import { useUrlQuerySync } from '~/composables/useUrlQuerySync'
 import type { UrlQueryState } from '~/composables/useUrlQuerySync'
 import { useApiService } from '~/services/apiClient'
-import type { TaskEventResponse, IncidentSummaryDTO } from '~/services/apiClient'
+import type { TaskEventResponse, IncidentSummary } from '~/src/types/api'
 import {ChevronRight, RefreshCw, Check, Loader2} from 'lucide-vue-next'
 import {IconButton} from "~/components/common";
 
@@ -370,10 +370,10 @@ const formatLookbackLabel = (hours: number) => {
 }
 const failedTasksTitle = computed(() => `Failed tasks (${formatLookbackLabel(failedTasksLookbackHours.value)})`)
 const failedTasksEmptyTitle = computed(() => `No failed tasks detected in the last ${formatLookbackLabel(failedTasksLookbackHours.value)}`)
-const incidentSummaries = ref<IncidentSummaryDTO[]>([])
+const incidentSummaries = ref<IncidentSummary[]>([])
 const incidentSearchQuery = ref('')
 
-const severityVariant = (severity: IncidentSummaryDTO['severity']) => ({
+const severityVariant = (severity: IncidentSummary['severity']) => ({
   low: 'outline',
   medium: 'secondary',
   high: 'orphaned',

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -283,7 +283,7 @@ import type { TimeRange } from '~/components/TimeRangeFilter.vue'
 import { useUrlQuerySync } from '~/composables/useUrlQuerySync'
 import type { UrlQueryState } from '~/composables/useUrlQuerySync'
 import { useApiService } from '~/services/apiClient'
-import type { TaskEventResponse, IncidentSummary } from '~/src/types/api'
+import type { TaskEventResponse, IncidentSummary } from '~/services/apiClient'
 import {ChevronRight, RefreshCw, Check, Loader2} from 'lucide-vue-next'
 import {IconButton} from "~/components/common";
 

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -16,6 +16,68 @@
 
       <!-- Failure & Orphaned Tasks Overview -->
       <div class="mb-6 flex flex-col gap-4 failure-insights-section">
+        <div v-if="incidentSummaries.length" class="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
+          <div
+            v-for="incident in incidentSummaries"
+            :key="incident.incident_key"
+            class="rounded-md border border-border-subtle bg-background-surface p-4 glow-border"
+          >
+            <div class="flex items-start justify-between gap-3">
+              <div class="min-w-0">
+                <p class="text-[11px] uppercase tracking-[0.18em] text-text-muted">Incident summary</p>
+                <TaskName :name="incident.task_name" size="sm" :max-length="36" :expandable="true" />
+              </div>
+              <Badge :variant="severityVariant(incident.severity)" class="capitalize">{{ incident.severity }}</Badge>
+            </div>
+            <div class="mt-3 grid grid-cols-2 gap-3 text-sm">
+              <div>
+                <p class="text-text-muted">Failures</p>
+                <p class="font-mono text-text-primary">{{ incident.failure_count }}</p>
+              </div>
+              <div>
+                <p class="text-text-muted">Retries</p>
+                <p class="font-mono text-text-primary">{{ incident.retry_attempt_count }}</p>
+              </div>
+              <div>
+                <p class="text-text-muted">Workers</p>
+                <p class="font-mono text-text-primary">{{ incident.worker_count }}</p>
+              </div>
+              <div>
+                <p class="text-text-muted">Status</p>
+                <p class="font-medium capitalize text-text-primary">{{ incident.latest_status }}</p>
+              </div>
+            </div>
+            <div class="mt-3 flex flex-wrap gap-2">
+              <Badge variant="outline" class="gap-1 border-border-subtle text-text-secondary">
+                First <TimeDisplay :timestamp="incident.first_seen" layout="inline" :auto-refresh="true" :refresh-interval="60000" />
+              </Badge>
+              <Badge variant="outline" class="gap-1 border-border-subtle text-text-secondary">
+                Last <TimeDisplay :timestamp="incident.last_seen" layout="inline" :auto-refresh="true" :refresh-interval="60000" />
+              </Badge>
+            </div>
+            <p v-if="incident.latest_exception" class="mt-3 line-clamp-2 text-xs text-text-muted">
+              {{ incident.latest_exception }}
+            </p>
+            <div class="mt-3 flex flex-wrap gap-2">
+              <Button variant="outline" size="xs" class="gap-1" @click="focusIncident(incident.task_name)">
+                Focus failures
+              </Button>
+              <NuxtLink :to="`/tasks/${incident.latest_task_id}`">
+                <Button variant="outline" size="xs" class="gap-1">
+                  <ChevronRight class="h-3.5 w-3.5" />
+                  Open latest
+                </Button>
+              </NuxtLink>
+            </div>
+            <div v-if="incident.affected_workers.length" class="mt-3 flex flex-wrap gap-1.5">
+              <Badge v-for="worker in incident.affected_workers.slice(0, 3)" :key="worker" variant="secondary" class="font-mono text-[10px]">
+                {{ worker }}
+              </Badge>
+              <span v-if="incident.affected_workers.length > 3" class="text-xs text-text-muted">+{{ incident.affected_workers.length - 3 }} more</span>
+            </div>
+          </div>
+        </div>
+
         <TaskIssueSummary
           :tasks="failedTasksStore.failedTasks"
           :is-loading="failedTasksStore.isLoading"
@@ -38,6 +100,7 @@
           :empty-state-title="failedTasksEmptyTitle"
           empty-state-description="New failures will appear here instantly."
           :item-action-loading-ids="retryLoadingIds"
+          :external-search-query="incidentSearchQuery"
           @item-action="handleFailedRetryAction"
           @lookback-change="handleLookbackChange"
         >
@@ -210,6 +273,7 @@ import WorkerStatusSummary from "~/components/WorkerStatusSummary.vue"
 import CommandPalette from "~/components/CommandPalette.vue"
 import TaskIssueSummary from "~/components/TaskIssueSummary.vue"
 import RetryTaskConfirmDialog from "~/components/RetryTaskConfirmDialog.vue"
+import TaskName from '~/components/TaskName.vue'
 import { Button } from '~/components/ui/button'
 import { Badge } from '~/components/ui/badge'
 import TimeDisplay from '~/components/TimeDisplay.vue'
@@ -218,7 +282,7 @@ import type { ParsedFilter } from '~/composables/useFilterParser'
 import type { TimeRange } from '~/components/TimeRangeFilter.vue'
 import { useUrlQuerySync } from '~/composables/useUrlQuerySync'
 import type { UrlQueryState } from '~/composables/useUrlQuerySync'
-import type { TaskEventResponse } from '~/services/apiClient'
+import type { TaskEventResponse, IncidentSummaryDTO } from '~/services/apiClient'
 import {ChevronRight, RefreshCw, Check, Loader2} from 'lucide-vue-next'
 import {IconButton} from "~/components/common";
 
@@ -229,6 +293,7 @@ const failedTasksStore = useFailedTasksStore()
 const configStore = useConfigStore()
 const wsStore = useWebSocketStore()
 const environmentStore = useEnvironmentStore()
+const apiService = useApiService()
 
 // Time range state
 const timeRange = ref<TimeRange>({ start: null, end: null })
@@ -304,6 +369,26 @@ const formatLookbackLabel = (hours: number) => {
 }
 const failedTasksTitle = computed(() => `Failed tasks (${formatLookbackLabel(failedTasksLookbackHours.value)})`)
 const failedTasksEmptyTitle = computed(() => `No failed tasks detected in the last ${formatLookbackLabel(failedTasksLookbackHours.value)}`)
+const incidentSummaries = ref<IncidentSummaryDTO[]>([])
+const incidentSearchQuery = ref('')
+
+const severityVariant = (severity: IncidentSummaryDTO['severity']) => ({
+  low: 'outline',
+  medium: 'secondary',
+  high: 'orphaned',
+  critical: 'destructive'
+}[severity] ?? 'outline')
+
+function focusIncident(taskName: string) {
+  incidentSearchQuery.value = taskName
+}
+
+async function refreshIncidentSummaries() {
+  incidentSummaries.value = await apiService.getIncidentSummaries({
+    hours: failedTasksStore.lookbackHours,
+    limit: 6
+  })
+}
 
 const retryDialogRef = ref<InstanceType<typeof RetryTaskConfirmDialog> | null>(null)
 const retryDialogState = ref<{ task: TaskEventResponse; type: 'failed' | 'orphan' } | null>(null)
@@ -371,6 +456,7 @@ function handleLookbackChange(hours: number) {
   const normalized = normalizeLookback(hours)
   failedTasksStore.setLookbackHours(normalized)
   failedTasksStore.fetchFailedTasks({ hours: normalized }).catch(() => {})
+  refreshIncidentSummaries().catch(() => {})
 }
 
 function handleSetSorting(sorting: { id: string; desc: boolean }[]) {
@@ -563,7 +649,8 @@ watch(() => environmentStore.activeEnvironment, async () => {
     tasksStore.fetchStats(),
     workersStore.fetchWorkers(),
     orphanTasksStore.fetchOrphanedTasks(),
-    failedTasksStore.fetchFailedTasks({ hours: failedTasksStore.lookbackHours })
+    failedTasksStore.fetchFailedTasks({ hours: failedTasksStore.lookbackHours }),
+    refreshIncidentSummaries()
   ])
 })
 
@@ -574,6 +661,11 @@ watch(() => configStore.taskIssueLookbackHours, (hours) => {
   }
   failedTasksStore.setLookbackHours(normalized)
   failedTasksStore.fetchFailedTasks({ hours: normalized }).catch(() => {})
+  refreshIncidentSummaries().catch(() => {})
+})
+
+watch(() => failedTasksStore.failedTasks.map(task => `${task.task_id}:${task.timestamp}`).join('|'), () => {
+  refreshIncidentSummaries().catch(() => {})
 })
 
 // Store interval IDs at component scope
@@ -594,7 +686,8 @@ onMounted(async () => {
     tasksStore.fetchStats(),
     workersStore.fetchWorkers(),
     orphanTasksStore.fetchOrphanedTasks(),
-    failedTasksStore.fetchFailedTasks({ hours: failedTasksStore.lookbackHours })
+    failedTasksStore.fetchFailedTasks({ hours: failedTasksStore.lookbackHours }),
+    refreshIncidentSummaries()
   ])
 
   tasksStore.setLiveMode(wsStore.clientMode === 'live')
@@ -608,6 +701,7 @@ onMounted(async () => {
 
   failedTasksInterval = setInterval(() => {
     failedTasksStore.fetchFailedTasks({ hours: failedTasksStore.lookbackHours }).catch(() => {})
+    refreshIncidentSummaries().catch(() => {})
   }, 60000) // Poll every 60 seconds for failed tasks
 
   workerInterval = setInterval(() => {

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -69,11 +69,11 @@
                 </Button>
               </NuxtLink>
             </div>
-            <div v-if="incident.affected_workers.length" class="mt-3 flex flex-wrap gap-1.5">
-              <Badge v-for="worker in incident.affected_workers.slice(0, 3)" :key="worker" variant="secondary" class="font-mono text-[10px]">
+            <div v-if="incident.affected_workers?.length" class="mt-3 flex flex-wrap gap-1.5">
+              <Badge v-for="worker in (incident.affected_workers || []).slice(0, 3)" :key="worker" variant="secondary" class="font-mono text-[10px]">
                 {{ worker }}
               </Badge>
-              <span v-if="incident.affected_workers.length > 3" class="text-xs text-text-muted">+{{ incident.affected_workers.length - 3 }} more</span>
+              <span v-if="incident.affected_workers && incident.affected_workers.length > 3" class="text-xs text-text-muted">+{{ incident.affected_workers.length - 3 }} more</span>
             </div>
           </div>
         </div>
@@ -372,6 +372,7 @@ const failedTasksTitle = computed(() => `Failed tasks (${formatLookbackLabel(fai
 const failedTasksEmptyTitle = computed(() => `No failed tasks detected in the last ${formatLookbackLabel(failedTasksLookbackHours.value)}`)
 const incidentSummaries = ref<IncidentSummary[]>([])
 const incidentSearchQuery = ref('')
+let incidentSummaryRequestId = 0
 
 const severityVariant = (severity: IncidentSummary['severity']) => ({
   low: 'outline',
@@ -385,10 +386,15 @@ function focusIncident(taskName: string) {
 }
 
 async function refreshIncidentSummaries() {
-  incidentSummaries.value = await apiService.getIncidentSummaries({
+  const requestId = ++incidentSummaryRequestId
+  const summaries = await apiService.getIncidentSummaries({
     hours: failedTasksStore.lookbackHours,
     limit: 6
   })
+
+  if (requestId === incidentSummaryRequestId) {
+    incidentSummaries.value = summaries
+  }
 }
 
 const retryDialogRef = ref<InstanceType<typeof RetryTaskConfirmDialog> | null>(null)
@@ -702,7 +708,6 @@ onMounted(async () => {
 
   failedTasksInterval = setInterval(() => {
     failedTasksStore.fetchFailedTasks({ hours: failedTasksStore.lookbackHours }).catch(() => {})
-    refreshIncidentSummaries().catch(() => {})
   }, 60000) // Poll every 60 seconds for failed tasks
 
   workerInterval = setInterval(() => {

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -282,6 +282,7 @@ import type { ParsedFilter } from '~/composables/useFilterParser'
 import type { TimeRange } from '~/components/TimeRangeFilter.vue'
 import { useUrlQuerySync } from '~/composables/useUrlQuerySync'
 import type { UrlQueryState } from '~/composables/useUrlQuerySync'
+import { useApiService } from '~/services/apiClient'
 import type { TaskEventResponse, IncidentSummaryDTO } from '~/services/apiClient'
 import {ChevronRight, RefreshCw, Check, Loader2} from 'lucide-vue-next'
 import {IconButton} from "~/components/common";

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -3,6 +3,7 @@
  */
 import { Api } from '../src/types/api'
 import type {
+  IncidentSummary,
   TaskStats,
   TaskEventResponse,
   WorkerInfo
@@ -101,25 +102,6 @@ export interface TaskProgressSnapshotResponse {
   latest?: TaskProgressEventResponse | null
   steps: TaskStepDefinition[]
   history: TaskProgressEventResponse[]
-}
-
-export interface IncidentSummaryDTO {
-  incident_key: string
-  task_name: string
-  failure_count: number
-  unresolved_count: number
-  retried_task_count: number
-  retry_attempt_count: number
-  affected_workers: string[]
-  worker_count: number
-  first_seen: string
-  last_seen: string
-  latest_task_id: string
-  latest_exception?: string | null
-  latest_status: 'active' | 'recovering'
-  severity: 'low' | 'medium' | 'high' | 'critical'
-  urgency_score: number
-  recent_failure_count: number
 }
 
 class ApiService {
@@ -358,12 +340,8 @@ class ApiService {
     return response.data
   }
 
-  async getIncidentSummaries(params?: { hours?: number; limit?: number }): Promise<IncidentSummaryDTO[]> {
-    const response = await this.api.request({
-      path: '/api/incidents/summaries',
-      method: 'GET',
-      query: params
-    })
+  async getIncidentSummaries(params?: { hours?: number; limit?: number }): Promise<IncidentSummary[]> {
+    const response = await this.api.api.getIncidentSummariesApiIncidentsSummariesGet(params)
     return response.data
   }
 

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -726,6 +726,7 @@ export function useApiService(): ApiService {
 }
 
 export type {
+  IncidentSummary,
   TaskStats,
   TaskEventResponse,
   WorkerInfo,

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -103,6 +103,25 @@ export interface TaskProgressSnapshotResponse {
   history: TaskProgressEventResponse[]
 }
 
+export interface IncidentSummaryDTO {
+  incident_key: string
+  task_name: string
+  failure_count: number
+  unresolved_count: number
+  retried_task_count: number
+  retry_attempt_count: number
+  affected_workers: string[]
+  worker_count: number
+  first_seen: string
+  last_seen: string
+  latest_task_id: string
+  latest_exception?: string | null
+  latest_status: 'active' | 'recovering'
+  severity: 'low' | 'medium' | 'high' | 'critical'
+  urgency_score: number
+  recent_failure_count: number
+}
+
 class ApiService {
   private api: Api<unknown>
 
@@ -333,6 +352,15 @@ class ApiService {
   async getRecentFailedTasks(params?: { hours?: number; limit?: number; include_retried?: boolean }): Promise<TaskEventResponse[]> {
     const response = await this.api.request({
       path: '/api/tasks/failed/recent',
+      method: 'GET',
+      query: params
+    })
+    return response.data
+  }
+
+  async getIncidentSummaries(params?: { hours?: number; limit?: number }): Promise<IncidentSummaryDTO[]> {
+    const response = await this.api.request({
+      path: '/api/incidents/summaries',
       method: 'GET',
       query: params
     })

--- a/frontend/app/src/types/api.ts
+++ b/frontend/app/src/types/api.ts
@@ -39,7 +39,7 @@ export interface ActionConfig {
   /** Config Id */
   config_id?: string | null;
   /** Params */
-  params?: object;
+  params?: Record<string, any>;
   /**
    * Continue On Failure
    * @default true
@@ -59,7 +59,7 @@ export interface ActionConfigCreateRequest {
   /** Action Type */
   action_type: string;
   /** Config */
-  config: object;
+  config: Record<string, any>;
 }
 
 /**
@@ -76,7 +76,7 @@ export interface ActionConfigDefinition {
   /** Action Type */
   action_type: string;
   /** Config */
-  config: object;
+  config: Record<string, any>;
   /** Created At */
   created_at?: string | null;
   /** Updated At */
@@ -102,7 +102,65 @@ export interface ActionConfigUpdateRequest {
   /** Description */
   description?: string | null;
   /** Config */
-  config?: object | null;
+  config?: Record<string, any> | null;
+}
+
+/**
+ * AppConfigSnapshot
+ * Grouped configuration snapshot returned to clients.
+ */
+export interface AppConfigSnapshot {
+  /** Configuration for the task issue summary section. */
+  task_issue_summary: TaskIssueConfig;
+}
+
+/**
+ * AppSetting
+ * Database-backed application setting.
+ */
+export interface AppSetting {
+  /** Key */
+  key: string;
+  /** Value */
+  value: any;
+  /**
+   * Value Type
+   * @default "string"
+   */
+  value_type?: "string" | "number" | "boolean" | "json";
+  /** Label */
+  label?: string | null;
+  /** Description */
+  description?: string | null;
+  /** Category */
+  category?: string | null;
+  /**
+   * Created At
+   * @format date-time
+   */
+  created_at: string;
+  /**
+   * Updated At
+   * @format date-time
+   */
+  updated_at: string;
+}
+
+/**
+ * AppSettingUpdate
+ * Create/update payload for an application setting.
+ */
+export interface AppSettingUpdate {
+  /** Value */
+  value: any;
+  /** Value Type */
+  value_type?: "string" | "number" | "boolean" | "json" | null;
+  /** Label */
+  label?: string | null;
+  /** Description */
+  description?: string | null;
+  /** Category */
+  category?: string | null;
 }
 
 /**
@@ -308,6 +366,57 @@ export interface HTTPValidationError {
 }
 
 /**
+ * IncidentSummary
+ * Compact failure-cluster summary for dashboard triage.
+ */
+export interface IncidentSummary {
+  /** Incident Key */
+  incident_key: string;
+  /** Task Name */
+  task_name: string;
+  /** Failure Count */
+  failure_count: number;
+  /** Unresolved Count */
+  unresolved_count: number;
+  /** Retried Task Count */
+  retried_task_count: number;
+  /** Retry Attempt Count */
+  retry_attempt_count: number;
+  /** Affected Workers */
+  affected_workers?: string[];
+  /**
+   * Worker Count
+   * @default 0
+   */
+  worker_count?: number;
+  /**
+   * First Seen
+   * @format date-time
+   */
+  first_seen: string;
+  /**
+   * Last Seen
+   * @format date-time
+   */
+  last_seen: string;
+  /** Latest Task Id */
+  latest_task_id: string;
+  /** Latest Exception */
+  latest_exception?: string | null;
+  /** Latest Status */
+  latest_status: string;
+  /** Severity */
+  severity: "low" | "medium" | "high" | "critical";
+  /** Urgency Score */
+  urgency_score: number;
+  /**
+   * Recent Failure Count
+   * @default 0
+   */
+  recent_failure_count?: number;
+}
+
+/**
  * LogEntry
  * Log entry from frontend
  */
@@ -319,7 +428,7 @@ export interface LogEntry {
   /** Timestamp */
   timestamp?: string | null;
   /** Context */
-  context?: object | null;
+  context?: Record<string, any> | null;
 }
 
 /**
@@ -351,6 +460,29 @@ export interface LogoutRequest {
 export interface RefreshRequest {
   /** Refresh Token */
   refresh_token: string;
+}
+
+/** ResolveTaskRequest */
+export interface ResolveTaskRequest {
+  /** Resolved By */
+  resolved_by?: string | null;
+}
+
+/**
+ * StepDefinition
+ * Single step definition for task progress.
+ */
+export interface StepDefinition {
+  /** Key */
+  key: string;
+  /** Label */
+  label: string;
+  /** Description */
+  description?: string | null;
+  /** Total */
+  total?: number | null;
+  /** Order */
+  order?: number | null;
 }
 
 /**
@@ -437,7 +569,7 @@ export interface TaskEvent {
   /** Args */
   args?: any[];
   /** Kwargs */
-  kwargs?: object;
+  kwargs?: Record<string, any>;
   /**
    * Retries
    * @default 0
@@ -500,6 +632,72 @@ export interface TaskEvent {
   is_orphan?: boolean;
   /** Orphaned At */
   orphaned_at?: string | null;
+  /**
+   * Resolved
+   * @default false
+   */
+  resolved?: boolean;
+  /** Resolved By */
+  resolved_by?: string | null;
+  /** Resolved At */
+  resolved_at?: string | null;
+}
+
+/**
+ * TaskIssueConfig
+ * Configuration for the task issue summary section.
+ */
+export interface TaskIssueConfig {
+  /**
+   * Lookback Hours
+   * @min 1
+   * @max 168
+   * @default 24
+   */
+  lookback_hours?: number;
+}
+
+/**
+ * TaskProgressEvent
+ * Task progress update event.
+ */
+export interface TaskProgressEvent {
+  /** Task Id */
+  task_id: string;
+  /** Task Name */
+  task_name: string;
+  /** Progress */
+  progress: number;
+  /**
+   * Timestamp
+   * @format date-time
+   */
+  timestamp: string;
+  /** Step Key */
+  step_key?: string | null;
+  /** Message */
+  message?: string | null;
+  /** Meta */
+  meta?: Record<string, any> | null;
+  /**
+   * Event Type
+   * @default "kanchi-task-progress"
+   */
+  event_type?: "kanchi-task-progress";
+}
+
+/**
+ * TaskProgressSnapshot
+ * Aggregate view of progress and steps for a task.
+ */
+export interface TaskProgressSnapshot {
+  /** Task Id */
+  task_id: string;
+  latest?: TaskProgressEvent | null;
+  /** Steps */
+  steps?: StepDefinition[];
+  /** History */
+  history?: TaskProgressEvent[];
 }
 
 /**
@@ -653,7 +851,7 @@ export interface TriggerConfig {
   /** Type */
   type: string;
   /** Config */
-  config?: object;
+  config?: Record<string, any>;
 }
 
 /**
@@ -683,7 +881,7 @@ export interface UserSessionResponse {
   /** Active Environment Id */
   active_environment_id?: string | null;
   /** Preferences */
-  preferences?: object;
+  preferences?: Record<string, any>;
   /**
    * Created At
    * @format date-time
@@ -704,7 +902,7 @@ export interface UserSessionUpdate {
   /** Active Environment Id */
   active_environment_id?: string | null;
   /** Preferences */
-  preferences?: object | null;
+  preferences?: Record<string, any> | null;
 }
 
 /** ValidationError */
@@ -863,7 +1061,7 @@ export interface WorkflowExecutionRecord {
   /** Trigger Type */
   trigger_type: string;
   /** Trigger Event */
-  trigger_event: object;
+  trigger_event: Record<string, any>;
   /** Status */
   status:
     | "pending"
@@ -873,7 +1071,7 @@ export interface WorkflowExecutionRecord {
     | "rate_limited"
     | "circuit_open";
   /** Actions Executed */
-  actions_executed?: object[] | null;
+  actions_executed?: Record<string, any>[] | null;
   /** Error Message */
   error_message?: string | null;
   /** Stack Trace */
@@ -885,7 +1083,7 @@ export interface WorkflowExecutionRecord {
   /** Duration Ms */
   duration_ms?: number | null;
   /** Workflow Snapshot */
-  workflow_snapshot?: object | null;
+  workflow_snapshot?: Record<string, any> | null;
   /** Circuit Breaker Key */
   circuit_breaker_key?: string | null;
 }
@@ -1150,7 +1348,7 @@ export class Api<
       },
       params: RequestParams = {},
     ) =>
-      this.request<object, HTTPValidationError>({
+      this.request<Record<string, any>, HTTPValidationError>({
         path: `/api/events/recent`,
         method: "GET",
         query: query,
@@ -1172,6 +1370,25 @@ export class Api<
     ) =>
       this.request<TaskEvent[], HTTPValidationError>({
         path: `/api/events/${taskId}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Get latest progress, steps, and recent history for a task.
+     *
+     * @tags tasks
+     * @name GetTaskProgressApiTasksTaskIdProgressGet
+     * @summary Get Task Progress
+     * @request GET:/api/tasks/{task_id}/progress
+     */
+    getTaskProgressApiTasksTaskIdProgressGet: (
+      taskId: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<TaskProgressSnapshot, HTTPValidationError>({
+        path: `/api/tasks/${taskId}/progress`,
         method: "GET",
         format: "json",
         ...params,
@@ -1221,9 +1438,9 @@ export class Api<
       query?: {
         /**
          * Hours
-         * @default 24
+         * Lookback window in hours (defaults to configured value)
          */
-        hours?: number;
+        hours?: number | null;
         /**
          * Limit
          * @default 50
@@ -1241,6 +1458,80 @@ export class Api<
         path: `/api/tasks/failed/recent`,
         method: "GET",
         query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Get ranked incident summaries for current failure clusters.
+     *
+     * @tags tasks
+     * @name GetIncidentSummariesApiIncidentsSummariesGet
+     * @summary Get Incident Summaries
+     * @request GET:/api/incidents/summaries
+     */
+    getIncidentSummariesApiIncidentsSummariesGet: (
+      query?: {
+        /**
+         * Hours
+         * Lookback window in hours (defaults to configured value)
+         */
+        hours?: number | null;
+        /**
+         * Limit
+         * @min 1
+         * @max 50
+         * @default 12
+         */
+        limit?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<IncidentSummary[], HTTPValidationError>({
+        path: `/api/incidents/summaries`,
+        method: "GET",
+        query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Manually mark a task as resolved without altering its state.
+     *
+     * @tags tasks
+     * @name ResolveTaskApiTasksTaskIdResolvePost
+     * @summary Resolve Task
+     * @request POST:/api/tasks/{task_id}/resolve
+     */
+    resolveTaskApiTasksTaskIdResolvePost: (
+      taskId: string,
+      data: ResolveTaskRequest | null,
+      params: RequestParams = {},
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/api/tasks/${taskId}/resolve`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Remove manual resolution mark from a task.
+     *
+     * @tags tasks
+     * @name ClearTaskResolutionApiTasksTaskIdResolveDelete
+     * @summary Clear Task Resolution
+     * @request DELETE:/api/tasks/{task_id}/resolve
+     */
+    clearTaskResolutionApiTasksTaskIdResolveDelete: (
+      taskId: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/api/tasks/${taskId}/resolve`,
+        method: "DELETE",
         format: "json",
         ...params,
       }),
@@ -1565,7 +1856,7 @@ export class Api<
       },
       params: RequestParams = {},
     ) =>
-      this.request<object, HTTPValidationError>({
+      this.request<Record<string, any>, HTTPValidationError>({
         path: `/api/registry/tasks/${taskName}/trend`,
         method: "GET",
         query: query,
@@ -1987,7 +2278,7 @@ export class Api<
      */
     testWorkflowApiWorkflowsWorkflowIdTestPost: (
       workflowId: string,
-      data: object,
+      data: Record<string, any>,
       params: RequestParams = {},
     ) =>
       this.request<any, HTTPValidationError>({
@@ -2263,6 +2554,97 @@ export class Api<
       }),
 
     /**
+     * @description Get grouped application configuration with defaults applied.
+     *
+     * @tags config
+     * @name GetConfigSnapshotApiConfigGet
+     * @summary Get Config Snapshot
+     * @request GET:/api/config
+     */
+    getConfigSnapshotApiConfigGet: (params: RequestParams = {}) =>
+      this.request<AppConfigSnapshot, any>({
+        path: `/api/config`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description List all application settings.
+     *
+     * @tags config
+     * @name ListSettingsApiConfigSettingsGet
+     * @summary List Settings
+     * @request GET:/api/config/settings
+     */
+    listSettingsApiConfigSettingsGet: (params: RequestParams = {}) =>
+      this.request<AppSetting[], any>({
+        path: `/api/config/settings`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Get a single application setting.
+     *
+     * @tags config
+     * @name GetSettingApiConfigSettingsKeyGet
+     * @summary Get Setting
+     * @request GET:/api/config/settings/{key}
+     */
+    getSettingApiConfigSettingsKeyGet: (
+      key: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<AppSetting, HTTPValidationError>({
+        path: `/api/config/settings/${key}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Create or update an application setting.
+     *
+     * @tags config
+     * @name UpsertSettingApiConfigSettingsKeyPut
+     * @summary Upsert Setting
+     * @request PUT:/api/config/settings/{key}
+     */
+    upsertSettingApiConfigSettingsKeyPut: (
+      key: string,
+      data: AppSettingUpdate,
+      params: RequestParams = {},
+    ) =>
+      this.request<AppSetting, HTTPValidationError>({
+        path: `/api/config/settings/${key}`,
+        method: "PUT",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Delete a setting (falls back to default).
+     *
+     * @tags config
+     * @name DeleteSettingApiConfigSettingsKeyDelete
+     * @summary Delete Setting
+     * @request DELETE:/api/config/settings/{key}
+     */
+    deleteSettingApiConfigSettingsKeyDelete: (
+      key: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, HTTPValidationError>({
+        path: `/api/config/settings/${key}`,
+        method: "DELETE",
+        ...params,
+      }),
+
+    /**
      * @description Public health endpoint without sensitive data.
      *
      * @name HealthCheckApiHealthGet
@@ -2287,6 +2669,22 @@ export class Api<
     healthDetailsApiHealthDetailsGet: (params: RequestParams = {}) =>
       this.request<any, any>({
         path: `/api/health/details`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+  };
+  metrics = {
+    /**
+     * No description
+     *
+     * @name MetricsMetricsGet
+     * @summary Metrics
+     * @request GET:/metrics
+     */
+    metricsMetricsGet: (params: RequestParams = {}) =>
+      this.request<any, any>({
+        path: `/metrics`,
         method: "GET",
         format: "json",
         ...params,

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,18 @@
 /** @type {import('tailwindcss').Config} */
+const withOpacity = (cssVariable: string) => ({ opacityValue }: { opacityValue?: string }) => {
+  if (opacityValue === undefined) {
+    return `var(${cssVariable})`
+  }
+
+  const opacity = Number.parseFloat(opacityValue)
+
+  if (Number.isNaN(opacity)) {
+    return `var(${cssVariable})`
+  }
+
+  return `color-mix(in srgb, var(${cssVariable}) ${opacity * 100}%, transparent)`
+}
+
 export default {
   content: [
     "./app/**/*.{js,vue,ts}",
@@ -19,90 +33,90 @@ export default {
       colors: {
         // Backgrounds using CSS variables
         background: {
-          base: 'var(--bg-base)',
-          surface: 'var(--bg-surface)',
-          raised: 'var(--bg-raised)',
+          base: withOpacity('--bg-base'),
+          surface: withOpacity('--bg-surface'),
+          raised: withOpacity('--bg-raised'),
           overlay: 'hsl(0, 0%, 18%, 0.8)',
           // Interactive states
-          hover: 'var(--bg-hover)',
-          'hover-subtle': 'var(--bg-hover-subtle)',
-          active: 'var(--bg-active)',
-          selected: 'var(--bg-selected)'
+          hover: withOpacity('--bg-hover'),
+          'hover-subtle': withOpacity('--bg-hover-subtle'),
+          active: withOpacity('--bg-active'),
+          selected: withOpacity('--bg-selected')
         },
         // Text colors using CSS variables
         text: {
-          primary: 'var(--text-primary)',
-          secondary: 'var(--text-secondary)',
-          muted: 'var(--text-muted)',
-          disabled: 'var(--text-disabled)'
+          primary: withOpacity('--text-primary'),
+          secondary: withOpacity('--text-secondary'),
+          muted: withOpacity('--text-muted'),
+          disabled: withOpacity('--text-disabled')
         },
         // Card and borders
         card: {
-          base: 'var(--bg-surface)',
-          border: 'var(--border)',
+          base: withOpacity('--bg-surface'),
+          border: withOpacity('--border'),
         },
         // Border colors
         border: {
-          DEFAULT: 'var(--border)',
-          highlight: 'var(--highlight)',
-          subtle: 'var(--border-subtle)'
+          DEFAULT: withOpacity('--border'),
+          highlight: withOpacity('--highlight'),
+          subtle: withOpacity('--border-subtle')
         },
         // Primary/Brand colors
         primary: {
-          DEFAULT: 'var(--primary)',
-          hover: 'var(--primary-hover)',
-          bg: 'var(--primary-bg)',
-          border: 'var(--primary-border)'
+          DEFAULT: withOpacity('--primary'),
+          hover: withOpacity('--primary-hover'),
+          bg: withOpacity('--primary-bg'),
+          border: withOpacity('--primary-border')
         },
         // Semantic status colors using CSS variables
         status: {
           // Success states
           success: {
-            DEFAULT: 'var(--status-success)',
-            bg: 'var(--status-success-bg)',
-            border: 'var(--status-success-border)',
+            DEFAULT: withOpacity('--status-success'),
+            bg: withOpacity('--status-success-bg'),
+            border: withOpacity('--status-success-border'),
             hover: 'hsl(158,100%,13%)'
           },
           // Error states
           error: {
-            DEFAULT: 'var(--status-error)',
-            bg: 'var(--status-error-bg)',
-            border: 'var(--status-error-border)',
+            DEFAULT: withOpacity('--status-error'),
+            bg: withOpacity('--status-error-bg'),
+            border: withOpacity('--status-error-border'),
             hover: 'hsl(347, 77%, 18%)'
           },
           // Warning states
           warning: {
-            DEFAULT: 'var(--status-warning)',
-            bg: 'var(--status-warning-bg)',
-            border: 'var(--status-warning-border)',
+            DEFAULT: withOpacity('--status-warning'),
+            bg: withOpacity('--status-warning-bg'),
+            border: withOpacity('--status-warning-border'),
             hover: 'hsl(45, 85%, 18%)'
           },
           // Info states
           info: {
-            DEFAULT: 'var(--status-info)',
-            bg: 'var(--status-info-bg)',
-            border: 'var(--status-info-border)',
+            DEFAULT: withOpacity('--status-info'),
+            bg: withOpacity('--status-info-bg'),
+            border: withOpacity('--status-info-border'),
             hover: 'hsl(199, 89%, 18%)'
           },
           // Retry states
           retry: {
-            DEFAULT: 'var(--status-retry)',
-            bg: 'var(--status-retry-bg)',
-            border: 'var(--status-retry-border)',
+            DEFAULT: withOpacity('--status-retry'),
+            bg: withOpacity('--status-retry-bg'),
+            border: withOpacity('--status-retry-border'),
             hover: 'hsl(24, 95%, 18%)'
           },
           // Neutral states
           neutral: {
-            DEFAULT: 'var(--status-neutral)',
-            bg: 'var(--status-neutral-bg)',
-            border: 'var(--status-neutral-border)',
+            DEFAULT: withOpacity('--status-neutral'),
+            bg: withOpacity('--status-neutral-bg'),
+            border: withOpacity('--status-neutral-border'),
             hover: 'hsl(215, 20%, 18%)'
           },
           // Special states
           special: {
-            DEFAULT: 'var(--status-special)',
-            bg: 'var(--status-special-bg)',
-            border: 'var(--status-special-border)',
+            DEFAULT: withOpacity('--status-special'),
+            bg: withOpacity('--status-special-bg'),
+            border: withOpacity('--status-special-border'),
             hover: 'hsl(263, 70%, 18%)'
           }
         }


### PR DESCRIPTION
$## Summary
- add backend incident summary aggregation and a new dashboard API endpoint
- render ranked incident summary cards above failed tasks with quick navigation into the latest failure
- let summary cards focus the failed-task table and cover aggregation heuristics with unit tests

## Testing
- python3 -m pytest tests/unit/test_task_service_recent_failures.py tests/unit/test_task_service_incident_summaries.py
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incident Summaries dashboard: aggregated failure clusters with severity, counts, latest status/exception, affected workers (up to 3 + “+N”), first/last seen, “Focus failures” to filter failed-tasks, and external search control.
  * Incident summaries exposed via API and added client method for retrieval.

* **Tests**
  * Unit tests validating incident grouping, metrics, ordering, and urgency scoring.

* **Style**
  * Improved color handling with an opacity helper for theme colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->