### PR TITLE
Add failure grouping for failed task incidents

### DIFF
--- a/agent/alembic/versions/7c1e9d2b4a11_add_failure_groups.py
+++ b/agent/alembic/versions/7c1e9d2b4a11_add_failure_groups.py
@@ -1,0 +1,82 @@
+"""add failure grouping metadata
+
+Revision ID: 7c1e9d2b4a11
+Revises: d927bf6ca0c2, ff4d89c580cc
+Create Date: 2026-04-29 19:45:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '7c1e9d2b4a11'
+down_revision: Union[str, Sequence[str], None] = ('d927bf6ca0c2', 'ff4d89c580cc')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('task_events', sa.Column('failure_fingerprint', sa.String(length=64), nullable=True))
+    op.add_column('task_events', sa.Column('failure_group_id', sa.String(length=64), nullable=True))
+    op.add_column('task_events', sa.Column('environment', sa.String(length=255), nullable=True))
+    op.create_index('ix_task_events_failure_fingerprint', 'task_events', ['failure_fingerprint'])
+    op.create_index('ix_task_events_failure_group_id', 'task_events', ['failure_group_id'])
+    op.create_index('ix_task_events_environment', 'task_events', ['environment'])
+
+    op.add_column('task_latest', sa.Column('failure_fingerprint', sa.String(length=64), nullable=True))
+    op.add_column('task_latest', sa.Column('failure_group_id', sa.String(length=64), nullable=True))
+    op.add_column('task_latest', sa.Column('environment', sa.String(length=255), nullable=True))
+    op.create_index('ix_task_latest_failure_fingerprint', 'task_latest', ['failure_fingerprint'])
+    op.create_index('ix_task_latest_failure_group_id', 'task_latest', ['failure_group_id'])
+    op.create_index('ix_task_latest_environment', 'task_latest', ['environment'])
+    op.create_index('idx_task_latest_failure_group_ts', 'task_latest', ['failure_group_id', 'timestamp'])
+
+    op.create_table(
+        'failure_groups',
+        sa.Column('id', sa.String(length=64), primary_key=True),
+        sa.Column('fingerprint', sa.String(length=64), nullable=False),
+        sa.Column('task_name', sa.String(length=255), nullable=False),
+        sa.Column('exception_fingerprint', sa.Text(), nullable=True),
+        sa.Column('queue', sa.String(length=255), nullable=True),
+        sa.Column('hostname', sa.String(length=255), nullable=True),
+        sa.Column('environment', sa.String(length=255), nullable=True),
+        sa.Column('first_seen', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('last_seen', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('failure_count', sa.Integer(), nullable=False, server_default='1'),
+        sa.Column('last_task_id', sa.String(length=255), nullable=False),
+    )
+    op.create_index('ix_failure_groups_fingerprint', 'failure_groups', ['fingerprint'])
+    op.create_index('ix_failure_groups_task_name', 'failure_groups', ['task_name'])
+    op.create_index('ix_failure_groups_queue', 'failure_groups', ['queue'])
+    op.create_index('ix_failure_groups_hostname', 'failure_groups', ['hostname'])
+    op.create_index('ix_failure_groups_environment', 'failure_groups', ['environment'])
+    op.create_index('ix_failure_groups_last_task_id', 'failure_groups', ['last_task_id'])
+    op.create_index('idx_failure_groups_last_seen', 'failure_groups', ['last_seen'])
+    op.create_index('idx_failure_groups_task_name', 'failure_groups', ['task_name', 'last_seen'])
+
+
+def downgrade() -> None:
+    op.drop_index('idx_failure_groups_task_name', table_name='failure_groups')
+    op.drop_index('idx_failure_groups_last_seen', table_name='failure_groups')
+    op.drop_index('ix_failure_groups_last_task_id', table_name='failure_groups')
+    op.drop_index('ix_failure_groups_environment', table_name='failure_groups')
+    op.drop_index('ix_failure_groups_hostname', table_name='failure_groups')
+    op.drop_index('ix_failure_groups_queue', table_name='failure_groups')
+    op.drop_index('ix_failure_groups_task_name', table_name='failure_groups')
+    op.drop_index('ix_failure_groups_fingerprint', table_name='failure_groups')
+    op.drop_table('failure_groups')
+
+    op.drop_index('idx_task_latest_failure_group_ts', table_name='task_latest')
+    op.drop_index('ix_task_latest_environment', table_name='task_latest')
+    op.drop_index('ix_task_latest_failure_group_id', table_name='task_latest')
+    op.drop_index('ix_task_latest_failure_fingerprint', table_name='task_latest')
+    op.drop_column('task_latest', 'environment')
+    op.drop_column('task_latest', 'failure_group_id')
+    op.drop_column('task_latest', 'failure_fingerprint')
+
+    op.drop_index('ix_task_events_environment', table_name='task_events')
+    op.drop_index('ix_task_events_failure_group_id', table_name='task_events')
+    op.drop_index('ix_task_events_failure_fingerprint', table_name='task_events')
+    op.drop_column('task_events', 'environment')
+    op.drop_column('task_events', 'failure_group_id')
+    op.drop_column('task_events', 'failure_fingerprint')

--- a/agent/api/task_routes.py
+++ b/agent/api/task_routes.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from services import TaskService, EnvironmentService, SessionService, AppConfigService, ProgressService
 from database import TaskEventDB
-from models import TaskEvent, TaskProgressSnapshot
+from models import TaskEvent, TaskProgressSnapshot, FailureGroupSummary
 from database import ensure_utc_isoformat
 from config import Config
 from security.auth import AuthenticatedUser
@@ -149,6 +149,37 @@ def create_router(app_state) -> APIRouter:
         """Get tasks that have been marked as orphaned and NOT yet retried."""
         task_service = TaskService(session, active_env=active_env)
         return task_service.get_unretried_orphaned_tasks()
+
+    @router.get("/tasks/failed/groups/recent", response_model=List[FailureGroupSummary])
+    async def get_recent_failure_groups(
+        hours: Optional[int] = Query(default=None, ge=1, le=168, description="Lookback window in hours (defaults to configured value)"),
+        limit: int = 50,
+        include_retried: bool = False,
+        session: Session = Depends(get_db),
+        active_env = Depends(get_active_env)
+    ):
+        """Get grouped failed-task incidents within the last ``hours`` window."""
+        task_service = TaskService(session, active_env=active_env)
+        config_service = AppConfigService(session)
+        lookback_hours = hours if hours is not None else config_service.get_task_issue_lookback_hours()
+        return task_service.get_recent_failure_groups(
+            hours=lookback_hours,
+            limit=limit,
+            exclude_retried=not include_retried
+        )
+
+
+    @router.get("/tasks/failed/groups/{group_id}", response_model=List[TaskEvent])
+    async def get_failure_group_events(
+        group_id: str,
+        limit: int = 100,
+        session: Session = Depends(get_db),
+        active_env = Depends(get_active_env)
+    ):
+        """Get individual failed task executions for a failure group."""
+        task_service = TaskService(session, active_env=active_env)
+        return task_service.get_failure_group_events(group_id, limit=limit)
+
 
     @router.get("/tasks/failed/recent", response_model=List[TaskEvent])
     async def get_recent_failed_tasks(

--- a/agent/database.py
+++ b/agent/database.py
@@ -72,6 +72,9 @@ class TaskEventDB(Base):
     runtime = Column(Float)
     exception = Column(Text)
     traceback = Column(Text)
+    failure_fingerprint = Column(String(64), index=True)
+    failure_group_id = Column(String(64), index=True)
+    environment = Column(String(255), index=True)
     
     retry_of = Column(String(255), index=True)
     retried_by = Column(Text)  # JSON serialized list
@@ -118,6 +121,9 @@ class TaskEventDB(Base):
             'runtime': self.runtime,
             'exception': self.exception,
             'traceback': self.traceback,
+            'failure_fingerprint': self.failure_fingerprint,
+            'failure_group_id': self.failure_group_id,
+            'environment': self.environment,
             'retry_of': self.retry_of,
             'retried_by': json.loads(self.retried_by) if self.retried_by else [],
             'is_retry': self.is_retry,
@@ -242,6 +248,9 @@ class TaskLatestDB(Base):
     runtime = Column(Float)
     exception = Column(Text)
     traceback = Column(Text)
+    failure_fingerprint = Column(String(64), index=True)
+    failure_group_id = Column(String(64), index=True)
+    environment = Column(String(255), index=True)
 
     retry_of = Column(String(255), index=True)
     retried_by = Column(Text)  # JSON serialized list of task IDs
@@ -260,7 +269,45 @@ class TaskLatestDB(Base):
         Index('idx_task_latest_hostname_ts', 'hostname', 'timestamp'),
         Index('idx_task_latest_routing_ts', 'routing_key', 'timestamp'),
         Index('idx_task_latest_event_type_ts', 'event_type', 'timestamp'),
+        Index('idx_task_latest_failure_group_ts', 'failure_group_id', 'timestamp'),
     )
+
+
+class FailureGroupDB(Base):
+    """Durable incident-style grouping for failed tasks."""
+    __tablename__ = 'failure_groups'
+
+    id = Column(String(64), primary_key=True)
+    fingerprint = Column(String(64), nullable=False, index=True)
+    task_name = Column(String(255), nullable=False, index=True)
+    exception_fingerprint = Column(Text)
+    queue = Column(String(255), index=True)
+    hostname = Column(String(255), index=True)
+    environment = Column(String(255), index=True)
+    first_seen = Column(DateTime(timezone=True), nullable=False)
+    last_seen = Column(DateTime(timezone=True), nullable=False, index=True)
+    failure_count = Column(Integer, default=1, nullable=False)
+    last_task_id = Column(String(255), nullable=False, index=True)
+
+    __table_args__ = (
+        Index('idx_failure_groups_last_seen', 'last_seen'),
+        Index('idx_failure_groups_task_name', 'task_name', 'last_seen'),
+    )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'fingerprint': self.fingerprint,
+            'task_name': self.task_name,
+            'exception_fingerprint': self.exception_fingerprint,
+            'queue': self.queue,
+            'hostname': self.hostname,
+            'environment': self.environment,
+            'first_seen': ensure_utc_isoformat(self.first_seen),
+            'last_seen': ensure_utc_isoformat(self.last_seen),
+            'failure_count': self.failure_count,
+            'last_task_id': self.last_task_id,
+        }
 
 class TaskResolutionDB(Base):
     """Tracks manual resolution state per task."""

--- a/agent/models.py
+++ b/agent/models.py
@@ -29,6 +29,9 @@ class TaskEvent(BaseModel):
     runtime: Optional[float] = None
     exception: Optional[str] = None
     traceback: Optional[str] = None
+    failure_fingerprint: Optional[str] = None
+    failure_group_id: Optional[str] = None
+    environment: Optional[str] = None
     retry_of: Optional['TaskEvent'] = None
     retried_by: List['TaskEvent'] = Field(default_factory=list)
     is_retry: bool = False
@@ -131,6 +134,29 @@ class TaskEvent(BaseModel):
 
 
 TaskEvent.model_rebuild()
+
+class FailureGroupSummary(BaseModel):
+    id: str
+    fingerprint: str
+    task_name: str
+    exception_fingerprint: Optional[str] = None
+    queue: Optional[str] = None
+    hostname: Optional[str] = None
+    environment: Optional[str] = None
+    first_seen: datetime
+    last_seen: datetime
+    failure_count: int = 0
+    last_task_id: str
+    recurrence_rate_per_hour: float = 0.0
+    latest_failure: Optional[TaskEvent] = None
+
+    model_config = {
+        'from_attributes': True,
+        'json_encoders': {
+            datetime: lambda v: v.isoformat() if v else None
+        }
+    }
+
 
 
 class StepDefinition(BaseModel):

--- a/agent/services/task_service.py
+++ b/agent/services/task_service.py
@@ -2,6 +2,9 @@
 
 import json
 import logging
+import hashlib
+import fnmatch
+import re
 from datetime import datetime, timezone, timedelta
 from typing import List, Dict, Any, Optional, Tuple, Union
 
@@ -11,8 +14,8 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 
-from database import TaskEventDB, RetryRelationshipDB, TaskLatestDB, TaskResolutionDB
-from models import TaskEvent
+from database import TaskEventDB, RetryRelationshipDB, TaskLatestDB, TaskResolutionDB, FailureGroupDB, EnvironmentDB
+from models import TaskEvent, FailureGroupSummary
 from constants import TaskState, EventType, STATE_TO_EVENT_MAP, ACTIVE_EVENT_TYPES
 from services.utils import EnvironmentFilter, GenericFilter, parse_filter_string
 from utils.payload_sanitizer import find_placeholder_paths
@@ -32,6 +35,85 @@ class TaskService:
     def __init__(self, session: Session, active_env=None):
         self.session = session
         self.active_env = active_env
+
+    def _resolve_environment_name(self, queue: Optional[str], hostname: Optional[str]) -> Optional[str]:
+        environments = self.session.query(EnvironmentDB).all()
+        for env in environments:
+            queue_match = True
+            worker_match = True
+            if env.queue_patterns:
+                queue_match = bool(queue) and any(fnmatch.fnmatch(queue, pattern) for pattern in env.queue_patterns)
+            if env.worker_patterns:
+                worker_match = bool(hostname) and any(fnmatch.fnmatch(hostname, pattern) for pattern in env.worker_patterns)
+            if queue_match and worker_match and (env.queue_patterns or env.worker_patterns):
+                return env.name
+        return None
+
+    def _normalize_exception_text(self, exception: Optional[str], traceback: Optional[str]) -> str:
+        source = (traceback or exception or '').strip()
+        if not source:
+            return 'unknown'
+        line = source.splitlines()[-1] if 'Traceback' in source else source.splitlines()[0]
+        line = re.sub(r'[0-9a-f]{8}-[0-9a-f-]{27}', '<uuid>', line, flags=re.IGNORECASE)
+        line = re.sub(r'0x[0-9a-f]+', '<hex>', line, flags=re.IGNORECASE)
+        line = re.sub(r'\d+', '<num>', line)
+        line = re.sub(r"'[^']*'|\"[^\"]*\"", '<str>', line)
+        line = re.sub(r'\s+', ' ', line).strip()
+        return line[:500] or 'unknown'
+
+    def _build_failure_grouping(self, task_event: TaskEvent, queue: Optional[str]) -> Dict[str, Optional[str]]:
+        if task_event.event_type != EventType.TASK_FAILED.value:
+            return {'failure_fingerprint': None, 'failure_group_id': None, 'environment': self._resolve_environment_name(queue, task_event.hostname), 'exception_fingerprint': None}
+
+        environment = self._resolve_environment_name(queue, task_event.hostname)
+        exception_fingerprint = self._normalize_exception_text(task_event.exception, task_event.traceback)
+        parts = [
+            task_event.task_name or 'unknown',
+            exception_fingerprint,
+            queue or '',
+            task_event.hostname or '',
+            environment or '',
+        ]
+        digest = hashlib.sha256('||'.join(parts).encode('utf-8')).hexdigest()
+        return {
+            'failure_fingerprint': digest,
+            'failure_group_id': digest[:16],
+            'environment': environment,
+            'exception_fingerprint': exception_fingerprint,
+        }
+
+    def _upsert_failure_group(self, event_db: TaskEventDB, exception_fingerprint: Optional[str]) -> None:
+        if not event_db.failure_group_id:
+            return
+        group = self.session.query(FailureGroupDB).filter(FailureGroupDB.id == event_db.failure_group_id).one_or_none()
+        if not group:
+            self.session.add(FailureGroupDB(
+                id=event_db.failure_group_id,
+                fingerprint=event_db.failure_fingerprint,
+                task_name=event_db.task_name or 'unknown',
+                exception_fingerprint=exception_fingerprint,
+                queue=event_db.queue,
+                hostname=event_db.hostname,
+                environment=event_db.environment,
+                first_seen=_ensure_utc(event_db.timestamp),
+                last_seen=_ensure_utc(event_db.timestamp),
+                failure_count=1,
+                last_task_id=event_db.task_id,
+            ))
+            return
+
+        event_ts = _ensure_utc(event_db.timestamp)
+        if group.first_seen is None or event_ts < _ensure_utc(group.first_seen):
+            group.first_seen = event_ts
+        if group.last_seen is None or event_ts >= _ensure_utc(group.last_seen):
+            group.last_seen = event_ts
+            group.last_task_id = event_db.task_id
+        group.failure_count = (group.failure_count or 0) + 1
+        group.fingerprint = event_db.failure_fingerprint or group.fingerprint
+        group.exception_fingerprint = exception_fingerprint or group.exception_fingerprint
+        group.queue = event_db.queue or group.queue
+        group.hostname = event_db.hostname or group.hostname
+        group.environment = event_db.environment or group.environment
 
     def save_task_event(self, task_event: TaskEvent) -> TaskEventDB:
         """
@@ -58,6 +140,11 @@ class TaskService:
             task_event.args = args
             task_event.kwargs = kwargs
 
+            grouping = self._build_failure_grouping(task_event, queue)
+            task_event.failure_fingerprint = grouping['failure_fingerprint']
+            task_event.failure_group_id = grouping['failure_group_id']
+            task_event.environment = grouping['environment']
+
             task_event_db = self._create_task_event_db(
                 task_event, routing_key, queue, args, kwargs
             )
@@ -65,6 +152,7 @@ class TaskService:
             self.session.add(task_event_db)
             self.session.flush()  # Ensure task_event_db.id is available for snapshot upsert
             self._upsert_task_latest(task_event_db)
+            self._upsert_failure_group(task_event_db, grouping.get('exception_fingerprint'))
             self.session.commit()
             return task_event_db
 
@@ -358,6 +446,69 @@ class TaskService:
         self._bulk_enrich_with_retry_info(events)
         self._attach_resolution_info(events)
 
+        return events
+
+    def get_recent_failure_groups(
+        self,
+        hours: int = 24,
+        limit: int = 50,
+        exclude_retried: bool = True
+    ) -> List[FailureGroupSummary]:
+        since = datetime.now(timezone.utc) - timedelta(hours=hours)
+
+        query = (
+            self.session.query(FailureGroupDB, TaskLatestDB)
+            .join(TaskLatestDB, TaskLatestDB.task_id == FailureGroupDB.last_task_id)
+            .filter(FailureGroupDB.last_seen >= since)
+        )
+
+        if self.active_env is not None:
+            query = EnvironmentFilter.apply(query, self.active_env, model=TaskLatestDB)
+
+        if exclude_retried:
+            query = query.filter(
+                or_(TaskLatestDB.has_retries.is_(False), TaskLatestDB.has_retries.is_(None))
+            )
+
+        rows = query.order_by(FailureGroupDB.last_seen.desc()).limit(limit).all()
+        summaries = []
+        for group_db, latest_db in rows:
+            latest_failure = self._db_to_task_event(latest_db)
+            self._bulk_enrich_with_retry_info([latest_failure])
+            self._attach_resolution_info([latest_failure])
+            summaries.append(FailureGroupSummary(
+                id=group_db.id,
+                fingerprint=group_db.fingerprint,
+                task_name=group_db.task_name,
+                exception_fingerprint=group_db.exception_fingerprint,
+                queue=group_db.queue,
+                hostname=group_db.hostname,
+                environment=group_db.environment,
+                first_seen=group_db.first_seen,
+                last_seen=group_db.last_seen,
+                failure_count=group_db.failure_count,
+                last_task_id=group_db.last_task_id,
+                recurrence_rate_per_hour=round((group_db.failure_count or 0) / max(hours, 1), 2),
+                latest_failure=latest_failure,
+            ))
+        return summaries
+
+    def get_failure_group_events(self, group_id: str, limit: int = 100) -> List[TaskEvent]:
+        query = (
+            self.session.query(TaskEventDB)
+            .filter(
+                TaskEventDB.failure_group_id == group_id,
+                TaskEventDB.event_type == EventType.TASK_FAILED.value,
+            )
+            .order_by(TaskEventDB.timestamp.desc())
+        )
+
+        if self.active_env is not None:
+            query = EnvironmentFilter.apply(query, self.active_env, model=TaskEventDB)
+
+        events = [self._db_to_task_event(event_db) for event_db in query.limit(limit).all()]
+        self._bulk_enrich_with_retry_info(events)
+        self._attach_resolution_info(events)
         return events
 
     def create_retry_relationship(
@@ -676,6 +827,9 @@ class TaskService:
             runtime=task_event.runtime,
             exception=task_event.exception,
             traceback=task_event.traceback,
+            failure_fingerprint=task_event.failure_fingerprint,
+            failure_group_id=task_event.failure_group_id,
+            environment=task_event.environment,
             retry_of=task_event.retry_of.task_id if task_event.retry_of else None,
             retried_by=(
                 json.dumps([t.task_id for t in task_event.retried_by])
@@ -712,6 +866,9 @@ class TaskService:
             "runtime": event_db.runtime,
             "exception": event_db.exception,
             "traceback": event_db.traceback,
+            "failure_fingerprint": event_db.failure_fingerprint,
+            "failure_group_id": event_db.failure_group_id,
+            "environment": event_db.environment,
             "retry_of": event_db.retry_of,
             "retried_by": event_db.retried_by,
             "is_retry": event_db.is_retry,
@@ -908,7 +1065,10 @@ class TaskService:
             result=event_db.result,
             runtime=event_db.runtime,
             exception=event_db.exception,
-            traceback=event_db.traceback
+            traceback=event_db.traceback,
+            failure_fingerprint=getattr(event_db, 'failure_fingerprint', None),
+            failure_group_id=getattr(event_db, 'failure_group_id', None),
+            environment=getattr(event_db, 'environment', None),
         )
 
         task_event.is_orphan = event_db.is_orphan or False

--- a/agent/tests/unit/test_task_service_failure_groups.py
+++ b/agent/tests/unit/test_task_service_failure_groups.py
@@ -1,0 +1,57 @@
+import unittest
+from datetime import datetime, timezone, timedelta
+
+from models import TaskEvent
+from services.task_service import TaskService
+from tests.base import DatabaseTestCase
+
+
+class TestTaskServiceFailureGroups(DatabaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.service = TaskService(self.session)
+        self.now = datetime.now(timezone.utc)
+
+    def _save_failed_event(self, task_id: str, when: datetime, exception: str, queue: str = 'critical', hostname: str = 'worker-a'):
+        event = TaskEvent(
+            task_id=task_id,
+            task_name='tasks.example',
+            event_type='task-failed',
+            timestamp=when,
+            exception=exception,
+            traceback=f'Traceback\nValueError: {exception}',
+            queue=queue,
+            hostname=hostname,
+        )
+        return self.service.save_task_event(event)
+
+    def test_groups_related_failures_with_stable_fingerprint(self):
+        self._save_failed_event('task-1', self.now - timedelta(minutes=10), 'customer 123 missing')
+        self._save_failed_event('task-2', self.now - timedelta(minutes=5), 'customer 456 missing')
+
+        groups = self.service.get_recent_failure_groups(hours=24)
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].failure_count, 2)
+        self.assertEqual(groups[0].last_task_id, 'task-2')
+        self.assertEqual(groups[0].latest_failure.failure_group_id, groups[0].id)
+
+    def test_separates_distinct_workers_or_queues(self):
+        self._save_failed_event('task-1', self.now - timedelta(minutes=10), 'boom', queue='critical', hostname='worker-a')
+        self._save_failed_event('task-2', self.now - timedelta(minutes=5), 'boom', queue='bulk', hostname='worker-a')
+
+        groups = self.service.get_recent_failure_groups(hours=24)
+        self.assertEqual(len(groups), 2)
+
+    def test_group_drilldown_returns_all_failed_events(self):
+        self._save_failed_event('task-1', self.now - timedelta(minutes=10), 'customer 123 missing')
+        self._save_failed_event('task-2', self.now - timedelta(minutes=5), 'customer 456 missing')
+
+        group = self.service.get_recent_failure_groups(hours=24)[0]
+        events = self.service.get_failure_group_events(group.id)
+
+        self.assertEqual([event.task_id for event in events], ['task-2', 'task-1'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/frontend/app/components/FailureGroupSummary.vue
+++ b/frontend/app/components/FailureGroupSummary.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="border border-border-subtle rounded-md bg-background-surface glow-border">
+    <div class="flex items-center justify-between border-b border-border-subtle px-4 py-3">
+      <div>
+        <div class="text-sm font-medium text-text-primary">Failed task incidents</div>
+        <div class="text-xs text-text-secondary">Grouped by fingerprint · {{ groups.length }} active group{{ groups.length === 1 ? '' : 's' }}</div>
+      </div>
+      <div class="text-xs text-text-muted">{{ lookbackHours }}h window</div>
+    </div>
+
+    <div v-if="groups.length === 0" class="p-8 text-sm text-text-secondary text-center">No grouped failures in this window.</div>
+    <div v-else class="divide-y divide-border-subtle">
+      <div v-for="group in groups" :key="group.id" class="p-4">
+        <button class="flex w-full items-start justify-between gap-4 text-left" @click="toggle(group.id)">
+          <div>
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-sm text-text-primary">{{ group.task_name }}</span>
+              <span class="text-[11px] rounded border border-red-500/40 bg-red-500/10 px-2 py-0.5 text-red-300">{{ group.failure_count }} failures</span>
+              <span v-if="group.environment" class="text-[11px] text-text-muted">{{ group.environment }}</span>
+            </div>
+            <div class="mt-1 text-xs text-text-secondary">{{ group.exception_fingerprint || 'Unknown error' }}</div>
+            <div class="mt-2 flex flex-wrap gap-3 text-[11px] text-text-muted">
+              <span>First: {{ formatRelative(group.first_seen) }}</span>
+              <span>Last: {{ formatRelative(group.last_seen) }}</span>
+              <span>{{ group.recurrence_rate_per_hour }}/hr</span>
+              <span v-if="group.queue">Queue {{ group.queue }}</span>
+              <span v-if="group.hostname">Worker {{ group.hostname }}</span>
+            </div>
+          </div>
+          <span class="text-xs text-text-muted">{{ expanded[group.id] ? 'Hide' : 'Show' }}</span>
+        </button>
+
+        <div v-if="expanded[group.id]" class="mt-4 space-y-2">
+          <div v-if="loading[group.id]" class="text-xs text-text-muted">Loading failures…</div>
+          <div v-else-if="groupEvents[group.id]?.length">
+            <div v-for="event in groupEvents[group.id]" :key="event.task_id" class="rounded border border-border-subtle p-3">
+              <div class="flex items-center justify-between gap-3">
+                <div class="text-xs font-mono text-text-primary">{{ event.task_id }}</div>
+                <NuxtLink :to="`/tasks/${event.task_id}`" class="text-xs text-primary">Open</NuxtLink>
+              </div>
+              <div class="mt-1 text-xs text-text-secondary">{{ event.exception || event.traceback || 'Unknown error' }}</div>
+            </div>
+          </div>
+          <div v-else class="text-xs text-text-muted">No failure executions found.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive } from 'vue'
+import type { FailureGroupSummaryResponse, TaskEventResponse } from '~/services/apiClient'
+
+const props = defineProps<{
+  groups: FailureGroupSummaryResponse[]
+  lookbackHours: number
+  fetchGroupEvents: (groupId: string) => Promise<TaskEventResponse[]>
+}>()
+
+const expanded = reactive<Record<string, boolean>>({})
+const loading = reactive<Record<string, boolean>>({})
+const groupEvents = reactive<Record<string, TaskEventResponse[]>>({})
+
+function formatRelative(value?: string | null) {
+  if (!value) return '—'
+  return new Date(value).toLocaleString()
+}
+
+async function toggle(groupId: string) {
+  expanded[groupId] = !expanded[groupId]
+  if (!expanded[groupId] || groupEvents[groupId]) return
+  loading[groupId] = true
+  try {
+    groupEvents[groupId] = await props.fetchGroupEvents(groupId)
+  } finally {
+    loading[groupId] = false
+  }
+}
+</script>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -16,7 +16,20 @@
 
       <!-- Failure & Orphaned Tasks Overview -->
       <div class="mb-6 flex flex-col gap-4 failure-insights-section">
+        <div class="flex items-center justify-end gap-2">
+          <Button variant="outline" size="sm" :class="failedTasksStore.viewMode === 'grouped' ? 'bg-background-raised' : ''" @click="failedTasksStore.setViewMode('grouped')">Grouped</Button>
+          <Button variant="outline" size="sm" :class="failedTasksStore.viewMode === 'raw' ? 'bg-background-raised' : ''" @click="failedTasksStore.setViewMode('raw')">Raw</Button>
+        </div>
+
+        <FailureGroupSummary
+          v-if="failedTasksStore.viewMode === 'grouped'"
+          :groups="failedTasksStore.failureGroups"
+          :lookback-hours="failedTasksStore.lookbackHours"
+          :fetch-group-events="failedTasksStore.fetchFailureGroupEvents"
+        />
+
         <TaskIssueSummary
+          v-else
           :tasks="failedTasksStore.failedTasks"
           :is-loading="failedTasksStore.isLoading"
           :status="failedCardStatus"
@@ -209,6 +222,7 @@ import DataTable from "~/components/data-table.vue"
 import WorkerStatusSummary from "~/components/WorkerStatusSummary.vue"
 import CommandPalette from "~/components/CommandPalette.vue"
 import TaskIssueSummary from "~/components/TaskIssueSummary.vue"
+import FailureGroupSummary from '~/components/FailureGroupSummary.vue'
 import RetryTaskConfirmDialog from "~/components/RetryTaskConfirmDialog.vue"
 import { Button } from '~/components/ui/button'
 import { Badge } from '~/components/ui/badge'

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -87,6 +87,22 @@ export interface RetentionCleanupResponseDTO {
   results: RetentionCleanupResultDTO[]
 }
 
+export interface FailureGroupSummaryResponse {
+  id: string
+  fingerprint: string
+  task_name: string
+  exception_fingerprint?: string | null
+  queue?: string | null
+  hostname?: string | null
+  environment?: string | null
+  first_seen: string
+  last_seen: string
+  failure_count: number
+  last_task_id: string
+  recurrence_rate_per_hour: number
+  latest_failure?: TaskEventResponse | null
+}
+
 export interface AppConfigSnapshotDTO {
   task_issue_summary: TaskIssueConfigDTO
   data_retention: DataRetentionConfigDTO
@@ -372,6 +388,24 @@ class ApiService {
   async getRecentFailedTasks(params?: { hours?: number; limit?: number; include_retried?: boolean }): Promise<TaskEventResponse[]> {
     const response = await this.api.request({
       path: '/api/tasks/failed/recent',
+      method: 'GET',
+      query: params
+    })
+    return response.data
+  }
+
+  async getRecentFailureGroups(params?: { hours?: number; limit?: number; include_retried?: boolean }): Promise<FailureGroupSummaryResponse[]> {
+    const response = await this.api.request({
+      path: '/api/tasks/failed/groups/recent',
+      method: 'GET',
+      query: params
+    })
+    return response.data
+  }
+
+  async getFailureGroupEvents(groupId: string, params?: { limit?: number }): Promise<TaskEventResponse[]> {
+    const response = await this.api.request({
+      path: `/api/tasks/failed/groups/${encodeURIComponent(groupId)}`,
       method: 'GET',
       query: params
     })

--- a/frontend/app/stores/failedTasks.ts
+++ b/frontend/app/stores/failedTasks.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed, readonly } from 'vue'
 import { useApiService } from '../services/apiClient'
-import type { TaskEventResponse } from '../services/apiClient'
+import type { TaskEventResponse, FailureGroupSummaryResponse } from '../services/apiClient'
 
 const DEFAULT_LOOKBACK_HOURS = 24
 const MIN_LOOKBACK_HOURS = 1
@@ -19,6 +19,8 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
   const apiService = useApiService()
 
   const failedTasks = ref<TaskEventResponse[]>([])
+  const failureGroups = ref<FailureGroupSummaryResponse[]>([])
+  const viewMode = ref<'raw' | 'grouped'>('grouped')
   const isLoading = ref(false)
   const error = ref<string | null>(null)
   const lastFetchedAt = ref<Date | null>(null)
@@ -116,6 +118,11 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
       const filtered = response.filter(task => !shouldExclude(task))
       setTasks(filtered)
       pruneExpired()
+      failureGroups.value = await apiService.getRecentFailureGroups({
+        hours: effectiveHours,
+        limit: options?.limit,
+        include_retried: options?.includeRetried ?? false
+      })
       lastFetchedAt.value = new Date()
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to fetch failed tasks'
@@ -189,8 +196,18 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     }
   }
 
+  async function fetchFailureGroupEvents(groupId: string, limit = 100) {
+    return apiService.getFailureGroupEvents(groupId, { limit })
+  }
+
+  function setViewMode(mode: 'raw' | 'grouped') {
+    viewMode.value = mode
+  }
+
   return {
     failedTasks: readonly(failedTasks),
+    failureGroups: readonly(failureGroups),
+    viewMode: readonly(viewMode),
     isLoading: readonly(isLoading),
     error: readonly(error),
     lastFetchedAt: readonly(lastFetchedAt),
@@ -200,6 +217,8 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     latestFailedTask,
 
     fetchFailedTasks,
+    fetchFailureGroupEvents,
+    setViewMode,
     setLookbackHours,
     updateFromLiveEvent,
     pruneExpired,

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,18 @@
 /** @type {import('tailwindcss').Config} */
+const withOpacity = (cssVariable: string) => ({ opacityValue }: { opacityValue?: string }) => {
+  if (opacityValue === undefined) {
+    return `var(${cssVariable})`
+  }
+
+  const opacity = Number.parseFloat(opacityValue)
+
+  if (Number.isNaN(opacity)) {
+    return `var(${cssVariable})`
+  }
+
+  return `color-mix(in srgb, var(${cssVariable}) ${opacity * 100}%, transparent)`
+}
+
 export default {
   content: [
     "./app/**/*.{js,vue,ts}",
@@ -19,90 +33,90 @@ export default {
       colors: {
         // Backgrounds using CSS variables
         background: {
-          base: 'var(--bg-base)',
-          surface: 'var(--bg-surface)',
-          raised: 'var(--bg-raised)',
+          base: withOpacity('--bg-base'),
+          surface: withOpacity('--bg-surface'),
+          raised: withOpacity('--bg-raised'),
           overlay: 'hsl(0, 0%, 18%, 0.8)',
           // Interactive states
-          hover: 'var(--bg-hover)',
-          'hover-subtle': 'var(--bg-hover-subtle)',
-          active: 'var(--bg-active)',
-          selected: 'var(--bg-selected)'
+          hover: withOpacity('--bg-hover'),
+          'hover-subtle': withOpacity('--bg-hover-subtle'),
+          active: withOpacity('--bg-active'),
+          selected: withOpacity('--bg-selected')
         },
         // Text colors using CSS variables
         text: {
-          primary: 'var(--text-primary)',
-          secondary: 'var(--text-secondary)',
-          muted: 'var(--text-muted)',
-          disabled: 'var(--text-disabled)'
+          primary: withOpacity('--text-primary'),
+          secondary: withOpacity('--text-secondary'),
+          muted: withOpacity('--text-muted'),
+          disabled: withOpacity('--text-disabled')
         },
         // Card and borders
         card: {
-          base: 'var(--bg-surface)',
-          border: 'var(--border)',
+          base: withOpacity('--bg-surface'),
+          border: withOpacity('--border'),
         },
         // Border colors
         border: {
-          DEFAULT: 'var(--border)',
-          highlight: 'var(--highlight)',
-          subtle: 'var(--border-subtle)'
+          DEFAULT: withOpacity('--border'),
+          highlight: withOpacity('--highlight'),
+          subtle: withOpacity('--border-subtle')
         },
         // Primary/Brand colors
         primary: {
-          DEFAULT: 'var(--primary)',
-          hover: 'var(--primary-hover)',
-          bg: 'var(--primary-bg)',
-          border: 'var(--primary-border)'
+          DEFAULT: withOpacity('--primary'),
+          hover: withOpacity('--primary-hover'),
+          bg: withOpacity('--primary-bg'),
+          border: withOpacity('--primary-border')
         },
         // Semantic status colors using CSS variables
         status: {
           // Success states
           success: {
-            DEFAULT: 'var(--status-success)',
-            bg: 'var(--status-success-bg)',
-            border: 'var(--status-success-border)',
+            DEFAULT: withOpacity('--status-success'),
+            bg: withOpacity('--status-success-bg'),
+            border: withOpacity('--status-success-border'),
             hover: 'hsl(158,100%,13%)'
           },
           // Error states
           error: {
-            DEFAULT: 'var(--status-error)',
-            bg: 'var(--status-error-bg)',
-            border: 'var(--status-error-border)',
+            DEFAULT: withOpacity('--status-error'),
+            bg: withOpacity('--status-error-bg'),
+            border: withOpacity('--status-error-border'),
             hover: 'hsl(347, 77%, 18%)'
           },
           // Warning states
           warning: {
-            DEFAULT: 'var(--status-warning)',
-            bg: 'var(--status-warning-bg)',
-            border: 'var(--status-warning-border)',
+            DEFAULT: withOpacity('--status-warning'),
+            bg: withOpacity('--status-warning-bg'),
+            border: withOpacity('--status-warning-border'),
             hover: 'hsl(45, 85%, 18%)'
           },
           // Info states
           info: {
-            DEFAULT: 'var(--status-info)',
-            bg: 'var(--status-info-bg)',
-            border: 'var(--status-info-border)',
+            DEFAULT: withOpacity('--status-info'),
+            bg: withOpacity('--status-info-bg'),
+            border: withOpacity('--status-info-border'),
             hover: 'hsl(199, 89%, 18%)'
           },
           // Retry states
           retry: {
-            DEFAULT: 'var(--status-retry)',
-            bg: 'var(--status-retry-bg)',
-            border: 'var(--status-retry-border)',
+            DEFAULT: withOpacity('--status-retry'),
+            bg: withOpacity('--status-retry-bg'),
+            border: withOpacity('--status-retry-border'),
             hover: 'hsl(24, 95%, 18%)'
           },
           // Neutral states
           neutral: {
-            DEFAULT: 'var(--status-neutral)',
-            bg: 'var(--status-neutral-bg)',
-            border: 'var(--status-neutral-border)',
+            DEFAULT: withOpacity('--status-neutral'),
+            bg: withOpacity('--status-neutral-bg'),
+            border: withOpacity('--status-neutral-border'),
             hover: 'hsl(215, 20%, 18%)'
           },
           // Special states
           special: {
-            DEFAULT: 'var(--status-special)',
-            bg: 'var(--status-special-bg)',
-            border: 'var(--status-special-border)',
+            DEFAULT: withOpacity('--status-special'),
+            bg: withOpacity('--status-special-bg'),
+            border: withOpacity('--status-special-border'),
             hover: 'hsl(263, 70%, 18%)'
           }
         }


### PR DESCRIPTION
# Todo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added failure grouping to automatically organize related failed tasks by fingerprint
  * New "Grouped" and "Raw" view toggle for failed tasks
  * Expandable failure group details with drilldown into execution events
  * Failure group metrics including first/last seen timestamps and failure counts
  * Enhanced Tailwind theming with opacity-aware color support

* **Tests**
  * Added comprehensive test suite for failure grouping functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->