### PR TITLE
Add operator audit log for manual and workflow actions

### DIFF
--- a/agent/alembic/versions/97a4e6d2c1ab_add_audit_log_table.py
+++ b/agent/alembic/versions/97a4e6d2c1ab_add_audit_log_table.py
@@ -1,0 +1,96 @@
+"""Add audit log table for operator and workflow actions.
+
+Revision ID: 97a4e6d2c1ab
+Revises: 930bf786783a
+Create Date: 2026-04-30 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "97a4e6d2c1ab"
+down_revision: Union[str, None] = "930bf786783a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audit_logs",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("timestamp", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("source", sa.String(length=32), nullable=False),
+        sa.Column("action_type", sa.String(length=100), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("actor_type", sa.String(length=32), nullable=False),
+        sa.Column("actor_id", sa.String(length=255), nullable=True),
+        sa.Column("actor_name", sa.String(length=255), nullable=False),
+        sa.Column("target_type", sa.String(length=50), nullable=False),
+        sa.Column("target_id", sa.String(length=255), nullable=False),
+        sa.Column("target_label", sa.String(length=255), nullable=True),
+        sa.Column("task_id", sa.String(length=255), nullable=True),
+        sa.Column("related_task_id", sa.String(length=255), nullable=True),
+        sa.Column("workflow_id", sa.String(length=36), nullable=True),
+        sa.Column("execution_id", sa.Integer(), nullable=True),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("result_summary", sa.Text(), nullable=True),
+        sa.Column("details", sa.JSON(), nullable=True),
+    )
+
+    op.create_index(op.f("ix_audit_logs_timestamp"), "audit_logs", ["timestamp"], unique=False)
+    op.create_index(op.f("ix_audit_logs_source"), "audit_logs", ["source"], unique=False)
+    op.create_index(op.f("ix_audit_logs_action_type"), "audit_logs", ["action_type"], unique=False)
+    op.create_index(op.f("ix_audit_logs_status"), "audit_logs", ["status"], unique=False)
+    op.create_index(op.f("ix_audit_logs_actor_id"), "audit_logs", ["actor_id"], unique=False)
+    op.create_index(op.f("ix_audit_logs_actor_name"), "audit_logs", ["actor_name"], unique=False)
+    op.create_index(op.f("ix_audit_logs_target_type"), "audit_logs", ["target_type"], unique=False)
+    op.create_index(op.f("ix_audit_logs_target_id"), "audit_logs", ["target_id"], unique=False)
+    op.create_index(op.f("ix_audit_logs_target_label"), "audit_logs", ["target_label"], unique=False)
+    op.create_index(op.f("ix_audit_logs_task_id"), "audit_logs", ["task_id"], unique=False)
+    op.create_index(op.f("ix_audit_logs_related_task_id"), "audit_logs", ["related_task_id"], unique=False)
+    op.create_index(op.f("ix_audit_logs_workflow_id"), "audit_logs", ["workflow_id"], unique=False)
+    op.create_index(op.f("ix_audit_logs_execution_id"), "audit_logs", ["execution_id"], unique=False)
+    op.create_index("idx_audit_timestamp_id", "audit_logs", ["timestamp", "id"], unique=False)
+    op.create_index(
+        "idx_audit_target_lookup",
+        "audit_logs",
+        ["target_type", "target_id", "timestamp"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_audit_task_lookup",
+        "audit_logs",
+        ["task_id", "related_task_id", "timestamp"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_audit_workflow_lookup",
+        "audit_logs",
+        ["workflow_id", "timestamp"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_audit_workflow_lookup", table_name="audit_logs")
+    op.drop_index("idx_audit_task_lookup", table_name="audit_logs")
+    op.drop_index("idx_audit_target_lookup", table_name="audit_logs")
+    op.drop_index("idx_audit_timestamp_id", table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_execution_id"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_workflow_id"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_related_task_id"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_task_id"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_target_label"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_target_id"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_target_type"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_actor_name"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_actor_id"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_status"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_action_type"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_source"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_timestamp"), table_name="audit_logs")
+    op.drop_table("audit_logs")

--- a/agent/api/audit_routes.py
+++ b/agent/api/audit_routes.py
@@ -1,0 +1,85 @@
+"""API routes for audit log queries."""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from config import Config
+from models import AuditLogListResponse
+from security.dependencies import get_auth_dependency
+from services.audit_service import AuditLogService
+
+
+def create_router(app_state) -> APIRouter:
+    """Create audit router with dependency injection."""
+    router = APIRouter(prefix="/api", tags=["audit"])
+
+    config = app_state.config or Config.from_env()
+    require_user_dep = get_auth_dependency(app_state, require=True)
+
+    if config.auth_enabled:
+        router.dependencies.append(Depends(require_user_dep))
+
+    def get_db() -> Session:
+        if not app_state.db_manager:
+            raise HTTPException(status_code=500, detail="Database not initialized")
+        with app_state.db_manager.get_session() as session:
+            yield session
+
+    @router.get("/audit-logs", response_model=AuditLogListResponse)
+    async def list_audit_logs(
+        limit: int = Query(default=100, ge=1, le=200),
+        offset: int = Query(default=0, ge=0),
+        search: Optional[str] = None,
+        source: Optional[str] = None,
+        status: Optional[str] = None,
+        action_type: Optional[str] = None,
+        target_type: Optional[str] = None,
+        target_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+        actor: Optional[str] = None,
+        session: Session = Depends(get_db),
+    ):
+        """Search and filter audit log entries."""
+        service = AuditLogService(session)
+        return service.list_entries(
+            limit=limit,
+            offset=offset,
+            search=search,
+            source=source,
+            status=status,
+            action_type=action_type,
+            target_type=target_type,
+            target_id=target_id,
+            workflow_id=workflow_id,
+            task_id=task_id,
+            actor=actor,
+        )
+
+    @router.get("/tasks/{task_id}/audit", response_model=AuditLogListResponse)
+    async def get_task_audit_logs(
+        task_id: str,
+        limit: int = Query(default=50, ge=1, le=200),
+        offset: int = Query(default=0, ge=0),
+        session: Session = Depends(get_db),
+    ):
+        """Get audit entries related to a task."""
+        return AuditLogService(session).get_task_entries(task_id, limit=limit, offset=offset)
+
+    @router.get("/workflows/{workflow_id}/audit", response_model=AuditLogListResponse)
+    async def get_workflow_audit_logs(
+        workflow_id: str,
+        limit: int = Query(default=50, ge=1, le=200),
+        offset: int = Query(default=0, ge=0),
+        session: Session = Depends(get_db),
+    ):
+        """Get audit entries related to a workflow."""
+        return AuditLogService(session).get_workflow_entries(
+            workflow_id,
+            limit=limit,
+            offset=offset,
+        )
+
+    return router

--- a/agent/api/task_routes.py
+++ b/agent/api/task_routes.py
@@ -8,13 +8,21 @@ from fastapi import APIRouter, Depends, HTTPException, Header, Query
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
-from services import TaskService, EnvironmentService, SessionService, AppConfigService, ProgressService
+from services import (
+    TaskService,
+    EnvironmentService,
+    SessionService,
+    AppConfigService,
+    ProgressService,
+    AuditLogService,
+)
 from database import TaskEventDB
 from models import TaskEvent, TaskProgressSnapshot
 from database import ensure_utc_isoformat
 from config import Config
 from security.auth import AuthenticatedUser
 from security.dependencies import get_auth_dependency
+from services.audit_service import get_actor_for_user
 
 logger = logging.getLogger(__name__)
 
@@ -193,6 +201,22 @@ def create_router(app_state) -> APIRouter:
             resolved_by = resolved_by or current_user.email or current_user.name
 
         resolution = task_service.set_task_resolution(task_id, resolved_by)
+        AuditLogService(session).record_safe_entry(
+            source="manual",
+            action_type="task.resolved",
+            status="success",
+            target_type="task",
+            target_id=task_id,
+            target_label=task_events[-1].task_name,
+            task_id=task_id,
+            reason=payload.resolved_by if payload and payload.resolved_by else None,
+            result_summary="Task marked as resolved",
+            details={
+                "resolved_by": resolution.resolved_by,
+                "resolved_at": ensure_utc_isoformat(resolution.resolved_at) if resolution.resolved_at else None,
+            },
+            **get_actor_for_user(current_user, fallback_name=resolved_by),
+        )
         return {
             "task_id": task_id,
             "resolved": True,
@@ -205,6 +229,7 @@ def create_router(app_state) -> APIRouter:
     async def clear_task_resolution(
         task_id: str,
         session: Session = Depends(get_db),
+        current_user: Optional[AuthenticatedUser] = Depends(optional_user_dep),
     ):
         """Remove manual resolution mark from a task."""
         task_service = TaskService(session)
@@ -213,6 +238,18 @@ def create_router(app_state) -> APIRouter:
             raise HTTPException(status_code=404, detail="Task not found")
 
         task_service.clear_task_resolution(task_id)
+        AuditLogService(session).record_safe_entry(
+            source="manual",
+            action_type="task.unresolved",
+            status="success",
+            target_type="task",
+            target_id=task_id,
+            target_label=task_events[-1].task_name,
+            task_id=task_id,
+            result_summary="Task resolution cleared",
+            details={},
+            **get_actor_for_user(current_user),
+        )
         return {
             "task_id": task_id,
             "resolved": False,
@@ -222,7 +259,11 @@ def create_router(app_state) -> APIRouter:
 
 
     @router.post("/tasks/{task_id}/retry")
-    async def retry_task(task_id: str, session: Session = Depends(get_db)):
+    async def retry_task(
+        task_id: str,
+        session: Session = Depends(get_db),
+        current_user: Optional[AuthenticatedUser] = Depends(optional_user_dep),
+    ):
         """Retry a failed task by creating a new task with the same parameters."""
         if not app_state.monitor_instance:
             raise HTTPException(status_code=500, detail="Monitor not initialized")
@@ -251,14 +292,54 @@ def create_router(app_state) -> APIRouter:
         task_service.create_retry_relationship(task_id, new_task_id)
         session.commit()
 
-        result = app_state.monitor_instance.app.send_task(
-            original_task.task_name,
-            args=args,
-            kwargs=kwargs,
-            queue=queue_name,
-            task_id=new_task_id  # Use our pre-generated ID
+        actor = get_actor_for_user(current_user)
+        try:
+            app_state.monitor_instance.app.send_task(
+                original_task.task_name,
+                args=args,
+                kwargs=kwargs,
+                queue=queue_name,
+                task_id=new_task_id  # Use our pre-generated ID
+            )
+        except Exception as exc:
+            AuditLogService(session).record_safe_entry(
+                source="manual",
+                action_type="task.retry",
+                status="failed",
+                target_type="task",
+                target_id=task_id,
+                target_label=original_task.task_name,
+                task_id=task_id,
+                related_task_id=new_task_id,
+                reason=str(exc),
+                result_summary="Manual retry failed",
+                details={
+                    "new_task_id": new_task_id,
+                    "queue": queue_name,
+                    "was_orphaned": orphaned_task is not None,
+                },
+                **actor,
+            )
+            raise HTTPException(status_code=500, detail=f"Failed to retry task: {exc}") from exc
+
+        AuditLogService(session).record_safe_entry(
+            source="manual",
+            action_type="task.retry",
+            status="success",
+            target_type="task",
+            target_id=task_id,
+            target_label=original_task.task_name,
+            task_id=task_id,
+            related_task_id=new_task_id,
+            result_summary=f"Manual retry created {new_task_id}",
+            details={
+                "new_task_id": new_task_id,
+                "queue": queue_name,
+                "was_orphaned": orphaned_task is not None,
+            },
+            **actor,
         )
-        
+
         return {
             "status": "success",
             "message": "Task retried successfully",

--- a/agent/api/workflow_routes.py
+++ b/agent/api/workflow_routes.py
@@ -13,7 +13,9 @@ from models import (
 from services.workflow_service import WorkflowService
 from services.action_executor import ActionExecutor
 from services.workflow_catalog import TRIGGER_METADATA
+from services.audit_service import AuditLogService, get_actor_for_user
 from config import Config
+from security.auth import AuthenticatedUser
 from security.dependencies import get_auth_dependency
 
 
@@ -23,6 +25,7 @@ def create_router(app_state) -> APIRouter:
 
     config = app_state.config or Config.from_env()
     require_user_dep = get_auth_dependency(app_state, require=True)
+    optional_user_dep = get_auth_dependency(app_state, require=False)
 
     if config.auth_enabled:
         router.dependencies.append(Depends(require_user_dep))
@@ -47,7 +50,8 @@ def create_router(app_state) -> APIRouter:
     @router.post("", response_model=WorkflowDefinition, status_code=201)
     async def create_workflow(
         workflow_data: WorkflowCreateRequest,
-        session: Session = Depends(get_db)
+        session: Session = Depends(get_db),
+        current_user: Optional[AuthenticatedUser] = Depends(optional_user_dep),
     ):
         """Create a new workflow."""
         workflow_service = WorkflowService(session)
@@ -55,6 +59,21 @@ def create_router(app_state) -> APIRouter:
             workflow = workflow_service.create_workflow(workflow_data)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        AuditLogService(session).record_safe_entry(
+            source="manual",
+            action_type="workflow.created",
+            status="success",
+            target_type="workflow",
+            target_id=workflow.id or "",
+            target_label=workflow.name,
+            workflow_id=workflow.id,
+            result_summary="Workflow created",
+            details={
+                "trigger_type": workflow.trigger.type,
+                "action_types": [action.type for action in workflow.actions],
+            },
+            **get_actor_for_user(current_user),
+        )
         return workflow
 
     @router.get("", response_model=List[WorkflowDefinition])
@@ -93,7 +112,8 @@ def create_router(app_state) -> APIRouter:
     async def update_workflow(
         workflow_id: str,
         updates: WorkflowUpdateRequest,
-        session: Session = Depends(get_db)
+        session: Session = Depends(get_db),
+        current_user: Optional[AuthenticatedUser] = Depends(optional_user_dep),
     ):
         """Update an existing workflow."""
         workflow_service = WorkflowService(session)
@@ -105,19 +125,46 @@ def create_router(app_state) -> APIRouter:
         if not workflow:
             raise HTTPException(status_code=404, detail="Workflow not found")
 
+        AuditLogService(session).record_safe_entry(
+            source="manual",
+            action_type="workflow.updated",
+            status="success",
+            target_type="workflow",
+            target_id=workflow_id,
+            target_label=workflow.name,
+            workflow_id=workflow_id,
+            result_summary="Workflow updated",
+            details=updates.model_dump(exclude_unset=True),
+            **get_actor_for_user(current_user),
+        )
         return workflow
 
     @router.delete("/{workflow_id}", status_code=204)
     async def delete_workflow(
         workflow_id: str,
-        session: Session = Depends(get_db)
+        session: Session = Depends(get_db),
+        current_user: Optional[AuthenticatedUser] = Depends(optional_user_dep),
     ):
         """Delete a workflow."""
         workflow_service = WorkflowService(session)
+        existing = workflow_service.get_workflow(workflow_id)
         success = workflow_service.delete_workflow(workflow_id)
 
         if not success:
             raise HTTPException(status_code=404, detail="Workflow not found")
+
+        AuditLogService(session).record_safe_entry(
+            source="manual",
+            action_type="workflow.deleted",
+            status="success",
+            target_type="workflow",
+            target_id=workflow_id,
+            target_label=existing.name if existing else None,
+            workflow_id=workflow_id,
+            result_summary="Workflow deleted",
+            details={},
+            **get_actor_for_user(current_user),
+        )
 
     # ==================== Workflow Executions ====================
 

--- a/agent/app.py
+++ b/agent/app.py
@@ -101,6 +101,7 @@ def create_app() -> FastAPI:
     from api.auth_routes import create_router as create_auth_router
     from api.metrics_routes import create_router as create_metrics_router
     from api.config_routes import create_router as create_config_router
+    from api.audit_routes import create_router as create_audit_router
 
     app.include_router(create_task_router(app_state))
     app.include_router(create_worker_router(app_state))
@@ -114,6 +115,7 @@ def create_app() -> FastAPI:
     app.include_router(create_auth_router(app_state))
     app.include_router(create_metrics_router(app_state))
     app.include_router(create_config_router(app_state))
+    app.include_router(create_audit_router(app_state))
 
     require_user_dep = get_auth_dependency(app_state, require=True)
 

--- a/agent/database.py
+++ b/agent/database.py
@@ -275,6 +275,66 @@ class TaskResolutionDB(Base):
         Index('idx_task_resolved_flag', 'resolved'),
     )
 
+
+class AuditLogDB(Base):
+    """Persistent audit trail for manual and automated actions."""
+    __tablename__ = 'audit_logs'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    timestamp = Column(DateTime(timezone=True), nullable=False, default=utc_now, index=True)
+
+    source = Column(String(32), nullable=False, index=True)
+    action_type = Column(String(100), nullable=False, index=True)
+    status = Column(String(32), nullable=False, index=True)
+
+    actor_type = Column(String(32), nullable=False)
+    actor_id = Column(String(255), index=True)
+    actor_name = Column(String(255), nullable=False, index=True)
+
+    target_type = Column(String(50), nullable=False, index=True)
+    target_id = Column(String(255), nullable=False, index=True)
+    target_label = Column(String(255), index=True)
+
+    task_id = Column(String(255), index=True)
+    related_task_id = Column(String(255), index=True)
+    workflow_id = Column(String(36), index=True)
+    execution_id = Column(Integer, index=True)
+
+    reason = Column(Text)
+    result_summary = Column(Text)
+    details = Column(JSON)
+
+    __table_args__ = (
+        Index('idx_audit_timestamp_id', 'timestamp', 'id'),
+        Index('idx_audit_target_lookup', 'target_type', 'target_id', 'timestamp'),
+        Index('idx_audit_task_lookup', 'task_id', 'related_task_id', 'timestamp'),
+        Index('idx_audit_workflow_lookup', 'workflow_id', 'timestamp'),
+    )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for API responses."""
+        return {
+            'id': self.id,
+            'timestamp': ensure_utc_isoformat(self.timestamp),
+            'source': self.source,
+            'action_type': self.action_type,
+            'status': self.status,
+            'actor_type': self.actor_type,
+            'actor_id': self.actor_id,
+            'actor_name': self.actor_name,
+            'target_type': self.target_type,
+            'target_id': self.target_id,
+            'target_label': self.target_label,
+            'task_id': self.task_id,
+            'related_task_id': self.related_task_id,
+            'workflow_id': self.workflow_id,
+            'execution_id': self.execution_id,
+            'reason': self.reason,
+            'result_summary': self.result_summary,
+            'details': self.details or {},
+        }
+
+
 class WorkerEventDB(Base):
     """SQLAlchemy model for worker events."""
     __tablename__ = 'worker_events'

--- a/agent/models.py
+++ b/agent/models.py
@@ -208,6 +208,46 @@ class TaskProgressSnapshot(BaseModel):
     history: List[TaskProgressEvent] = Field(default_factory=list)
 
 
+class AuditLogActor(BaseModel):
+    """Actor associated with an audit entry."""
+    type: str
+    id: Optional[str] = None
+    name: str
+
+
+class AuditLogEntry(BaseModel):
+    """Single audit log entry."""
+    id: int
+    timestamp: datetime
+    source: Literal["manual", "workflow", "system"]
+    action_type: str
+    status: Literal["success", "failed", "skipped"]
+    actor: AuditLogActor
+    target_type: str
+    target_id: str
+    target_label: Optional[str] = None
+    task_id: Optional[str] = None
+    related_task_id: Optional[str] = None
+    workflow_id: Optional[str] = None
+    execution_id: Optional[int] = None
+    reason: Optional[str] = None
+    result_summary: Optional[str] = None
+    details: Dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {
+        'from_attributes': True,
+        'json_encoders': {
+            datetime: lambda v: v.isoformat() if v else None
+        }
+    }
+
+
+class AuditLogListResponse(BaseModel):
+    """Paginated audit log response."""
+    total: int
+    items: List[AuditLogEntry] = Field(default_factory=list)
+
+
 class WorkerInfo(BaseModel):
     """Worker information model"""
     hostname: str

--- a/agent/services/__init__.py
+++ b/agent/services/__init__.py
@@ -11,6 +11,7 @@ from .session_service import SessionService
 from .auth_service import AuthService
 from .app_config_service import AppConfigService
 from .retention_service import RetentionService
+from .audit_service import AuditLogService
 
 __all__ = [
     'TaskService',
@@ -23,5 +24,6 @@ __all__ = [
     'SessionService',
     'AuthService',
     'AppConfigService',
-    'RetentionService'
+    'RetentionService',
+    'AuditLogService'
 ]

--- a/agent/services/audit_service.py
+++ b/agent/services/audit_service.py
@@ -1,0 +1,243 @@
+"""Service for audit log persistence and querying."""
+
+import logging
+from typing import Any, Dict, Optional
+
+from sqlalchemy import and_, or_
+from sqlalchemy.orm import Query, Session
+
+from database import AuditLogDB
+from models import AuditLogActor, AuditLogEntry, AuditLogListResponse
+from security.auth import AuthenticatedUser
+
+logger = logging.getLogger(__name__)
+
+
+class AuditLogService:
+    """Manage audit log writes and queries."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def record_entry(
+        self,
+        *,
+        source: str,
+        action_type: str,
+        status: str,
+        actor_type: str,
+        actor_name: str,
+        target_type: str,
+        target_id: str,
+        actor_id: Optional[str] = None,
+        target_label: Optional[str] = None,
+        task_id: Optional[str] = None,
+        related_task_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+        execution_id: Optional[int] = None,
+        reason: Optional[str] = None,
+        result_summary: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        commit: bool = True,
+    ) -> AuditLogEntry:
+        """Persist an audit entry and return the API model."""
+        entry_db = AuditLogDB(
+            source=source,
+            action_type=action_type,
+            status=status,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            actor_name=actor_name,
+            target_type=target_type,
+            target_id=target_id,
+            target_label=target_label,
+            task_id=task_id,
+            related_task_id=related_task_id,
+            workflow_id=workflow_id,
+            execution_id=execution_id,
+            reason=reason,
+            result_summary=result_summary,
+            details=details or {},
+        )
+        self.session.add(entry_db)
+
+        if commit:
+            self.session.commit()
+            self.session.refresh(entry_db)
+        else:
+            self.session.flush()
+
+        return self._db_to_entry(entry_db)
+
+    def record_safe_entry(self, **kwargs) -> Optional[AuditLogEntry]:
+        """Best-effort audit recording that never raises to the caller."""
+        try:
+            return self.record_entry(**kwargs)
+        except Exception as exc:
+            self.session.rollback()
+            logger.error("Failed to persist audit log entry: %s", exc, exc_info=True)
+            return None
+
+    def list_entries(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+        search: Optional[str] = None,
+        source: Optional[str] = None,
+        status: Optional[str] = None,
+        action_type: Optional[str] = None,
+        target_type: Optional[str] = None,
+        target_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+        actor: Optional[str] = None,
+    ) -> AuditLogListResponse:
+        """Return filtered audit log entries."""
+        query = self.session.query(AuditLogDB)
+        query = self._apply_filters(
+            query,
+            search=search,
+            source=source,
+            status=status,
+            action_type=action_type,
+            target_type=target_type,
+            target_id=target_id,
+            workflow_id=workflow_id,
+            task_id=task_id,
+            actor=actor,
+        )
+
+        total = query.order_by(None).count()
+        rows = (
+            query.order_by(AuditLogDB.timestamp.desc(), AuditLogDB.id.desc())
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
+        return AuditLogListResponse(total=total, items=[self._db_to_entry(row) for row in rows])
+
+    def get_task_entries(self, task_id: str, *, limit: int = 50, offset: int = 0) -> AuditLogListResponse:
+        """Get audit entries related to a task, including retry descendants."""
+        return self.list_entries(task_id=task_id, limit=limit, offset=offset)
+
+    def get_workflow_entries(
+        self,
+        workflow_id: str,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> AuditLogListResponse:
+        """Get audit entries related to a workflow."""
+        return self.list_entries(workflow_id=workflow_id, limit=limit, offset=offset)
+
+    def _apply_filters(
+        self,
+        query: Query,
+        *,
+        search: Optional[str],
+        source: Optional[str],
+        status: Optional[str],
+        action_type: Optional[str],
+        target_type: Optional[str],
+        target_id: Optional[str],
+        workflow_id: Optional[str],
+        task_id: Optional[str],
+        actor: Optional[str],
+    ) -> Query:
+        if source:
+            query = query.filter(AuditLogDB.source == source)
+
+        if status:
+            query = query.filter(AuditLogDB.status == status)
+
+        if action_type:
+            query = query.filter(AuditLogDB.action_type == action_type)
+
+        if target_type:
+            query = query.filter(AuditLogDB.target_type == target_type)
+
+        if target_id:
+            query = query.filter(AuditLogDB.target_id == target_id)
+
+        if workflow_id:
+            query = query.filter(AuditLogDB.workflow_id == workflow_id)
+
+        if task_id:
+            query = query.filter(
+                or_(
+                    AuditLogDB.task_id == task_id,
+                    AuditLogDB.related_task_id == task_id,
+                    and_(AuditLogDB.target_type == "task", AuditLogDB.target_id == task_id),
+                )
+            )
+
+        if actor:
+            pattern = f"%{actor.strip()}%"
+            if pattern != "%%":
+                query = query.filter(
+                    or_(
+                        AuditLogDB.actor_name.ilike(pattern),
+                        AuditLogDB.actor_id.ilike(pattern),
+                    )
+                )
+
+        if search:
+            pattern = f"%{search.strip()}%"
+            if pattern != "%%":
+                query = query.filter(
+                    or_(
+                        AuditLogDB.action_type.ilike(pattern),
+                        AuditLogDB.actor_name.ilike(pattern),
+                        AuditLogDB.target_id.ilike(pattern),
+                        AuditLogDB.target_label.ilike(pattern),
+                        AuditLogDB.reason.ilike(pattern),
+                        AuditLogDB.result_summary.ilike(pattern),
+                    )
+                )
+
+        return query
+
+    def _db_to_entry(self, row: AuditLogDB) -> AuditLogEntry:
+        return AuditLogEntry(
+            id=row.id,
+            timestamp=row.timestamp,
+            source=row.source,
+            action_type=row.action_type,
+            status=row.status,
+            actor=AuditLogActor(
+                type=row.actor_type,
+                id=row.actor_id,
+                name=row.actor_name,
+            ),
+            target_type=row.target_type,
+            target_id=row.target_id,
+            target_label=row.target_label,
+            task_id=row.task_id,
+            related_task_id=row.related_task_id,
+            workflow_id=row.workflow_id,
+            execution_id=row.execution_id,
+            reason=row.reason,
+            result_summary=row.result_summary,
+            details=row.details or {},
+        )
+
+
+def get_actor_for_user(
+    current_user: Optional[AuthenticatedUser],
+    *,
+    fallback_name: Optional[str] = None,
+) -> Dict[str, Optional[str]]:
+    """Normalize request user context into audit actor fields."""
+    if isinstance(current_user, AuthenticatedUser):
+        return {
+            "actor_type": "user",
+            "actor_id": current_user.id,
+            "actor_name": current_user.email or current_user.name or fallback_name or current_user.id,
+        }
+
+    return {
+        "actor_type": "operator",
+        "actor_id": None,
+        "actor_name": fallback_name or "anonymous",
+    }

--- a/agent/services/workflow_engine.py
+++ b/agent/services/workflow_engine.py
@@ -16,6 +16,7 @@ from models import (
 from services.workflow_service import WorkflowService
 from services.workflow_executor import WorkflowExecutor
 from services.workflow_catalog import EVENT_TRIGGER_MAP, TRIGGER_METADATA
+from services.audit_service import AuditLogService
 
 logger = logging.getLogger(__name__)
 
@@ -101,13 +102,34 @@ class WorkflowEngine:
                         logger.warning(
                             f"Circuit breaker skipped workflow {workflow.name}: {cb_state.reason}"
                         )
-                        workflow_service.record_circuit_breaker_skip(
+                        execution_id = workflow_service.record_circuit_breaker_skip(
                             workflow=workflow,
                             trigger_type=trigger_type,
                             trigger_event=context,
-                            workflow_snapshot=workflow.dict(),
+                            workflow_snapshot=workflow.model_dump(),
                             circuit_breaker_key=cb_state.key,
                             reason=cb_state.reason,
+                        )
+                        AuditLogService(session).record_safe_entry(
+                            source="workflow",
+                            action_type="workflow.execution",
+                            status="skipped",
+                            actor_type="workflow",
+                            actor_id=workflow.id,
+                            actor_name=workflow.name,
+                            target_type="workflow",
+                            target_id=workflow.id or "",
+                            target_label=workflow.name,
+                            task_id=context.get("task_id"),
+                            workflow_id=workflow.id,
+                            execution_id=execution_id,
+                            reason=cb_state.reason,
+                            result_summary="Workflow execution skipped by circuit breaker",
+                            details={
+                                "trigger_type": trigger_type,
+                                "circuit_breaker_key": cb_state.key,
+                                "circuit_breaker_field": cb_state.field,
+                            },
                         )
                         continue
 

--- a/agent/services/workflow_executor.py
+++ b/agent/services/workflow_executor.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from models import TaskEvent, WorkerEvent, WorkflowDefinition
 from services.workflow_service import WorkflowService
 from services.action_executor import ActionExecutor
+from services.audit_service import AuditLogService
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ class WorkflowExecutor:
             workflow_id=workflow.id,
             trigger_type=workflow.trigger.type,
             trigger_event=context,
-            workflow_snapshot=workflow.dict(),
+            workflow_snapshot=workflow.model_dump(),
             circuit_breaker_key=circuit_breaker_key
         )
 
@@ -47,6 +48,7 @@ class WorkflowExecutor:
         overall_status = "completed"
         error_message = None
         stack_trace = None
+        audit_service = AuditLogService(self.session)
 
         try:
             action_executor = ActionExecutor(
@@ -74,6 +76,30 @@ class WorkflowExecutor:
                     "error_message": result.error_message,
                     "duration_ms": result.duration_ms
                 })
+
+                target = self._resolve_action_target(workflow, context, result.result)
+                audit_service.record_safe_entry(
+                    source="workflow",
+                    action_type=f"workflow.action.{result.action_type}",
+                    status=result.status,
+                    actor_type="workflow",
+                    actor_id=workflow.id,
+                    actor_name=workflow.name,
+                    target_type=target["target_type"],
+                    target_id=target["target_id"],
+                    target_label=target.get("target_label"),
+                    task_id=target.get("task_id"),
+                    related_task_id=target.get("related_task_id"),
+                    workflow_id=workflow.id,
+                    execution_id=execution_id,
+                    reason=result.error_message,
+                    result_summary=self._summarize_action_result(result),
+                    details={
+                        "trigger_type": workflow.trigger.type,
+                        "params": action_config.params,
+                        "result": result.result or {},
+                    },
+                )
 
                 if result.status == "failed":
                     logger.warning(
@@ -114,3 +140,86 @@ class WorkflowExecutor:
                 error_message=error_message,
                 stack_trace=stack_trace
             )
+            audit_service.record_safe_entry(
+                source="workflow",
+                action_type="workflow.execution",
+                status="success" if overall_status == "completed" else "failed",
+                actor_type="workflow",
+                actor_id=workflow.id,
+                actor_name=workflow.name,
+                target_type="workflow",
+                target_id=workflow.id or "",
+                target_label=workflow.name,
+                task_id=context.get("task_id"),
+                workflow_id=workflow.id,
+                execution_id=execution_id,
+                reason=error_message,
+                result_summary=self._summarize_workflow_result(action_results, overall_status),
+                details={
+                    "trigger_type": workflow.trigger.type,
+                    "actions_executed": action_results,
+                    "circuit_breaker_key": circuit_breaker_key,
+                },
+            )
+
+    @staticmethod
+    def _resolve_action_target(
+        workflow: WorkflowDefinition,
+        context: Dict[str, Any],
+        result: Optional[Dict[str, Any]],
+    ) -> Dict[str, Optional[str]]:
+        """Resolve the primary target for an action audit entry."""
+        result = result or {}
+
+        if result.get("original_task_id"):
+            return {
+                "target_type": "task",
+                "target_id": result["original_task_id"],
+                "target_label": result.get("task_name") or context.get("task_name"),
+                "task_id": result["original_task_id"],
+                "related_task_id": result.get("new_task_id"),
+            }
+
+        if context.get("task_id"):
+            return {
+                "target_type": "task",
+                "target_id": context["task_id"],
+                "target_label": context.get("task_name"),
+                "task_id": context["task_id"],
+                "related_task_id": None,
+            }
+
+        if context.get("hostname"):
+            return {
+                "target_type": "worker",
+                "target_id": context["hostname"],
+                "target_label": context["hostname"],
+                "task_id": None,
+                "related_task_id": None,
+            }
+
+        return {
+            "target_type": "workflow",
+            "target_id": workflow.id,
+            "target_label": workflow.name,
+            "task_id": None,
+            "related_task_id": None,
+        }
+
+    @staticmethod
+    def _summarize_action_result(result) -> str:
+        if result.status == "success":
+            return f"{result.action_type} completed"
+        if result.status == "skipped":
+            return f"{result.action_type} skipped"
+        return f"{result.action_type} failed"
+
+    @staticmethod
+    def _summarize_workflow_result(action_results: list[Dict[str, Any]], overall_status: str) -> str:
+        successful = len([item for item in action_results if item.get("status") == "success"])
+        failed = len([item for item in action_results if item.get("status") == "failed"])
+        if overall_status == "completed":
+            return f"Workflow completed with {successful} successful action(s)"
+        if failed:
+            return f"Workflow failed after {failed} failed action(s)"
+        return "Workflow failed"

--- a/agent/services/workflow_service.py
+++ b/agent/services/workflow_service.py
@@ -181,7 +181,7 @@ class WorkflowService:
         workflow_snapshot: Dict[str, Any],
         circuit_breaker_key: Optional[str],
         reason: str
-    ) -> None:
+    ) -> int:
         """Persist a workflow execution record for a circuit breaker skip."""
         execution_db = WorkflowExecutionDB(
             workflow_id=workflow.id,
@@ -196,6 +196,7 @@ class WorkflowService:
 
         self.session.add(execution_db)
         self.session.commit()
+        return execution_db.id
 
     def _validate_workflow_definition(
         self,

--- a/agent/tests/unit/test_audit_log_service.py
+++ b/agent/tests/unit/test_audit_log_service.py
@@ -1,0 +1,33 @@
+from services.audit_service import AuditLogService
+from tests.base import DatabaseTestCase
+
+
+class TestAuditLogService(DatabaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.service = AuditLogService(self.session)
+
+    def test_task_lookup_matches_primary_and_related_retry_task(self):
+        self.service.record_entry(
+            source="manual",
+            action_type="task.retry",
+            status="success",
+            actor_type="user",
+            actor_id="user-1",
+            actor_name="operator@example.com",
+            target_type="task",
+            target_id="task-original",
+            target_label="tasks.example",
+            task_id="task-original",
+            related_task_id="task-rerun",
+            result_summary="Manual retry created task-rerun",
+            details={"new_task_id": "task-rerun"},
+        )
+
+        original_entries = self.service.get_task_entries("task-original")
+        rerun_entries = self.service.get_task_entries("task-rerun")
+
+        self.assertEqual(original_entries.total, 1)
+        self.assertEqual(rerun_entries.total, 1)
+        self.assertEqual(original_entries.items[0].action_type, "task.retry")
+        self.assertEqual(rerun_entries.items[0].related_task_id, "task-rerun")

--- a/agent/tests/unit/test_workflow_audit_logging.py
+++ b/agent/tests/unit/test_workflow_audit_logging.py
@@ -1,0 +1,65 @@
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import Mock
+
+from database import AuditLogDB
+from models import ActionConfig, TaskEvent, TriggerConfig, WorkflowDefinition
+from services.workflow_executor import WorkflowExecutor
+from tests.base import DatabaseTestCase
+
+
+class TestWorkflowAuditLogging(DatabaseTestCase):
+    def test_workflow_executor_records_action_and_execution_audit_entries(self):
+        self.create_task_event_db(
+            task_id="task-123",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc),
+        )
+
+        monitor_instance = Mock()
+        monitor_instance.app = Mock()
+        monitor_instance.app.send_task = Mock(return_value=None)
+
+        workflow = WorkflowDefinition(
+            id="workflow-123",
+            name="Retry failed task",
+            trigger=TriggerConfig(type="task.failed", config={}),
+            actions=[
+                ActionConfig(
+                    type="task.retry",
+                    params={"max_retries": 3},
+                    continue_on_failure=False,
+                )
+            ],
+        )
+
+        context = {
+            "task_id": "task-123",
+            "task_name": "tasks.example",
+            "root_id": "task-123",
+            "args": [],
+            "kwargs": {},
+        }
+        event = TaskEvent(
+            task_id="task-123",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc),
+        )
+
+        executor = WorkflowExecutor(
+            session=self.session,
+            db_manager=None,
+            monitor_instance=monitor_instance,
+        )
+
+        asyncio.run(executor.execute_workflow(workflow, context, event))
+
+        entries = self.session.query(AuditLogDB).order_by(AuditLogDB.id.asc()).all()
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0].action_type, "workflow.action.task.retry")
+        self.assertEqual(entries[0].status, "success")
+        self.assertEqual(entries[0].task_id, "task-123")
+        self.assertEqual(entries[1].action_type, "workflow.execution")
+        self.assertEqual(entries[1].status, "success")

--- a/frontend/app/components/audit/AuditLogList.vue
+++ b/frontend/app/components/audit/AuditLogList.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="space-y-3">
+    <div v-if="loading" class="space-y-3">
+      <div
+        v-for="idx in 3"
+        :key="idx"
+        class="h-24 rounded-md border border-border-subtle animate-pulse"
+      />
+    </div>
+
+    <div
+      v-else-if="entries.length === 0"
+      class="rounded-md border border-dashed border-border-subtle px-4 py-8 text-center"
+    >
+      <p class="text-sm font-medium text-text-primary">{{ emptyTitle }}</p>
+      <p v-if="emptyDescription" class="mt-1 text-xs text-text-muted">{{ emptyDescription }}</p>
+    </div>
+
+    <div v-else class="space-y-3">
+      <div
+        v-for="entry in entries"
+        :key="entry.id"
+        class="rounded-md border border-border-subtle bg-background-surface p-4"
+      >
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div class="min-w-0 flex-1">
+            <div class="flex flex-wrap items-center gap-2">
+              <Badge variant="outline" class="font-mono text-[10px] uppercase tracking-wide">
+                {{ entry.source }}
+              </Badge>
+              <Badge :variant="statusVariant(entry.status)" class="text-[10px] uppercase tracking-wide">
+                {{ entry.status }}
+              </Badge>
+              <span class="text-sm font-medium text-text-primary">
+                {{ formatAction(entry.action_type) }}
+              </span>
+            </div>
+
+            <div class="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-text-secondary">
+              <span>{{ entry.actor.name }}</span>
+              <span class="text-text-muted">•</span>
+              <span>
+                {{ entry.target_type }}
+                <span class="font-mono text-text-primary">
+                  {{ entry.target_label || entry.target_id }}
+                </span>
+              </span>
+              <template v-if="entry.task_id">
+                <span class="text-text-muted">•</span>
+                <NuxtLink
+                  :to="`/tasks/${entry.task_id}`"
+                  class="font-mono text-primary hover:text-primary-hover"
+                >
+                  task {{ entry.task_id }}
+                </NuxtLink>
+              </template>
+              <template v-if="entry.related_task_id">
+                <span class="text-text-muted">•</span>
+                <NuxtLink
+                  :to="`/tasks/${entry.related_task_id}`"
+                  class="font-mono text-primary hover:text-primary-hover"
+                >
+                  related {{ entry.related_task_id }}
+                </NuxtLink>
+              </template>
+              <template v-if="entry.workflow_id">
+                <span class="text-text-muted">•</span>
+                <NuxtLink
+                  :to="`/workflows/${entry.workflow_id}`"
+                  class="font-mono text-primary hover:text-primary-hover"
+                >
+                  workflow {{ entry.workflow_id }}
+                </NuxtLink>
+              </template>
+            </div>
+
+            <p v-if="entry.result_summary" class="mt-3 text-sm text-text-primary">
+              {{ entry.result_summary }}
+            </p>
+            <p v-if="entry.reason" class="mt-1 text-xs text-status-error">
+              {{ entry.reason }}
+            </p>
+          </div>
+
+          <div class="shrink-0 text-xs text-text-muted">
+            <TimeDisplay :timestamp="entry.timestamp" layout="inline" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Badge } from '~/components/ui/badge'
+import TimeDisplay from '~/components/TimeDisplay.vue'
+import type { AuditLogEntryDTO } from '~/services/apiClient'
+
+defineProps<{
+  entries: AuditLogEntryDTO[]
+  loading?: boolean
+  emptyTitle?: string
+  emptyDescription?: string
+}>()
+
+function formatAction(actionType: string): string {
+  return actionType
+    .replace(/^workflow\.action\./, '')
+    .replace(/\./g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+function statusVariant(status: AuditLogEntryDTO['status']) {
+  switch (status) {
+    case 'success':
+      return 'success'
+    case 'failed':
+      return 'destructive'
+    default:
+      return 'secondary'
+  }
+}
+</script>

--- a/frontend/app/components/navbar.vue
+++ b/frontend/app/components/navbar.vue
@@ -108,6 +108,7 @@ const navItems = [
   { label: 'Dashboard', path: '/' },
   { label: 'Tasks', path: '/tasks' },
   { label: 'Workflows', path: '/workflows' },
+  { label: 'Audit', path: '/audit' },
 ]
 
 const isActive = (path: string) => {

--- a/frontend/app/pages/audit/index.vue
+++ b/frontend/app/pages/audit/index.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="max-w-7xl mx-auto">
+    <div class="mb-8 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+      <div>
+        <h1 class="text-xl font-semibold text-text-primary">Audit Log</h1>
+        <p class="mt-1 text-xs text-text-muted">
+          Search manual operator actions and automated workflow interventions.
+        </p>
+      </div>
+
+      <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Input
+          v-model="search"
+          type="text"
+          placeholder="Search actor, action, task..."
+          @keyup.enter="loadAudit"
+        />
+        <Select v-model="sourceFilter">
+          <option value="">All Sources</option>
+          <option value="manual">Manual</option>
+          <option value="workflow">Workflow</option>
+          <option value="system">System</option>
+        </Select>
+        <Select v-model="statusFilter">
+          <option value="">All Statuses</option>
+          <option value="success">Success</option>
+          <option value="failed">Failed</option>
+          <option value="skipped">Skipped</option>
+        </Select>
+        <Button variant="outline" @click="loadAudit">
+          Refresh
+        </Button>
+      </div>
+    </div>
+
+    <div class="mb-4 flex flex-wrap items-center gap-2 text-xs text-text-muted">
+      <span v-if="taskFilter" class="rounded-full border border-border-subtle px-3 py-1">
+        task {{ taskFilter }}
+      </span>
+      <span v-if="workflowFilter" class="rounded-full border border-border-subtle px-3 py-1">
+        workflow {{ workflowFilter }}
+      </span>
+      <span class="rounded-full border border-border-subtle px-3 py-1">
+        {{ auditStore.total }} matching entries
+      </span>
+    </div>
+
+    <AuditLogList
+      :entries="auditStore.entries"
+      :loading="auditStore.isLoading"
+      empty-title="No audit entries match the current filters"
+      empty-description="Try broadening the search or clear scoped query parameters."
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { Input } from '~/components/ui/input'
+import { Button } from '~/components/ui/button'
+import Select from '~/components/common/Select.vue'
+import AuditLogList from '~/components/audit/AuditLogList.vue'
+
+const route = useRoute()
+const auditStore = useAuditStore()
+
+const search = ref((route.query.search as string) || '')
+const sourceFilter = ref((route.query.source as string) || '')
+const statusFilter = ref((route.query.status as string) || '')
+const taskFilter = ref((route.query.task_id as string) || '')
+const workflowFilter = ref((route.query.workflow_id as string) || '')
+
+async function loadAudit() {
+  await auditStore.fetchAuditLogs({
+    limit: 100,
+    search: search.value || null,
+    source: sourceFilter.value || null,
+    status: statusFilter.value || null,
+    task_id: taskFilter.value || null,
+    workflow_id: workflowFilter.value || null,
+  })
+}
+
+onMounted(loadAudit)
+</script>

--- a/frontend/app/pages/tasks/[id].vue
+++ b/frontend/app/pages/tasks/[id].vue
@@ -34,6 +34,14 @@
         </div>
 
         <div class="flex items-center gap-2">
+          <NuxtLink :to="`/audit?task_id=${task.task_id}`">
+            <Button
+              variant="outline"
+              size="sm"
+            >
+              Audit Log
+            </Button>
+          </NuxtLink>
           <Button
             @click="handleTaskIdUrlCopy"
             variant="outline"
@@ -77,10 +85,11 @@
       <main class="flex-1 min-w-0">
         <!-- Tabs -->
         <Tabs default-value="overview" class="w-full">
-          <TabsList class="grid w-full grid-cols-3 mb-6">
+          <TabsList class="grid w-full grid-cols-4 mb-6">
             <TabsTrigger value="overview">Overview</TabsTrigger>
             <TabsTrigger value="timeline">Timeline</TabsTrigger>
             <TabsTrigger value="data">Data</TabsTrigger>
+            <TabsTrigger value="audit">Audit</TabsTrigger>
           </TabsList>
 
           <!-- Overview Tab -->
@@ -319,6 +328,27 @@
               </div>
             </div>
           </TabsContent>
+
+          <TabsContent value="audit">
+            <div class="space-y-4">
+              <div class="flex items-center justify-between gap-3">
+                <div>
+                  <h2 class="text-sm font-medium text-text-primary">Audit History</h2>
+                  <p class="text-xs text-text-muted">Manual actions and workflow interventions for this task.</p>
+                </div>
+                <NuxtLink :to="`/audit?task_id=${task?.task_id}`">
+                  <Button variant="outline" size="sm">Open Full Log</Button>
+                </NuxtLink>
+              </div>
+
+              <AuditLogList
+                :entries="auditEntries"
+                :loading="isAuditLoading"
+                empty-title="No audit events for this task"
+                empty-description="Manual retries, resolutions, and workflow actions will appear here."
+              />
+            </div>
+          </TabsContent>
         </Tabs>
       </main>
 
@@ -400,16 +430,19 @@ import UuidDisplay from '~/components/UuidDisplay.vue'
 import PayloadTruncationNotice from '~/components/PayloadTruncationNotice.vue'
 import RetryTaskConfirmDialog from '~/components/RetryTaskConfirmDialog.vue'
 import TaskProgressSteps from '~/components/tasks/TaskProgressSteps.vue'
+import AuditLogList from '~/components/audit/AuditLogList.vue'
 import type { TaskEventResponse } from '~/services/apiClient'
 import { useCopy } from '~/composables/useCopy'
 
 const route = useRoute()
 const tasksStore = useTasksStore()
+const auditStore = useAuditStore()
 const isRetrying = computed(() => tasksStore.isLoading)
 const retryDialogRef = ref<InstanceType<typeof RetryTaskConfirmDialog> | null>(null)
 
 const task = ref<TaskEventResponse | null>(null)
 const allEvents = ref<TaskEventResponse[]>([])
+const isAuditLoading = ref(false)
 const isLoading = ref(true)
 const error = ref<string | null>(null)
 
@@ -431,6 +464,7 @@ const taskId = computed(() => route.params.id as string)
 const progressSnapshot = computed(() => tasksStore.getProgressSnapshot(taskId.value))
 const currentProgress = computed(() => progressSnapshot.value?.latest?.progress ?? null)
 const currentMessage = computed(() => progressSnapshot.value?.latest?.message ?? '')
+const auditEntries = computed(() => auditStore.getTaskAudit(taskId.value))
 
 const shareUrl = computed(() => {
   if (typeof window === 'undefined') return ''
@@ -495,8 +529,24 @@ async function fetchTaskData() {
   }
 }
 
+async function fetchTaskAudit() {
+  if (!taskId.value) return
+
+  try {
+    isAuditLoading.value = true
+    await auditStore.fetchTaskAuditLogs(taskId.value, 25)
+  } finally {
+    isAuditLoading.value = false
+  }
+}
+
 onMounted(async () => {
-  await fetchTaskData()
+  await Promise.all([
+    fetchTaskData(),
+    fetchTaskAudit().catch((auditError) => {
+      console.error('Failed to load task audit log:', auditError)
+    }),
+  ])
 })
 
 const openRetryDialog = () => {
@@ -508,7 +558,12 @@ const handleRetryConfirm = async () => {
 
   try {
     await tasksStore.retryTask(task.value.task_id)
-    await fetchTaskData()
+    await Promise.all([
+      fetchTaskData(),
+      fetchTaskAudit().catch((auditError) => {
+        console.error('Failed to refresh task audit log:', auditError)
+      }),
+    ])
   } catch (error) {
     console.error('Failed to rerun task:', error)
   }

--- a/frontend/app/pages/workflows/[id]/index.vue
+++ b/frontend/app/pages/workflows/[id]/index.vue
@@ -30,6 +30,14 @@
         </div>
 
         <div class="flex items-center gap-2">
+          <NuxtLink :to="`/audit?workflow_id=${route.params.id}`">
+            <Button
+              variant="outline"
+              size="sm"
+            >
+              Audit Log
+            </Button>
+          </NuxtLink>
           <Button
             variant="outline"
             size="sm"
@@ -59,9 +67,10 @@
       <main class="flex-1 min-w-0">
         <!-- Tabs -->
         <Tabs default-value="overview" class="w-full">
-      <TabsList class="grid w-full grid-cols-3 mb-6">
+      <TabsList class="grid w-full grid-cols-4 mb-6">
         <TabsTrigger value="overview">Overview</TabsTrigger>
         <TabsTrigger value="executions">Executions</TabsTrigger>
+        <TabsTrigger value="audit">Audit</TabsTrigger>
         <TabsTrigger value="settings">Settings</TabsTrigger>
       </TabsList>
 
@@ -125,6 +134,27 @@
       <!-- Executions Tab -->
       <TabsContent value="executions">
         <WorkflowExecutionHistory :workflow-id="route.params.id as string" />
+      </TabsContent>
+
+      <TabsContent value="audit">
+        <div class="space-y-4">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <h2 class="text-sm font-medium text-text-primary">Audit History</h2>
+              <p class="text-xs text-text-muted">Manual edits and automated executions for this workflow.</p>
+            </div>
+            <NuxtLink :to="`/audit?workflow_id=${route.params.id}`">
+              <Button variant="outline" size="sm">Open Full Log</Button>
+            </NuxtLink>
+          </div>
+
+          <AuditLogList
+            :entries="workflowAuditEntries"
+            :loading="isAuditLoading"
+            empty-title="No audit events for this workflow"
+            empty-description="Workflow changes and executions will appear here."
+          />
+        </div>
       </TabsContent>
 
       <!-- Settings Tab -->
@@ -246,10 +276,14 @@ import { Badge } from '~/components/ui/badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
 import StatusDot from '~/components/StatusDot.vue'
 import WorkflowExecutionHistory from '~/components/workflows/WorkflowExecutionHistory.vue'
+import AuditLogList from '~/components/audit/AuditLogList.vue'
 
 const route = useRoute()
 const workflowStore = useWorkflowsStore()
+const auditStore = useAuditStore()
 const toggling = ref(false)
+const isAuditLoading = ref(false)
+const workflowAuditEntries = computed(() => auditStore.getWorkflowAudit(route.params.id as string))
 
 const successRate = computed(() => {
   const workflow = workflowStore.currentWorkflow
@@ -263,6 +297,9 @@ async function toggleEnabled() {
   toggling.value = true
   try {
     await workflowStore.toggleWorkflow(workflowStore.currentWorkflow.id)
+    await fetchWorkflowAudit().catch((auditError) => {
+      console.error('Failed to refresh workflow audit log:', auditError)
+    })
   } finally {
     toggling.value = false
   }
@@ -272,7 +309,21 @@ function formatDateTime(timestamp: string): string {
   return new Date(timestamp).toLocaleString()
 }
 
+async function fetchWorkflowAudit() {
+  try {
+    isAuditLoading.value = true
+    await auditStore.fetchWorkflowAuditLogs(route.params.id as string, 25)
+  } finally {
+    isAuditLoading.value = false
+  }
+}
+
 onMounted(async () => {
-  await workflowStore.fetchWorkflow(route.params.id as string)
+  await Promise.all([
+    workflowStore.fetchWorkflow(route.params.id as string),
+    fetchWorkflowAudit().catch((auditError) => {
+      console.error('Failed to load workflow audit log:', auditError)
+    }),
+  ])
 })
 </script>

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -126,6 +126,36 @@ export interface TaskProgressSnapshotResponse {
   history: TaskProgressEventResponse[]
 }
 
+export interface AuditLogActorDTO {
+  type: 'user' | 'operator' | 'workflow' | 'system'
+  id?: string | null
+  name: string
+}
+
+export interface AuditLogEntryDTO {
+  id: number
+  timestamp: string
+  source: 'manual' | 'workflow' | 'system'
+  action_type: string
+  status: 'success' | 'failed' | 'skipped'
+  actor: AuditLogActorDTO
+  target_type: string
+  target_id: string
+  target_label?: string | null
+  task_id?: string | null
+  related_task_id?: string | null
+  workflow_id?: string | null
+  execution_id?: number | null
+  reason?: string | null
+  result_summary?: string | null
+  details: Record<string, any>
+}
+
+export interface AuditLogListResponseDTO {
+  total: number
+  items: AuditLogEntryDTO[]
+}
+
 class ApiService {
   private api: Api<unknown>
 
@@ -372,6 +402,51 @@ class ApiService {
   async getRecentFailedTasks(params?: { hours?: number; limit?: number; include_retried?: boolean }): Promise<TaskEventResponse[]> {
     const response = await this.api.request({
       path: '/api/tasks/failed/recent',
+      method: 'GET',
+      query: params
+    })
+    return response.data
+  }
+
+  async getAuditLogs(params?: {
+    limit?: number
+    offset?: number
+    search?: string | null
+    source?: string | null
+    status?: string | null
+    action_type?: string | null
+    target_type?: string | null
+    target_id?: string | null
+    workflow_id?: string | null
+    task_id?: string | null
+    actor?: string | null
+  }): Promise<AuditLogListResponseDTO> {
+    const response = await this.api.request({
+      path: '/api/audit-logs',
+      method: 'GET',
+      query: params
+    })
+    return response.data
+  }
+
+  async getTaskAuditLogs(taskId: string, params?: {
+    limit?: number
+    offset?: number
+  }): Promise<AuditLogListResponseDTO> {
+    const response = await this.api.request({
+      path: `/api/tasks/${encodeURIComponent(taskId)}/audit`,
+      method: 'GET',
+      query: params
+    })
+    return response.data
+  }
+
+  async getWorkflowAuditLogs(workflowId: string, params?: {
+    limit?: number
+    offset?: number
+  }): Promise<AuditLogListResponseDTO> {
+    const response = await this.api.request({
+      path: `/api/workflows/${encodeURIComponent(workflowId)}/audit`,
       method: 'GET',
       query: params
     })
@@ -765,7 +840,9 @@ export type {
   AppConfigSnapshotDTO,
   AppSettingDTO,
   AppSettingInput,
-  TaskIssueConfigDTO
+  TaskIssueConfigDTO,
+  AuditLogEntryDTO,
+  AuditLogListResponseDTO
 }
 
 // Re-export session types from auto-generated API

--- a/frontend/app/stores/audit.ts
+++ b/frontend/app/stores/audit.ts
@@ -1,0 +1,103 @@
+import { defineStore } from 'pinia'
+import { readonly, ref } from 'vue'
+import { useApiService } from '~/services/apiClient'
+import type { AuditLogEntryDTO, AuditLogListResponseDTO } from '~/services/apiClient'
+
+export interface AuditLogQuery {
+  limit?: number
+  offset?: number
+  search?: string | null
+  source?: string | null
+  status?: string | null
+  action_type?: string | null
+  target_type?: string | null
+  target_id?: string | null
+  workflow_id?: string | null
+  task_id?: string | null
+  actor?: string | null
+}
+
+export const useAuditStore = defineStore('audit', () => {
+  const apiService = useApiService()
+
+  const entries = ref<AuditLogEntryDTO[]>([])
+  const total = ref(0)
+  const taskEntries = ref<Record<string, AuditLogEntryDTO[]>>({})
+  const workflowEntries = ref<Record<string, AuditLogEntryDTO[]>>({})
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchAuditLogs(query: AuditLogQuery = {}): Promise<AuditLogListResponseDTO> {
+    try {
+      isLoading.value = true
+      error.value = null
+      const response = await apiService.getAuditLogs(query)
+      entries.value = response.items
+      total.value = response.total
+      return response
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch audit log'
+      throw err
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function fetchTaskAuditLogs(taskId: string, limit = 25): Promise<AuditLogEntryDTO[]> {
+    try {
+      isLoading.value = true
+      error.value = null
+      const response = await apiService.getTaskAuditLogs(taskId, { limit })
+      taskEntries.value = {
+        ...taskEntries.value,
+        [taskId]: response.items,
+      }
+      return response.items
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch task audit log'
+      throw err
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function fetchWorkflowAuditLogs(workflowId: string, limit = 25): Promise<AuditLogEntryDTO[]> {
+    try {
+      isLoading.value = true
+      error.value = null
+      const response = await apiService.getWorkflowAuditLogs(workflowId, { limit })
+      workflowEntries.value = {
+        ...workflowEntries.value,
+        [workflowId]: response.items,
+      }
+      return response.items
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch workflow audit log'
+      throw err
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  function getTaskAudit(taskId: string): AuditLogEntryDTO[] {
+    return taskEntries.value[taskId] || []
+  }
+
+  function getWorkflowAudit(workflowId: string): AuditLogEntryDTO[] {
+    return workflowEntries.value[workflowId] || []
+  }
+
+  return {
+    entries: readonly(entries),
+    total: readonly(total),
+    taskEntries: readonly(taskEntries),
+    workflowEntries: readonly(workflowEntries),
+    isLoading: readonly(isLoading),
+    error: readonly(error),
+    fetchAuditLogs,
+    fetchTaskAuditLogs,
+    fetchWorkflowAuditLogs,
+    getTaskAudit,
+    getWorkflowAudit,
+  }
+})

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,18 @@
 /** @type {import('tailwindcss').Config} */
+const withOpacity = (cssVariable: string) => ({ opacityValue }: { opacityValue?: string }) => {
+  if (opacityValue === undefined) {
+    return `var(${cssVariable})`
+  }
+
+  const opacity = Number.parseFloat(opacityValue)
+
+  if (Number.isNaN(opacity)) {
+    return `var(${cssVariable})`
+  }
+
+  return `color-mix(in srgb, var(${cssVariable}) ${opacity * 100}%, transparent)`
+}
+
 export default {
   content: [
     "./app/**/*.{js,vue,ts}",
@@ -19,90 +33,90 @@ export default {
       colors: {
         // Backgrounds using CSS variables
         background: {
-          base: 'var(--bg-base)',
-          surface: 'var(--bg-surface)',
-          raised: 'var(--bg-raised)',
+          base: withOpacity('--bg-base'),
+          surface: withOpacity('--bg-surface'),
+          raised: withOpacity('--bg-raised'),
           overlay: 'hsl(0, 0%, 18%, 0.8)',
           // Interactive states
-          hover: 'var(--bg-hover)',
-          'hover-subtle': 'var(--bg-hover-subtle)',
-          active: 'var(--bg-active)',
-          selected: 'var(--bg-selected)'
+          hover: withOpacity('--bg-hover'),
+          'hover-subtle': withOpacity('--bg-hover-subtle'),
+          active: withOpacity('--bg-active'),
+          selected: withOpacity('--bg-selected')
         },
         // Text colors using CSS variables
         text: {
-          primary: 'var(--text-primary)',
-          secondary: 'var(--text-secondary)',
-          muted: 'var(--text-muted)',
-          disabled: 'var(--text-disabled)'
+          primary: withOpacity('--text-primary'),
+          secondary: withOpacity('--text-secondary'),
+          muted: withOpacity('--text-muted'),
+          disabled: withOpacity('--text-disabled')
         },
         // Card and borders
         card: {
-          base: 'var(--bg-surface)',
-          border: 'var(--border)',
+          base: withOpacity('--bg-surface'),
+          border: withOpacity('--border'),
         },
         // Border colors
         border: {
-          DEFAULT: 'var(--border)',
-          highlight: 'var(--highlight)',
-          subtle: 'var(--border-subtle)'
+          DEFAULT: withOpacity('--border'),
+          highlight: withOpacity('--highlight'),
+          subtle: withOpacity('--border-subtle')
         },
         // Primary/Brand colors
         primary: {
-          DEFAULT: 'var(--primary)',
-          hover: 'var(--primary-hover)',
-          bg: 'var(--primary-bg)',
-          border: 'var(--primary-border)'
+          DEFAULT: withOpacity('--primary'),
+          hover: withOpacity('--primary-hover'),
+          bg: withOpacity('--primary-bg'),
+          border: withOpacity('--primary-border')
         },
         // Semantic status colors using CSS variables
         status: {
           // Success states
           success: {
-            DEFAULT: 'var(--status-success)',
-            bg: 'var(--status-success-bg)',
-            border: 'var(--status-success-border)',
+            DEFAULT: withOpacity('--status-success'),
+            bg: withOpacity('--status-success-bg'),
+            border: withOpacity('--status-success-border'),
             hover: 'hsl(158,100%,13%)'
           },
           // Error states
           error: {
-            DEFAULT: 'var(--status-error)',
-            bg: 'var(--status-error-bg)',
-            border: 'var(--status-error-border)',
+            DEFAULT: withOpacity('--status-error'),
+            bg: withOpacity('--status-error-bg'),
+            border: withOpacity('--status-error-border'),
             hover: 'hsl(347, 77%, 18%)'
           },
           // Warning states
           warning: {
-            DEFAULT: 'var(--status-warning)',
-            bg: 'var(--status-warning-bg)',
-            border: 'var(--status-warning-border)',
+            DEFAULT: withOpacity('--status-warning'),
+            bg: withOpacity('--status-warning-bg'),
+            border: withOpacity('--status-warning-border'),
             hover: 'hsl(45, 85%, 18%)'
           },
           // Info states
           info: {
-            DEFAULT: 'var(--status-info)',
-            bg: 'var(--status-info-bg)',
-            border: 'var(--status-info-border)',
+            DEFAULT: withOpacity('--status-info'),
+            bg: withOpacity('--status-info-bg'),
+            border: withOpacity('--status-info-border'),
             hover: 'hsl(199, 89%, 18%)'
           },
           // Retry states
           retry: {
-            DEFAULT: 'var(--status-retry)',
-            bg: 'var(--status-retry-bg)',
-            border: 'var(--status-retry-border)',
+            DEFAULT: withOpacity('--status-retry'),
+            bg: withOpacity('--status-retry-bg'),
+            border: withOpacity('--status-retry-border'),
             hover: 'hsl(24, 95%, 18%)'
           },
           // Neutral states
           neutral: {
-            DEFAULT: 'var(--status-neutral)',
-            bg: 'var(--status-neutral-bg)',
-            border: 'var(--status-neutral-border)',
+            DEFAULT: withOpacity('--status-neutral'),
+            bg: withOpacity('--status-neutral-bg'),
+            border: withOpacity('--status-neutral-border'),
             hover: 'hsl(215, 20%, 18%)'
           },
           // Special states
           special: {
-            DEFAULT: 'var(--status-special)',
-            bg: 'var(--status-special-bg)',
-            border: 'var(--status-special-border)',
+            DEFAULT: withOpacity('--status-special'),
+            bg: withOpacity('--status-special-bg'),
+            border: withOpacity('--status-special-border'),
             hover: 'hsl(263, 70%, 18%)'
           }
         }


### PR DESCRIPTION
Closes #97

## Summary
- add a persisted audit log model, migration, service, and searchable API endpoints
- record manual task and workflow management actions plus automated workflow execution/action events
- add an audit log UI with scoped task/workflow links and a dedicated searchable audit page

## Testing
- `PYTHONPATH=agent python3 -m unittest agent.tests.unit.test_audit_log_service agent.tests.unit.test_workflow_audit_logging`
- `PYTHONPATH=. python3 - <<'PY' ... DatabaseManager.run_migrations() ... PY` from `agent/` against a temporary SQLite database
- `npm --prefix frontend run build`
