### PR TITLE
[codex] Add runbooks and response context to task views

### DIFF
--- a/agent/alembic/versions/5f7f1c6c0d21_add_response_context_to_task_registry.py
+++ b/agent/alembic/versions/5f7f1c6c0d21_add_response_context_to_task_registry.py
@@ -1,0 +1,30 @@
+"""add response context to task registry
+
+Revision ID: 5f7f1c6c0d21
+Revises: 930bf786783a
+Create Date: 2026-04-30 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "5f7f1c6c0d21"
+down_revision: Union[str, None] = "930bf786783a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("task_registry", sa.Column("runbook_url", sa.String(length=2048), nullable=True))
+    op.add_column("task_registry", sa.Column("severity_default", sa.String(length=32), nullable=True))
+    op.add_column("task_registry", sa.Column("response_notes", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("task_registry", "response_notes")
+    op.drop_column("task_registry", "severity_default")
+    op.drop_column("task_registry", "runbook_url")

--- a/agent/api/metrics_routes.py
+++ b/agent/api/metrics_routes.py
@@ -8,7 +8,19 @@ def create_router(app_state) -> APIRouter:  # noqa: ARG001 - signature kept for 
     """Expose Prometheus metrics."""
     router = APIRouter()
 
-    @router.get("/metrics")
+    @router.get(
+        "/metrics",
+        response_class=Response,
+        responses={
+            200: {
+                "content": {
+                    CONTENT_TYPE_LATEST: {
+                        "schema": {"type": "string"},
+                    }
+                }
+            }
+        },
+    )
     async def metrics():
         return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 

--- a/agent/api/task_routes.py
+++ b/agent/api/task_routes.py
@@ -10,8 +10,7 @@ from pydantic import BaseModel
 
 from services import TaskService, EnvironmentService, SessionService, AppConfigService, ProgressService
 from database import TaskEventDB
-from models import TaskEvent, TaskProgressSnapshot
-from database import ensure_utc_isoformat
+from models import TaskEvent, TaskProgressSnapshot, TaskResolutionResponse
 from config import Config
 from security.auth import AuthenticatedUser
 from security.dependencies import get_auth_dependency
@@ -175,7 +174,7 @@ def create_router(app_state) -> APIRouter:
         return failed_tasks
 
 
-    @router.post("/tasks/{task_id}/resolve")
+    @router.post("/tasks/{task_id}/resolve", response_model=TaskResolutionResponse)
     async def resolve_task(
         task_id: str,
         payload: Optional[ResolveTaskRequest] = None,
@@ -193,15 +192,15 @@ def create_router(app_state) -> APIRouter:
             resolved_by = resolved_by or current_user.email or current_user.name
 
         resolution = task_service.set_task_resolution(task_id, resolved_by)
-        return {
-            "task_id": task_id,
-            "resolved": True,
-            "resolved_by": resolution.resolved_by,
-            "resolved_at": ensure_utc_isoformat(resolution.resolved_at) if resolution.resolved_at else None,
-        }
+        return TaskResolutionResponse(
+            task_id=task_id,
+            resolved=True,
+            resolved_by=resolution.resolved_by,
+            resolved_at=resolution.resolved_at,
+        )
 
 
-    @router.delete("/tasks/{task_id}/resolve")
+    @router.delete("/tasks/{task_id}/resolve", response_model=TaskResolutionResponse)
     async def clear_task_resolution(
         task_id: str,
         session: Session = Depends(get_db),
@@ -213,12 +212,12 @@ def create_router(app_state) -> APIRouter:
             raise HTTPException(status_code=404, detail="Task not found")
 
         task_service.clear_task_resolution(task_id)
-        return {
-            "task_id": task_id,
-            "resolved": False,
-            "resolved_by": None,
-            "resolved_at": None,
-        }
+        return TaskResolutionResponse(
+            task_id=task_id,
+            resolved=False,
+            resolved_by=None,
+            resolved_at=None,
+        )
 
 
     @router.post("/tasks/{task_id}/retry")

--- a/agent/database.py
+++ b/agent/database.py
@@ -329,6 +329,9 @@ class TaskRegistryDB(Base):
     name = Column(String(255), unique=True, nullable=False, index=True)
     human_readable_name = Column(String(255))
     description = Column(Text)
+    runbook_url = Column(String(2048))
+    severity_default = Column(String(32))
+    response_notes = Column(Text)
     tags = Column(JSON)  # Array of strings
     created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
     updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
@@ -347,6 +350,9 @@ class TaskRegistryDB(Base):
             'name': self.name,
             'human_readable_name': self.human_readable_name,
             'description': self.description,
+            'runbook_url': self.runbook_url,
+            'severity_default': self.severity_default,
+            'response_notes': self.response_notes,
             'tags': self.tags or [],
             'created_at': ensure_utc_isoformat(self.created_at),
             'updated_at': ensure_utc_isoformat(self.updated_at),

--- a/agent/models.py
+++ b/agent/models.py
@@ -39,6 +39,9 @@ class TaskEvent(BaseModel):
     resolved: bool = False
     resolved_by: Optional[str] = None
     resolved_at: Optional[datetime] = None
+    runbook_url: Optional[str] = None
+    severity_default: Optional[Literal["info", "warning", "error", "critical"]] = None
+    response_notes: Optional[str] = None
 
     model_config = {
         'from_attributes': True,
@@ -297,6 +300,9 @@ class TaskRegistryResponse(BaseModel):
     name: str
     human_readable_name: Optional[str] = None
     description: Optional[str] = None
+    runbook_url: Optional[str] = None
+    severity_default: Optional[Literal["info", "warning", "error", "critical"]] = None
+    response_notes: Optional[str] = None
     tags: List[str] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
@@ -314,7 +320,20 @@ class TaskRegistryUpdate(BaseModel):
     """Task registry update request model"""
     human_readable_name: Optional[str] = None
     description: Optional[str] = None
+    runbook_url: Optional[str] = None
+    severity_default: Optional[Literal["info", "warning", "error", "critical"]] = None
+    response_notes: Optional[str] = None
     tags: Optional[List[str]] = None
+
+    @field_validator("human_readable_name", "description", "runbook_url", "response_notes", mode="before")
+    @classmethod
+    def normalize_optional_string(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
 
 
 class TaskRegistryStats(BaseModel):

--- a/agent/models.py
+++ b/agent/models.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Optional, List, Union, Literal
 from datetime import datetime, timezone, date
 from enum import Enum
+from urllib.parse import urlparse
 import ast
 from pydantic import BaseModel, Field, field_validator
 
@@ -333,6 +334,16 @@ class TaskRegistryUpdate(BaseModel):
         if isinstance(value, str):
             stripped = value.strip()
             return stripped or None
+        return value
+
+    @field_validator("runbook_url")
+    @classmethod
+    def validate_runbook_url(cls, value):
+        if value is None:
+            return None
+        parsed = urlparse(value)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("runbook_url must be an absolute http or https URL")
         return value
 
 

--- a/agent/models.py
+++ b/agent/models.py
@@ -347,6 +347,14 @@ class TaskRegistryUpdate(BaseModel):
         return value
 
 
+class TaskResolutionResponse(BaseModel):
+    """Response model for manual task resolution toggles."""
+    task_id: str
+    resolved: bool
+    resolved_by: Optional[str] = None
+    resolved_at: Optional[datetime] = None
+
+
 class TaskRegistryStats(BaseModel):
     """Statistics for a specific task"""
     task_name: str

--- a/agent/services/task_registry_service.py
+++ b/agent/services/task_registry_service.py
@@ -147,7 +147,7 @@ class TaskRegistryService:
         update_data: TaskRegistryUpdate
     ) -> Optional[TaskRegistryResponse]:
         """
-        Update task metadata (human_readable_name, description, tags).
+        Update task metadata (human_readable_name, description, runbook, severity, notes, tags).
 
         Args:
             task_name: Name of task to update
@@ -169,13 +169,22 @@ class TaskRegistryService:
             if not task:
                 return None
 
-            if update_data.human_readable_name is not None:
+            if "human_readable_name" in update_data.model_fields_set:
                 task.human_readable_name = update_data.human_readable_name
 
-            if update_data.description is not None:
+            if "description" in update_data.model_fields_set:
                 task.description = update_data.description
 
-            if update_data.tags is not None:
+            if "runbook_url" in update_data.model_fields_set:
+                task.runbook_url = update_data.runbook_url
+
+            if "severity_default" in update_data.model_fields_set:
+                task.severity_default = update_data.severity_default
+
+            if "response_notes" in update_data.model_fields_set:
+                task.response_notes = update_data.response_notes
+
+            if "tags" in update_data.model_fields_set:
                 task.tags = update_data.tags
 
             task.updated_at = datetime.now(timezone.utc)

--- a/agent/services/task_service.py
+++ b/agent/services/task_service.py
@@ -11,7 +11,7 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 
-from database import TaskEventDB, RetryRelationshipDB, TaskLatestDB, TaskResolutionDB
+from database import TaskEventDB, RetryRelationshipDB, TaskLatestDB, TaskRegistryDB, TaskResolutionDB
 from models import TaskEvent
 from constants import TaskState, EventType, STATE_TO_EVENT_MAP, ACTIVE_EVENT_TYPES
 from services.utils import EnvironmentFilter, GenericFilter, parse_filter_string
@@ -102,6 +102,7 @@ class TaskService:
                 events[i].retry_count = events[0].retry_count
 
         self._attach_resolution_info(events)
+        self._attach_registry_metadata(events)
         return events
 
     def get_recent_events(
@@ -205,6 +206,7 @@ class TaskService:
         events = [self._db_to_task_event(event_db) for event_db in active_events_db]
         self._bulk_enrich_with_retry_info(events)
         self._attach_resolution_info(events)
+        self._attach_registry_metadata(events)
 
         return events
 
@@ -259,6 +261,7 @@ class TaskService:
         orphaned_events = [self._db_to_task_event(e) for e in orphaned_events_db]
         self._bulk_enrich_with_retry_info(orphaned_events)
         self._attach_resolution_info(orphaned_events)
+        self._attach_registry_metadata(orphaned_events)
 
         if not orphaned_events:
             return []
@@ -357,6 +360,7 @@ class TaskService:
         events = [self._db_to_task_event(event_db) for event_db in events_db]
         self._bulk_enrich_with_retry_info(events)
         self._attach_resolution_info(events)
+        self._attach_registry_metadata(events)
 
         return events
 
@@ -1014,6 +1018,7 @@ class TaskService:
             task_event.retried_by = []
             related_tasks_map[event_db.task_id] = task_event
 
+        self._attach_registry_metadata(list(related_tasks_map.values()))
         return related_tasks_map
 
     def _attach_resolution_info(self, events: List[TaskEvent]) -> None:
@@ -1039,6 +1044,32 @@ class TaskService:
             event.resolved = bool(resolution.resolved) if resolution else False
             event.resolved_by = resolution.resolved_by if resolution else None
             event.resolved_at = _ensure_utc(resolution.resolved_at) if resolution else None
+
+    def _attach_registry_metadata(self, events: List[TaskEvent]) -> None:
+        """
+        Attach response guidance metadata from the task registry in bulk.
+        """
+        if not events:
+            return
+
+        task_names = {event.task_name for event in events if event.task_name}
+        if not task_names:
+            return
+
+        metadata_rows = (
+            self.session.query(TaskRegistryDB)
+            .filter(TaskRegistryDB.name.in_(task_names))
+            .all()
+        )
+        metadata_by_name = {row.name: row for row in metadata_rows}
+
+        for event in events:
+            metadata = metadata_by_name.get(event.task_name)
+            if not metadata:
+                continue
+            event.runbook_url = metadata.runbook_url
+            event.severity_default = metadata.severity_default
+            event.response_notes = metadata.response_notes
 
     def _populate_retry_info(
         self,
@@ -1156,6 +1187,7 @@ class TaskService:
         events = [self._db_to_task_event(event_db) for event_db in events_db]
         self._bulk_enrich_with_retry_info(events)
         self._attach_resolution_info(events)
+        self._attach_registry_metadata(events)
 
         return events, total_events
 
@@ -1222,6 +1254,7 @@ class TaskService:
         events = [self._db_to_task_event(event_db) for event_db in events_db]
         self._bulk_enrich_with_retry_info(events)
         self._attach_resolution_info(events)
+        self._attach_registry_metadata(events)
         return events, total_events
 
 

--- a/agent/tests/unit/test_task_registry_response_context.py
+++ b/agent/tests/unit/test_task_registry_response_context.py
@@ -1,0 +1,121 @@
+import unittest
+from datetime import datetime, timezone, timedelta
+
+from database import TaskRegistryDB
+from models import TaskRegistryUpdate
+from services.task_registry_service import TaskRegistryService
+from services.task_service import TaskService
+from tests.base import DatabaseTestCase
+
+
+class TestTaskRegistryResponseContext(DatabaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+        TaskRegistryService._cache = set()
+        TaskRegistryService._cache_initialized = False
+        self.registry_service = TaskRegistryService(self.session)
+        self.task_service = TaskService(self.session)
+        self.now = datetime.now(timezone.utc)
+
+    def test_update_task_persists_response_context_metadata(self):
+        self.registry_service.ensure_task_registered("tasks.alerting.sync")
+
+        updated = self.registry_service.update_task(
+            "tasks.alerting.sync",
+            TaskRegistryUpdate(
+                runbook_url=" https://docs.example.com/runbooks/alerting-sync ",
+                severity_default="critical",
+                response_notes=" Check upstream dependencies before retrying. ",
+            ),
+        )
+
+        self.assertIsNotNone(updated)
+        self.assertEqual(updated.runbook_url, "https://docs.example.com/runbooks/alerting-sync")
+        self.assertEqual(updated.severity_default, "critical")
+        self.assertEqual(updated.response_notes, "Check upstream dependencies before retrying.")
+
+        cleared = self.registry_service.update_task(
+            "tasks.alerting.sync",
+            TaskRegistryUpdate(
+                runbook_url="",
+                response_notes="",
+            ),
+        )
+
+        self.assertIsNotNone(cleared)
+        self.assertIsNone(cleared.runbook_url)
+        self.assertIsNone(cleared.response_notes)
+
+    def test_get_task_events_attach_response_context(self):
+        registry = TaskRegistryDB(
+            id="registry-1",
+            name="tasks.alerting.sync",
+            runbook_url="https://docs.example.com/runbooks/alerting-sync",
+            severity_default="critical",
+            response_notes="Check the upstream queue before retrying.",
+            tags=[],
+            created_at=self.now,
+            updated_at=self.now,
+            first_seen=self.now,
+            last_seen=self.now,
+        )
+        self.session.add(registry)
+        self.session.commit()
+
+        self.create_task_event_db(
+            task_id="task-1",
+            task_name="tasks.alerting.sync",
+            event_type="task-received",
+            timestamp=self.now - timedelta(minutes=2),
+        )
+        self.create_task_event_db(
+            task_id="task-1",
+            task_name="tasks.alerting.sync",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=1),
+            exception="boom",
+        )
+
+        events = self.task_service.get_task_events("task-1")
+
+        self.assertEqual(len(events), 2)
+        for event in events:
+            self.assertEqual(event.runbook_url, "https://docs.example.com/runbooks/alerting-sync")
+            self.assertEqual(event.severity_default, "critical")
+            self.assertEqual(event.response_notes, "Check the upstream queue before retrying.")
+
+    def test_recent_failed_tasks_attach_response_context(self):
+        registry = TaskRegistryDB(
+            id="registry-2",
+            name="tasks.example",
+            runbook_url="https://docs.example.com/runbooks/example",
+            severity_default="warning",
+            response_notes="Validate the dependency health before requeueing.",
+            tags=[],
+            created_at=self.now,
+            updated_at=self.now,
+            first_seen=self.now,
+            last_seen=self.now,
+        )
+        self.session.add(registry)
+        self.session.commit()
+
+        self.create_task_event_db(
+            task_id="failed-recent",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=5),
+            exception="dependency timeout",
+        )
+
+        results = self.task_service.get_recent_failed_tasks(hours=24, limit=10)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].runbook_url, "https://docs.example.com/runbooks/example")
+        self.assertEqual(results[0].severity_default, "warning")
+        self.assertEqual(results[0].response_notes, "Validate the dependency health before requeueing.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent/tests/unit/test_task_registry_response_context.py
+++ b/agent/tests/unit/test_task_registry_response_context.py
@@ -1,6 +1,8 @@
 import unittest
 from datetime import datetime, timezone, timedelta
 
+from pydantic import ValidationError
+
 from database import TaskRegistryDB
 from models import TaskRegistryUpdate
 from services.task_registry_service import TaskRegistryService
@@ -84,6 +86,15 @@ class TestTaskRegistryResponseContext(DatabaseTestCase):
             self.assertEqual(event.runbook_url, "https://docs.example.com/runbooks/alerting-sync")
             self.assertEqual(event.severity_default, "critical")
             self.assertEqual(event.response_notes, "Check the upstream queue before retrying.")
+
+    def test_update_task_rejects_non_http_runbook_urls(self):
+        self.registry_service.ensure_task_registered("tasks.alerting.sync")
+
+        with self.assertRaises(ValidationError):
+            TaskRegistryUpdate(runbook_url="javascript:alert('xss')")
+
+        with self.assertRaises(ValidationError):
+            TaskRegistryUpdate(runbook_url="/relative/runbook")
 
     def test_recent_failed_tasks_attach_response_context(self):
         registry = TaskRegistryDB(

--- a/frontend/app/components/TaskIssueSummary.vue
+++ b/frontend/app/components/TaskIssueSummary.vue
@@ -215,7 +215,13 @@
                         </span>
                       </div>
                     </template>
-
+                    <TaskResponseContext
+                      :runbook-url="task.runbook_url"
+                      :severity-default="task.severity_default"
+                      :response-notes="task.response_notes"
+                      compact
+                    />
+                    <slot name="details" :task="task" />
                   </TaskDetailsSection>
                 </TableCell>
               </TableRow>
@@ -333,6 +339,7 @@ import SearchInput from '~/components/SearchInput.vue'
 import PythonValueViewer from '~/components/PythonValueViewer.vue'
 import { IconButton, Select } from '~/components/common'
 import TaskDetailsSection from '~/components/common/TaskDetailsSection.vue'
+import TaskResponseContext from '~/components/tasks/TaskResponseContext.vue'
 import { ChevronDown, ChevronRight, Loader2, AlertTriangle, ChevronsLeft, ChevronLeft, ChevronsRight, CheckCircle2 } from 'lucide-vue-next'
 import type { TaskEventResponse } from '~/services/apiClient'
 import { useTaskStatus } from '~/composables/useTaskStatus'

--- a/frontend/app/components/tasks/TaskDetailSheet.vue
+++ b/frontend/app/components/tasks/TaskDetailSheet.vue
@@ -36,6 +36,40 @@
               {{ task.description }}
             </p>
 
+            <div v-if="isEditing" class="mb-2">
+              <label class="text-[10px] font-mono text-text-muted uppercase tracking-wider mb-1 block">Runbook URL</label>
+              <input
+                v-model="editForm.runbook_url"
+                type="url"
+                class="w-full px-2 py-1 text-xs font-mono bg-background-base border border-border-subtle rounded text-text-primary focus:outline-none focus:border-primary"
+                placeholder="https://docs.example.com/runbook"
+              />
+            </div>
+
+            <div v-if="isEditing" class="mb-2">
+              <label class="text-[10px] font-mono text-text-muted uppercase tracking-wider mb-1 block">Default Severity</label>
+              <select
+                v-model="editForm.severity_default"
+                class="w-full px-2 py-1 text-xs font-mono bg-background-base border border-border-subtle rounded text-text-primary focus:outline-none focus:border-primary"
+              >
+                <option :value="null">None</option>
+                <option value="info">Info</option>
+                <option value="warning">Warning</option>
+                <option value="error">Error</option>
+                <option value="critical">Critical</option>
+              </select>
+            </div>
+
+            <div v-if="isEditing" class="mb-2">
+              <label class="text-[10px] font-mono text-text-muted uppercase tracking-wider mb-1 block">Response Notes</label>
+              <textarea
+                v-model="editForm.response_notes"
+                rows="3"
+                class="w-full px-2 py-1 text-xs bg-background-base border border-border-subtle rounded text-text-secondary leading-relaxed focus:outline-none focus:border-primary resize-none"
+                placeholder="Concise response steps for operators"
+              />
+            </div>
+
             <!-- Edit mode: tags -->
             <div v-if="isEditing" class="mb-2">
               <label class="text-[10px] font-mono text-text-muted uppercase tracking-wider mb-1 block">Tags</label>
@@ -264,6 +298,13 @@
               </div>
             </div>
           </div>
+
+          <TaskResponseContext
+            :runbook-url="task.runbook_url"
+            :severity-default="task.severity_default"
+            :response-notes="task.response_notes"
+            compact
+          />
         </div>
       </div>
     </SheetContent>
@@ -285,6 +326,7 @@ import { Pencil, AlertTriangle, X } from 'lucide-vue-next'
 import { Sheet, SheetContent } from '~/components/ui/sheet'
 import { Button } from '~/components/ui/button'
 import TaskFrequencyTimeline from './TaskFrequencyTimeline.vue'
+import TaskResponseContext from './TaskResponseContext.vue'
 import Tag from '~/components/common/Tag.vue'
 import { Badge } from '~/components/ui/badge'
 import IconButton from '~/components/common/IconButton.vue'
@@ -324,6 +366,9 @@ const newTag = ref('')
 const editForm = ref<TaskRegistryUpdate>({
   human_readable_name: null,
   description: null,
+  runbook_url: null,
+  severity_default: null,
+  response_notes: null,
   tags: null
 })
 
@@ -375,6 +420,9 @@ function startEdit() {
   editForm.value = {
     human_readable_name: props.task.human_readable_name || '',
     description: props.task.description || '',
+    runbook_url: props.task.runbook_url || '',
+    severity_default: props.task.severity_default || null,
+    response_notes: props.task.response_notes || '',
     tags: [...(props.task.tags || [])]
   }
 }

--- a/frontend/app/components/tasks/TaskResponseContext.vue
+++ b/frontend/app/components/tasks/TaskResponseContext.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { BookOpen, ExternalLink, MessageSquareText, Siren } from 'lucide-vue-next'
+import { Badge } from '~/components/ui/badge'
+
+const props = defineProps<{
+  runbookUrl?: string | null
+  severityDefault?: 'info' | 'warning' | 'error' | 'critical' | null
+  responseNotes?: string | null
+  compact?: boolean
+}>()
+
+const hasResponseContext = computed(() =>
+  Boolean(props.runbookUrl || props.severityDefault || props.responseNotes)
+)
+
+const severityLabel = computed(() => {
+  if (!props.severityDefault) return null
+  return props.severityDefault.charAt(0).toUpperCase() + props.severityDefault.slice(1)
+})
+
+const severityVariant = computed(() => {
+  switch (props.severityDefault) {
+    case 'critical':
+      return 'destructive'
+    case 'error':
+      return 'failed'
+    case 'warning':
+      return 'pending'
+    case 'info':
+      return 'running'
+    default:
+      return 'outline'
+  }
+})
+</script>
+
+<template>
+  <div
+    v-if="hasResponseContext"
+    class="rounded-lg border border-border-subtle bg-background-surface"
+    :class="compact ? 'p-3' : 'p-5'"
+  >
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <div>
+        <p class="text-[10px] font-mono uppercase tracking-[0.18em] text-text-muted">
+          Response Context
+        </p>
+        <h3 class="mt-1 text-sm font-medium text-text-primary">
+          Recommended response guidance
+        </h3>
+      </div>
+
+      <Badge v-if="severityLabel" :variant="severityVariant" class="text-[11px]">
+        {{ severityLabel }}
+      </Badge>
+    </div>
+
+    <div class="mt-4 space-y-3 text-sm">
+      <a
+        v-if="runbookUrl"
+        :href="runbookUrl"
+        target="_blank"
+        rel="noreferrer"
+        class="flex items-start gap-2 rounded-md border border-border-subtle bg-background-base px-3 py-2 text-text-primary transition-colors hover:border-primary/40 hover:text-primary"
+      >
+        <BookOpen class="mt-0.5 h-4 w-4 shrink-0" />
+        <span class="min-w-0 flex-1 break-all">{{ runbookUrl }}</span>
+        <ExternalLink class="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      </a>
+
+      <div
+        v-if="responseNotes"
+        class="rounded-md border border-border-subtle bg-background-base px-3 py-2 text-text-secondary"
+      >
+        <div class="mb-1 flex items-center gap-2 text-text-primary">
+          <MessageSquareText class="h-4 w-4" />
+          <span class="text-xs font-medium uppercase tracking-wide text-text-muted">Notes</span>
+        </div>
+        <p class="whitespace-pre-wrap leading-6">
+          {{ responseNotes }}
+        </p>
+      </div>
+
+      <div
+        v-if="severityLabel && !compact"
+        class="flex items-center gap-2 text-xs text-text-secondary"
+      >
+        <Siren class="h-3.5 w-3.5" />
+        Default severity is marked as <span class="font-medium text-text-primary">{{ severityLabel }}</span>.
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/app/pages/tasks/[id].vue
+++ b/frontend/app/pages/tasks/[id].vue
@@ -166,6 +166,12 @@
                 </div>
               </div>
 
+              <TaskResponseContext
+                :runbook-url="task.runbook_url"
+                :severity-default="task.severity_default"
+                :response-notes="task.response_notes"
+              />
+
               <!-- Exception/Traceback -->
               <div v-if="task.exception || task.traceback" class="border border-status-error-border rounded-md p-5 bg-status-error-bg/20">
                 <h2 class="text-sm font-medium text-status-error mb-4">Error Details</h2>
@@ -400,6 +406,7 @@ import UuidDisplay from '~/components/UuidDisplay.vue'
 import PayloadTruncationNotice from '~/components/PayloadTruncationNotice.vue'
 import RetryTaskConfirmDialog from '~/components/RetryTaskConfirmDialog.vue'
 import TaskProgressSteps from '~/components/tasks/TaskProgressSteps.vue'
+import TaskResponseContext from '~/components/tasks/TaskResponseContext.vue'
 import type { TaskEventResponse } from '~/services/apiClient'
 import { useCopy } from '~/composables/useCopy'
 

--- a/frontend/app/src/types/api.ts
+++ b/frontend/app/src/types/api.ts
@@ -756,6 +756,21 @@ export interface TaskRegistryUpdate {
 }
 
 /**
+ * TaskResolutionResponse
+ * Response model for manual task resolution toggles.
+ */
+export interface TaskResolutionResponse {
+  /** Task Id */
+  task_id: string;
+  /** Resolved */
+  resolved: boolean;
+  /** Resolved By */
+  resolved_by?: string | null;
+  /** Resolved At */
+  resolved_at?: string | null;
+}
+
+/**
  * TaskTimelineResponse
  * Timeline response showing execution frequency over time
  */
@@ -1442,7 +1457,7 @@ export class Api<
       data: ResolveTaskRequest | null,
       params: RequestParams = {},
     ) =>
-      this.request<any, HTTPValidationError>({
+      this.request<TaskResolutionResponse, HTTPValidationError>({
         path: `/api/tasks/${taskId}/resolve`,
         method: "POST",
         body: data,
@@ -1463,7 +1478,7 @@ export class Api<
       taskId: string,
       params: RequestParams = {},
     ) =>
-      this.request<any, HTTPValidationError>({
+      this.request<TaskResolutionResponse, HTTPValidationError>({
         path: `/api/tasks/${taskId}/resolve`,
         method: "DELETE",
         format: "json",

--- a/frontend/app/src/types/api.ts
+++ b/frontend/app/src/types/api.ts
@@ -418,6 +418,73 @@ export interface ResolveTaskRequest {
 }
 
 /**
+ * RetentionCleanupResponse
+ * Summary of a retention cleanup run.
+ */
+export interface RetentionCleanupResponse {
+  /**
+   * Dry Run
+   * @default false
+   */
+  dry_run?: boolean;
+  /**
+   * Total Deleted
+   * @min 0
+   */
+  total_deleted: number;
+  /** Results */
+  results?: RetentionCleanupResult[];
+}
+
+/**
+ * RetentionCleanupResult
+ * Result for a single retention target cleanup.
+ */
+export interface RetentionCleanupResult {
+  /** Key */
+  key: string;
+  /** Label */
+  label: string;
+  /**
+   * Retention Days
+   * @min 1
+   */
+  retention_days: number;
+  /**
+   * Deleted
+   * @min 0
+   */
+  deleted: number;
+}
+
+/**
+ * RuntimeAnomaly
+ * Detected anomaly for an active task runtime/progress profile.
+ */
+export interface RuntimeAnomaly {
+  /** Represents a Celery task event */
+  task: TaskEvent;
+  /** Anomaly Type */
+  anomaly_type: "long_running" | "stalled_progress";
+  /** Runtime Seconds */
+  runtime_seconds: number;
+  /** Baseline Runtime Seconds */
+  baseline_runtime_seconds?: number | null;
+  /** Progress Age Seconds */
+  progress_age_seconds?: number | null;
+  /**
+   * Worker Active Task Count
+   * @default 1
+   */
+  worker_active_task_count?: number;
+  /** Threshold Seconds */
+  threshold_seconds: number;
+  /** Detail */
+  detail: string;
+}
+
+/**
+>>>>>>> ed76241 (Add typed task resolution responses)
  * StepDefinition
  * Single step definition for task progress.
  */

--- a/frontend/app/src/types/api.ts
+++ b/frontend/app/src/types/api.ts
@@ -2617,10 +2617,9 @@ export class Api<
      * @request GET:/metrics
      */
     metricsMetricsGet: (params: RequestParams = {}) =>
-      this.request<any, any>({
+      this.request<string, any>({
         path: `/metrics`,
         method: "GET",
-        format: "json",
         ...params,
       }),
   };

--- a/frontend/app/src/types/api.ts
+++ b/frontend/app/src/types/api.ts
@@ -39,7 +39,7 @@ export interface ActionConfig {
   /** Config Id */
   config_id?: string | null;
   /** Params */
-  params?: object;
+  params?: Record<string, any>;
   /**
    * Continue On Failure
    * @default true
@@ -59,7 +59,7 @@ export interface ActionConfigCreateRequest {
   /** Action Type */
   action_type: string;
   /** Config */
-  config: object;
+  config: Record<string, any>;
 }
 
 /**
@@ -76,7 +76,7 @@ export interface ActionConfigDefinition {
   /** Action Type */
   action_type: string;
   /** Config */
-  config: object;
+  config: Record<string, any>;
   /** Created At */
   created_at?: string | null;
   /** Updated At */
@@ -102,7 +102,65 @@ export interface ActionConfigUpdateRequest {
   /** Description */
   description?: string | null;
   /** Config */
-  config?: object | null;
+  config?: Record<string, any> | null;
+}
+
+/**
+ * AppConfigSnapshot
+ * Grouped configuration snapshot returned to clients.
+ */
+export interface AppConfigSnapshot {
+  /** Configuration for the task issue summary section. */
+  task_issue_summary: TaskIssueConfig;
+}
+
+/**
+ * AppSetting
+ * Database-backed application setting.
+ */
+export interface AppSetting {
+  /** Key */
+  key: string;
+  /** Value */
+  value: any;
+  /**
+   * Value Type
+   * @default "string"
+   */
+  value_type?: "string" | "number" | "boolean" | "json";
+  /** Label */
+  label?: string | null;
+  /** Description */
+  description?: string | null;
+  /** Category */
+  category?: string | null;
+  /**
+   * Created At
+   * @format date-time
+   */
+  created_at: string;
+  /**
+   * Updated At
+   * @format date-time
+   */
+  updated_at: string;
+}
+
+/**
+ * AppSettingUpdate
+ * Create/update payload for an application setting.
+ */
+export interface AppSettingUpdate {
+  /** Value */
+  value: any;
+  /** Value Type */
+  value_type?: "string" | "number" | "boolean" | "json" | null;
+  /** Label */
+  label?: string | null;
+  /** Description */
+  description?: string | null;
+  /** Category */
+  category?: string | null;
 }
 
 /**
@@ -319,7 +377,7 @@ export interface LogEntry {
   /** Timestamp */
   timestamp?: string | null;
   /** Context */
-  context?: object | null;
+  context?: Record<string, any> | null;
 }
 
 /**
@@ -351,6 +409,29 @@ export interface LogoutRequest {
 export interface RefreshRequest {
   /** Refresh Token */
   refresh_token: string;
+}
+
+/** ResolveTaskRequest */
+export interface ResolveTaskRequest {
+  /** Resolved By */
+  resolved_by?: string | null;
+}
+
+/**
+ * StepDefinition
+ * Single step definition for task progress.
+ */
+export interface StepDefinition {
+  /** Key */
+  key: string;
+  /** Label */
+  label: string;
+  /** Description */
+  description?: string | null;
+  /** Total */
+  total?: number | null;
+  /** Order */
+  order?: number | null;
 }
 
 /**
@@ -437,7 +518,7 @@ export interface TaskEvent {
   /** Args */
   args?: any[];
   /** Kwargs */
-  kwargs?: object;
+  kwargs?: Record<string, any>;
   /**
    * Retries
    * @default 0
@@ -500,6 +581,78 @@ export interface TaskEvent {
   is_orphan?: boolean;
   /** Orphaned At */
   orphaned_at?: string | null;
+  /**
+   * Resolved
+   * @default false
+   */
+  resolved?: boolean;
+  /** Resolved By */
+  resolved_by?: string | null;
+  /** Resolved At */
+  resolved_at?: string | null;
+  /** Runbook Url */
+  runbook_url?: string | null;
+  /** Severity Default */
+  severity_default?: "info" | "warning" | "error" | "critical" | null;
+  /** Response Notes */
+  response_notes?: string | null;
+}
+
+/**
+ * TaskIssueConfig
+ * Configuration for the task issue summary section.
+ */
+export interface TaskIssueConfig {
+  /**
+   * Lookback Hours
+   * @min 1
+   * @max 168
+   * @default 24
+   */
+  lookback_hours?: number;
+}
+
+/**
+ * TaskProgressEvent
+ * Task progress update event.
+ */
+export interface TaskProgressEvent {
+  /** Task Id */
+  task_id: string;
+  /** Task Name */
+  task_name: string;
+  /** Progress */
+  progress: number;
+  /**
+   * Timestamp
+   * @format date-time
+   */
+  timestamp: string;
+  /** Step Key */
+  step_key?: string | null;
+  /** Message */
+  message?: string | null;
+  /** Meta */
+  meta?: Record<string, any> | null;
+  /**
+   * Event Type
+   * @default "kanchi-task-progress"
+   */
+  event_type?: "kanchi-task-progress";
+}
+
+/**
+ * TaskProgressSnapshot
+ * Aggregate view of progress and steps for a task.
+ */
+export interface TaskProgressSnapshot {
+  /** Task Id */
+  task_id: string;
+  latest?: TaskProgressEvent | null;
+  /** Steps */
+  steps?: StepDefinition[];
+  /** History */
+  history?: TaskProgressEvent[];
 }
 
 /**
@@ -515,6 +668,12 @@ export interface TaskRegistryResponse {
   human_readable_name?: string | null;
   /** Description */
   description?: string | null;
+  /** Runbook Url */
+  runbook_url?: string | null;
+  /** Severity Default */
+  severity_default?: "info" | "warning" | "error" | "critical" | null;
+  /** Response Notes */
+  response_notes?: string | null;
   /** Tags */
   tags?: string[];
   /**
@@ -586,6 +745,12 @@ export interface TaskRegistryUpdate {
   human_readable_name?: string | null;
   /** Description */
   description?: string | null;
+  /** Runbook Url */
+  runbook_url?: string | null;
+  /** Severity Default */
+  severity_default?: "info" | "warning" | "error" | "critical" | null;
+  /** Response Notes */
+  response_notes?: string | null;
   /** Tags */
   tags?: string[] | null;
 }
@@ -653,7 +818,7 @@ export interface TriggerConfig {
   /** Type */
   type: string;
   /** Config */
-  config?: object;
+  config?: Record<string, any>;
 }
 
 /**
@@ -683,7 +848,7 @@ export interface UserSessionResponse {
   /** Active Environment Id */
   active_environment_id?: string | null;
   /** Preferences */
-  preferences?: object;
+  preferences?: Record<string, any>;
   /**
    * Created At
    * @format date-time
@@ -704,7 +869,7 @@ export interface UserSessionUpdate {
   /** Active Environment Id */
   active_environment_id?: string | null;
   /** Preferences */
-  preferences?: object | null;
+  preferences?: Record<string, any> | null;
 }
 
 /** ValidationError */
@@ -863,7 +1028,7 @@ export interface WorkflowExecutionRecord {
   /** Trigger Type */
   trigger_type: string;
   /** Trigger Event */
-  trigger_event: object;
+  trigger_event: Record<string, any>;
   /** Status */
   status:
     | "pending"
@@ -873,7 +1038,7 @@ export interface WorkflowExecutionRecord {
     | "rate_limited"
     | "circuit_open";
   /** Actions Executed */
-  actions_executed?: object[] | null;
+  actions_executed?: Record<string, any>[] | null;
   /** Error Message */
   error_message?: string | null;
   /** Stack Trace */
@@ -885,7 +1050,7 @@ export interface WorkflowExecutionRecord {
   /** Duration Ms */
   duration_ms?: number | null;
   /** Workflow Snapshot */
-  workflow_snapshot?: object | null;
+  workflow_snapshot?: Record<string, any> | null;
   /** Circuit Breaker Key */
   circuit_breaker_key?: string | null;
 }
@@ -1150,7 +1315,7 @@ export class Api<
       },
       params: RequestParams = {},
     ) =>
-      this.request<object, HTTPValidationError>({
+      this.request<Record<string, any>, HTTPValidationError>({
         path: `/api/events/recent`,
         method: "GET",
         query: query,
@@ -1172,6 +1337,25 @@ export class Api<
     ) =>
       this.request<TaskEvent[], HTTPValidationError>({
         path: `/api/events/${taskId}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Get latest progress, steps, and recent history for a task.
+     *
+     * @tags tasks
+     * @name GetTaskProgressApiTasksTaskIdProgressGet
+     * @summary Get Task Progress
+     * @request GET:/api/tasks/{task_id}/progress
+     */
+    getTaskProgressApiTasksTaskIdProgressGet: (
+      taskId: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<TaskProgressSnapshot, HTTPValidationError>({
+        path: `/api/tasks/${taskId}/progress`,
         method: "GET",
         format: "json",
         ...params,
@@ -1221,9 +1405,9 @@ export class Api<
       query?: {
         /**
          * Hours
-         * @default 24
+         * Lookback window in hours (defaults to configured value)
          */
-        hours?: number;
+        hours?: number | null;
         /**
          * Limit
          * @default 50
@@ -1241,6 +1425,47 @@ export class Api<
         path: `/api/tasks/failed/recent`,
         method: "GET",
         query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Manually mark a task as resolved without altering its state.
+     *
+     * @tags tasks
+     * @name ResolveTaskApiTasksTaskIdResolvePost
+     * @summary Resolve Task
+     * @request POST:/api/tasks/{task_id}/resolve
+     */
+    resolveTaskApiTasksTaskIdResolvePost: (
+      taskId: string,
+      data: ResolveTaskRequest | null,
+      params: RequestParams = {},
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/api/tasks/${taskId}/resolve`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Remove manual resolution mark from a task.
+     *
+     * @tags tasks
+     * @name ClearTaskResolutionApiTasksTaskIdResolveDelete
+     * @summary Clear Task Resolution
+     * @request DELETE:/api/tasks/{task_id}/resolve
+     */
+    clearTaskResolutionApiTasksTaskIdResolveDelete: (
+      taskId: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/api/tasks/${taskId}/resolve`,
+        method: "DELETE",
         format: "json",
         ...params,
       }),
@@ -1565,7 +1790,7 @@ export class Api<
       },
       params: RequestParams = {},
     ) =>
-      this.request<object, HTTPValidationError>({
+      this.request<Record<string, any>, HTTPValidationError>({
         path: `/api/registry/tasks/${taskName}/trend`,
         method: "GET",
         query: query,
@@ -1987,7 +2212,7 @@ export class Api<
      */
     testWorkflowApiWorkflowsWorkflowIdTestPost: (
       workflowId: string,
-      data: object,
+      data: Record<string, any>,
       params: RequestParams = {},
     ) =>
       this.request<any, HTTPValidationError>({
@@ -2263,6 +2488,97 @@ export class Api<
       }),
 
     /**
+     * @description Get grouped application configuration with defaults applied.
+     *
+     * @tags config
+     * @name GetConfigSnapshotApiConfigGet
+     * @summary Get Config Snapshot
+     * @request GET:/api/config
+     */
+    getConfigSnapshotApiConfigGet: (params: RequestParams = {}) =>
+      this.request<AppConfigSnapshot, any>({
+        path: `/api/config`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description List all application settings.
+     *
+     * @tags config
+     * @name ListSettingsApiConfigSettingsGet
+     * @summary List Settings
+     * @request GET:/api/config/settings
+     */
+    listSettingsApiConfigSettingsGet: (params: RequestParams = {}) =>
+      this.request<AppSetting[], any>({
+        path: `/api/config/settings`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Get a single application setting.
+     *
+     * @tags config
+     * @name GetSettingApiConfigSettingsKeyGet
+     * @summary Get Setting
+     * @request GET:/api/config/settings/{key}
+     */
+    getSettingApiConfigSettingsKeyGet: (
+      key: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<AppSetting, HTTPValidationError>({
+        path: `/api/config/settings/${key}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Create or update an application setting.
+     *
+     * @tags config
+     * @name UpsertSettingApiConfigSettingsKeyPut
+     * @summary Upsert Setting
+     * @request PUT:/api/config/settings/{key}
+     */
+    upsertSettingApiConfigSettingsKeyPut: (
+      key: string,
+      data: AppSettingUpdate,
+      params: RequestParams = {},
+    ) =>
+      this.request<AppSetting, HTTPValidationError>({
+        path: `/api/config/settings/${key}`,
+        method: "PUT",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Delete a setting (falls back to default).
+     *
+     * @tags config
+     * @name DeleteSettingApiConfigSettingsKeyDelete
+     * @summary Delete Setting
+     * @request DELETE:/api/config/settings/{key}
+     */
+    deleteSettingApiConfigSettingsKeyDelete: (
+      key: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, HTTPValidationError>({
+        path: `/api/config/settings/${key}`,
+        method: "DELETE",
+        ...params,
+      }),
+
+    /**
      * @description Public health endpoint without sensitive data.
      *
      * @name HealthCheckApiHealthGet
@@ -2287,6 +2603,22 @@ export class Api<
     healthDetailsApiHealthDetailsGet: (params: RequestParams = {}) =>
       this.request<any, any>({
         path: `/api/health/details`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+  };
+  metrics = {
+    /**
+     * No description
+     *
+     * @name MetricsMetricsGet
+     * @summary Metrics
+     * @request GET:/metrics
+     */
+    metricsMetricsGet: (params: RequestParams = {}) =>
+      this.request<any, any>({
+        path: `/metrics`,
         method: "GET",
         format: "json",
         ...params,

--- a/frontend/app/types/taskRegistry.ts
+++ b/frontend/app/types/taskRegistry.ts
@@ -9,6 +9,9 @@ export interface TaskRegistryResponse {
   name: string
   human_readable_name?: string | null
   description?: string | null
+  runbook_url?: string | null
+  severity_default?: 'info' | 'warning' | 'error' | 'critical' | null
+  response_notes?: string | null
   tags: string[]
   created_at: string
   updated_at: string
@@ -19,6 +22,9 @@ export interface TaskRegistryResponse {
 export interface TaskRegistryUpdate {
   human_readable_name?: string | null
   description?: string | null
+  runbook_url?: string | null
+  severity_default?: 'info' | 'warning' | 'error' | 'critical' | null
+  response_notes?: string | null
   tags?: string[] | null
 }
 

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,18 @@
 /** @type {import('tailwindcss').Config} */
+const withOpacity = (cssVariable: string) => ({ opacityValue }: { opacityValue?: string }) => {
+  if (opacityValue === undefined) {
+    return `var(${cssVariable})`
+  }
+
+  const opacity = Number.parseFloat(opacityValue)
+
+  if (Number.isNaN(opacity)) {
+    return `var(${cssVariable})`
+  }
+
+  return `color-mix(in srgb, var(${cssVariable}) ${opacity * 100}%, transparent)`
+}
+
 export default {
   content: [
     "./app/**/*.{js,vue,ts}",
@@ -19,90 +33,90 @@ export default {
       colors: {
         // Backgrounds using CSS variables
         background: {
-          base: 'var(--bg-base)',
-          surface: 'var(--bg-surface)',
-          raised: 'var(--bg-raised)',
+          base: withOpacity('--bg-base'),
+          surface: withOpacity('--bg-surface'),
+          raised: withOpacity('--bg-raised'),
           overlay: 'hsl(0, 0%, 18%, 0.8)',
           // Interactive states
-          hover: 'var(--bg-hover)',
-          'hover-subtle': 'var(--bg-hover-subtle)',
-          active: 'var(--bg-active)',
-          selected: 'var(--bg-selected)'
+          hover: withOpacity('--bg-hover'),
+          'hover-subtle': withOpacity('--bg-hover-subtle'),
+          active: withOpacity('--bg-active'),
+          selected: withOpacity('--bg-selected')
         },
         // Text colors using CSS variables
         text: {
-          primary: 'var(--text-primary)',
-          secondary: 'var(--text-secondary)',
-          muted: 'var(--text-muted)',
-          disabled: 'var(--text-disabled)'
+          primary: withOpacity('--text-primary'),
+          secondary: withOpacity('--text-secondary'),
+          muted: withOpacity('--text-muted'),
+          disabled: withOpacity('--text-disabled')
         },
         // Card and borders
         card: {
-          base: 'var(--bg-surface)',
-          border: 'var(--border)',
+          base: withOpacity('--bg-surface'),
+          border: withOpacity('--border'),
         },
         // Border colors
         border: {
-          DEFAULT: 'var(--border)',
-          highlight: 'var(--highlight)',
-          subtle: 'var(--border-subtle)'
+          DEFAULT: withOpacity('--border'),
+          highlight: withOpacity('--highlight'),
+          subtle: withOpacity('--border-subtle')
         },
         // Primary/Brand colors
         primary: {
-          DEFAULT: 'var(--primary)',
-          hover: 'var(--primary-hover)',
-          bg: 'var(--primary-bg)',
-          border: 'var(--primary-border)'
+          DEFAULT: withOpacity('--primary'),
+          hover: withOpacity('--primary-hover'),
+          bg: withOpacity('--primary-bg'),
+          border: withOpacity('--primary-border')
         },
         // Semantic status colors using CSS variables
         status: {
           // Success states
           success: {
-            DEFAULT: 'var(--status-success)',
-            bg: 'var(--status-success-bg)',
-            border: 'var(--status-success-border)',
+            DEFAULT: withOpacity('--status-success'),
+            bg: withOpacity('--status-success-bg'),
+            border: withOpacity('--status-success-border'),
             hover: 'hsl(158,100%,13%)'
           },
           // Error states
           error: {
-            DEFAULT: 'var(--status-error)',
-            bg: 'var(--status-error-bg)',
-            border: 'var(--status-error-border)',
+            DEFAULT: withOpacity('--status-error'),
+            bg: withOpacity('--status-error-bg'),
+            border: withOpacity('--status-error-border'),
             hover: 'hsl(347, 77%, 18%)'
           },
           // Warning states
           warning: {
-            DEFAULT: 'var(--status-warning)',
-            bg: 'var(--status-warning-bg)',
-            border: 'var(--status-warning-border)',
+            DEFAULT: withOpacity('--status-warning'),
+            bg: withOpacity('--status-warning-bg'),
+            border: withOpacity('--status-warning-border'),
             hover: 'hsl(45, 85%, 18%)'
           },
           // Info states
           info: {
-            DEFAULT: 'var(--status-info)',
-            bg: 'var(--status-info-bg)',
-            border: 'var(--status-info-border)',
+            DEFAULT: withOpacity('--status-info'),
+            bg: withOpacity('--status-info-bg'),
+            border: withOpacity('--status-info-border'),
             hover: 'hsl(199, 89%, 18%)'
           },
           // Retry states
           retry: {
-            DEFAULT: 'var(--status-retry)',
-            bg: 'var(--status-retry-bg)',
-            border: 'var(--status-retry-border)',
+            DEFAULT: withOpacity('--status-retry'),
+            bg: withOpacity('--status-retry-bg'),
+            border: withOpacity('--status-retry-border'),
             hover: 'hsl(24, 95%, 18%)'
           },
           // Neutral states
           neutral: {
-            DEFAULT: 'var(--status-neutral)',
-            bg: 'var(--status-neutral-bg)',
-            border: 'var(--status-neutral-border)',
+            DEFAULT: withOpacity('--status-neutral'),
+            bg: withOpacity('--status-neutral-bg'),
+            border: withOpacity('--status-neutral-border'),
             hover: 'hsl(215, 20%, 18%)'
           },
           // Special states
           special: {
-            DEFAULT: 'var(--status-special)',
-            bg: 'var(--status-special-bg)',
-            border: 'var(--status-special-border)',
+            DEFAULT: withOpacity('--status-special'),
+            bg: withOpacity('--status-special-bg'),
+            border: withOpacity('--status-special-border'),
             hover: 'hsl(263, 70%, 18%)'
           }
         }


### PR DESCRIPTION
## Summary
- add runbook URL, severity default, and response notes to task registry metadata with an Alembic migration
- attach response context to task event APIs so failed-task and task-detail views can render guidance without extra per-row requests
- add registry editing and task/incident UI presentation for the new response context fields

## Testing
- `python3 -m unittest tests.unit.test_task_registry_response_context tests.unit.test_task_service_recent_failures`
- `npm run build`

Closes #100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attach runbook URLs, default severity, and response notes to task registry entries; task UIs show this context.
  * Task detail editor lets you edit runbook URL, default severity, and response notes.
  * New "Response Context" UI component appears in task views; events are enriched with registry metadata.
  * New API endpoints for task progress and manual resolve/clear; metrics endpoint exposed.

* **Tests**
  * Added unit tests covering registry metadata persistence, validation, and event enrichment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->