### PR TITLE
Add data retention policy cleanup controls

### DIFF
--- a/agent/api/config_routes.py
+++ b/agent/api/config_routes.py
@@ -3,12 +3,12 @@
 import logging
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from config import Config
-from models import AppSetting, AppSettingUpdate, AppConfigSnapshot
-from services import AppConfigService
+from models import AppSetting, AppSettingUpdate, AppConfigSnapshot, DataRetentionConfig, RetentionCleanupResponse
+from services import AppConfigService, RetentionService
 from security.dependencies import get_auth_dependency
 
 logger = logging.getLogger(__name__)
@@ -33,6 +33,9 @@ def create_router(app_state) -> APIRouter:
 
     def get_config_service(session: Session = Depends(get_db)) -> AppConfigService:
         return AppConfigService(session)
+
+    def get_retention_service(session: Session = Depends(get_db)) -> RetentionService:
+        return RetentionService(session)
 
     @router.get("", response_model=AppConfigSnapshot)
     async def get_config_snapshot(
@@ -82,5 +85,20 @@ def create_router(app_state) -> APIRouter:
         if not deleted:
             raise HTTPException(status_code=404, detail="Setting not found")
         return None
+
+    @router.get("/retention", response_model=DataRetentionConfig)
+    async def get_retention_policy(
+        retention_service: RetentionService = Depends(get_retention_service)
+    ):
+        """Get normalized data retention policy values."""
+        return retention_service.get_policy()
+
+    @router.post("/retention/cleanup", response_model=RetentionCleanupResponse)
+    async def run_retention_cleanup(
+        dry_run: bool = Query(default=True),
+        retention_service: RetentionService = Depends(get_retention_service)
+    ):
+        """Run retention cleanup, optionally as a dry-run preview."""
+        return retention_service.cleanup(dry_run=dry_run)
 
     return router

--- a/agent/models.py
+++ b/agent/models.py
@@ -461,8 +461,8 @@ class TaskIssueConfig(BaseModel):
 
 class DataRetentionConfig(BaseModel):
     """Retention policy for stored operational data."""
-    task_events_days: int = Field(default=30, ge=1, le=3650)
-    task_progress_days: int = Field(default=14, ge=1, le=3650)
+    task_successful_days: int = Field(default=14, ge=1, le=3650)
+    task_unsuccessful_days: int = Field(default=30, ge=1, le=3650)
     worker_events_days: int = Field(default=30, ge=1, le=3650)
     workflow_executions_days: int = Field(default=30, ge=1, le=3650)
     task_daily_stats_days: int = Field(default=365, ge=1, le=3650)

--- a/agent/models.py
+++ b/agent/models.py
@@ -459,9 +459,35 @@ class TaskIssueConfig(BaseModel):
     lookback_hours: int = Field(default=24, ge=1, le=168)
 
 
+class DataRetentionConfig(BaseModel):
+    """Retention policy for stored operational data."""
+    task_events_days: int = Field(default=30, ge=1, le=3650)
+    task_progress_days: int = Field(default=14, ge=1, le=3650)
+    worker_events_days: int = Field(default=30, ge=1, le=3650)
+    workflow_executions_days: int = Field(default=30, ge=1, le=3650)
+    task_daily_stats_days: int = Field(default=365, ge=1, le=3650)
+    inactive_sessions_days: int = Field(default=30, ge=1, le=3650)
+
+
+class RetentionCleanupResult(BaseModel):
+    """Result for a single retention target cleanup."""
+    key: str
+    label: str
+    retention_days: int = Field(ge=1)
+    deleted: int = Field(ge=0)
+
+
+class RetentionCleanupResponse(BaseModel):
+    """Summary of a retention cleanup run."""
+    dry_run: bool = False
+    total_deleted: int = Field(ge=0)
+    results: List[RetentionCleanupResult] = Field(default_factory=list)
+
+
 class AppConfigSnapshot(BaseModel):
     """Grouped configuration snapshot returned to clients."""
     task_issue_summary: TaskIssueConfig
+    data_retention: DataRetentionConfig
 
 
 class UserInfo(BaseModel):

--- a/agent/services/__init__.py
+++ b/agent/services/__init__.py
@@ -10,6 +10,7 @@ from .environment_service import EnvironmentService
 from .session_service import SessionService
 from .auth_service import AuthService
 from .app_config_service import AppConfigService
+from .retention_service import RetentionService
 
 __all__ = [
     'TaskService',
@@ -21,5 +22,6 @@ __all__ = [
     'EnvironmentService',
     'SessionService',
     'AuthService',
-    'AppConfigService'
+    'AppConfigService',
+    'RetentionService'
 ]

--- a/agent/services/app_config_service.py
+++ b/agent/services/app_config_service.py
@@ -11,8 +11,8 @@ from models import AppSetting, AppSettingUpdate, AppConfigSnapshot, TaskIssueCon
 logger = logging.getLogger(__name__)
 
 TASK_ISSUE_LOOKBACK_KEY = "task_issue_summary.lookback_hours"
-RETENTION_TASK_EVENTS_DAYS_KEY = "data_retention.task_events_days"
-RETENTION_TASK_PROGRESS_DAYS_KEY = "data_retention.task_progress_days"
+RETENTION_TASK_SUCCESSFUL_DAYS_KEY = "data_retention.task_successful_days"
+RETENTION_TASK_UNSUCCESSFUL_DAYS_KEY = "data_retention.task_unsuccessful_days"
 RETENTION_WORKER_EVENTS_DAYS_KEY = "data_retention.worker_events_days"
 RETENTION_WORKFLOW_EXECUTIONS_DAYS_KEY = "data_retention.workflow_executions_days"
 RETENTION_TASK_DAILY_STATS_DAYS_KEY = "data_retention.task_daily_stats_days"
@@ -28,20 +28,20 @@ DEFAULT_SETTING_DEFINITIONS: Dict[str, Dict[str, Any]] = {
         "min": 1,
         "max": 168,
     },
-    RETENTION_TASK_EVENTS_DAYS_KEY: {
-        "default": 30,
+    RETENTION_TASK_SUCCESSFUL_DAYS_KEY: {
+        "default": 14,
         "value_type": "number",
-        "label": "Task event retention (days)",
-        "description": "How long raw task event history should be kept before cleanup.",
+        "label": "Successful task retention (days)",
+        "description": "How long successful task records and related events should be kept before cleanup.",
         "category": "data_retention",
         "min": 1,
         "max": 3650,
     },
-    RETENTION_TASK_PROGRESS_DAYS_KEY: {
-        "default": 14,
+    RETENTION_TASK_UNSUCCESSFUL_DAYS_KEY: {
+        "default": 30,
         "value_type": "number",
-        "label": "Task progress retention (days)",
-        "description": "How long detailed task progress events should be kept before cleanup.",
+        "label": "Unsuccessful task retention (days)",
+        "description": "How long failed, retried, revoked, orphaned, or otherwise non-successful task records and related events should be kept before cleanup.",
         "category": "data_retention",
         "min": 1,
         "max": 3650,
@@ -290,8 +290,8 @@ class AppConfigService:
         """Return normalized data retention configuration."""
         self.ensure_defaults()
         return DataRetentionConfig(
-            task_events_days=self._get_bounded_number_setting(RETENTION_TASK_EVENTS_DAYS_KEY),
-            task_progress_days=self._get_bounded_number_setting(RETENTION_TASK_PROGRESS_DAYS_KEY),
+            task_successful_days=self._get_bounded_number_setting(RETENTION_TASK_SUCCESSFUL_DAYS_KEY),
+            task_unsuccessful_days=self._get_bounded_number_setting(RETENTION_TASK_UNSUCCESSFUL_DAYS_KEY),
             worker_events_days=self._get_bounded_number_setting(RETENTION_WORKER_EVENTS_DAYS_KEY),
             workflow_executions_days=self._get_bounded_number_setting(RETENTION_WORKFLOW_EXECUTIONS_DAYS_KEY),
             task_daily_stats_days=self._get_bounded_number_setting(RETENTION_TASK_DAILY_STATS_DAYS_KEY),

--- a/agent/services/app_config_service.py
+++ b/agent/services/app_config_service.py
@@ -6,11 +6,17 @@ from typing import Any, Dict, List, Optional, Tuple
 from sqlalchemy.orm import Session
 
 from database import AppSettingDB
-from models import AppSetting, AppSettingUpdate, AppConfigSnapshot, TaskIssueConfig
+from models import AppSetting, AppSettingUpdate, AppConfigSnapshot, TaskIssueConfig, DataRetentionConfig
 
 logger = logging.getLogger(__name__)
 
 TASK_ISSUE_LOOKBACK_KEY = "task_issue_summary.lookback_hours"
+RETENTION_TASK_EVENTS_DAYS_KEY = "data_retention.task_events_days"
+RETENTION_TASK_PROGRESS_DAYS_KEY = "data_retention.task_progress_days"
+RETENTION_WORKER_EVENTS_DAYS_KEY = "data_retention.worker_events_days"
+RETENTION_WORKFLOW_EXECUTIONS_DAYS_KEY = "data_retention.workflow_executions_days"
+RETENTION_TASK_DAILY_STATS_DAYS_KEY = "data_retention.task_daily_stats_days"
+RETENTION_INACTIVE_SESSIONS_DAYS_KEY = "data_retention.inactive_sessions_days"
 
 DEFAULT_SETTING_DEFINITIONS: Dict[str, Dict[str, Any]] = {
     TASK_ISSUE_LOOKBACK_KEY: {
@@ -20,7 +26,61 @@ DEFAULT_SETTING_DEFINITIONS: Dict[str, Dict[str, Any]] = {
         "description": "Number of hours of failed tasks to surface in the dashboard issue summary.",
         "category": "task_issue_summary",
         "min": 1,
-        "max": 168,  # one week window cap to keep queries bounded
+        "max": 168,
+    },
+    RETENTION_TASK_EVENTS_DAYS_KEY: {
+        "default": 30,
+        "value_type": "number",
+        "label": "Task event retention (days)",
+        "description": "How long raw task event history should be kept before cleanup.",
+        "category": "data_retention",
+        "min": 1,
+        "max": 3650,
+    },
+    RETENTION_TASK_PROGRESS_DAYS_KEY: {
+        "default": 14,
+        "value_type": "number",
+        "label": "Task progress retention (days)",
+        "description": "How long detailed task progress events should be kept before cleanup.",
+        "category": "data_retention",
+        "min": 1,
+        "max": 3650,
+    },
+    RETENTION_WORKER_EVENTS_DAYS_KEY: {
+        "default": 30,
+        "value_type": "number",
+        "label": "Worker event retention (days)",
+        "description": "How long worker heartbeat and lifecycle events should be kept before cleanup.",
+        "category": "data_retention",
+        "min": 1,
+        "max": 3650,
+    },
+    RETENTION_WORKFLOW_EXECUTIONS_DAYS_KEY: {
+        "default": 30,
+        "value_type": "number",
+        "label": "Workflow execution retention (days)",
+        "description": "How long workflow execution logs should be kept before cleanup.",
+        "category": "data_retention",
+        "min": 1,
+        "max": 3650,
+    },
+    RETENTION_TASK_DAILY_STATS_DAYS_KEY: {
+        "default": 365,
+        "value_type": "number",
+        "label": "Task daily stats retention (days)",
+        "description": "How long aggregated daily task statistics should be kept before cleanup.",
+        "category": "data_retention",
+        "min": 1,
+        "max": 3650,
+    },
+    RETENTION_INACTIVE_SESSIONS_DAYS_KEY: {
+        "default": 30,
+        "value_type": "number",
+        "label": "Inactive session retention (days)",
+        "description": "How long inactive user sessions should be kept before cleanup.",
+        "category": "data_retention",
+        "min": 1,
+        "max": 3650,
     },
 }
 
@@ -212,10 +272,37 @@ class AppConfigService:
             numeric_value = min(max_value, numeric_value)
         return numeric_value
 
+    def _get_bounded_number_setting(self, key: str) -> int:
+        definition = DEFAULT_SETTING_DEFINITIONS[key]
+        value = self.get_setting_value(key, definition["default"])
+        try:
+            normalized, _ = self._normalize_number(value)
+            numeric_value = int(normalized)
+        except ValueError:
+            numeric_value = definition["default"]
+        numeric_value = max(definition.get("min", 1), numeric_value)
+        max_value = definition.get("max")
+        if max_value is not None:
+            numeric_value = min(max_value, numeric_value)
+        return numeric_value
+
+    def get_data_retention_config(self) -> DataRetentionConfig:
+        """Return normalized data retention configuration."""
+        self.ensure_defaults()
+        return DataRetentionConfig(
+            task_events_days=self._get_bounded_number_setting(RETENTION_TASK_EVENTS_DAYS_KEY),
+            task_progress_days=self._get_bounded_number_setting(RETENTION_TASK_PROGRESS_DAYS_KEY),
+            worker_events_days=self._get_bounded_number_setting(RETENTION_WORKER_EVENTS_DAYS_KEY),
+            workflow_executions_days=self._get_bounded_number_setting(RETENTION_WORKFLOW_EXECUTIONS_DAYS_KEY),
+            task_daily_stats_days=self._get_bounded_number_setting(RETENTION_TASK_DAILY_STATS_DAYS_KEY),
+            inactive_sessions_days=self._get_bounded_number_setting(RETENTION_INACTIVE_SESSIONS_DAYS_KEY),
+        )
+
     def get_config_snapshot(self) -> AppConfigSnapshot:
         """Return grouped configuration for clients."""
         self.ensure_defaults()
         lookback_hours = self.get_task_issue_lookback_hours()
         return AppConfigSnapshot(
-            task_issue_summary=TaskIssueConfig(lookback_hours=lookback_hours)
+            task_issue_summary=TaskIssueConfig(lookback_hours=lookback_hours),
+            data_retention=self.get_data_retention_config(),
         )

--- a/agent/services/retention_service.py
+++ b/agent/services/retention_service.py
@@ -6,12 +6,17 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Callable, List
 
+from sqlalchemy import and_, not_, select
 from sqlalchemy.orm import Session
 
+from constants import EventType
 from database import (
     TaskDailyStatsDB,
     TaskEventDB,
+    TaskLatestDB,
     TaskProgressDB,
+    TaskProgressLatestDB,
+    TaskStepsDB,
     UserSessionDB,
     WorkerEventDB,
     WorkflowExecutionDB,
@@ -85,18 +90,107 @@ def _delete_daily_stats(session: Session, cutoff: datetime, dry_run: bool) -> in
     return query.delete(synchronize_session=False)
 
 
+def _successful_task_filter(model):
+    return and_(
+        model.event_type == EventType.TASK_SUCCEEDED,
+        model.is_orphan.is_(False),
+    )
+
+
+def _expired_task_family_cleanup(model, time_column: str, successful: bool):
+    def apply(session: Session, cutoff: datetime, dry_run: bool) -> int:
+        latest_query = session.query(TaskLatestDB.task_id).filter(TaskLatestDB.timestamp < cutoff)
+        if successful:
+            latest_query = latest_query.filter(_successful_task_filter(TaskLatestDB))
+        else:
+            latest_query = latest_query.filter(not_(_successful_task_filter(TaskLatestDB)))
+        expired_task_ids = latest_query.subquery()
+
+        query = session.query(model).filter(
+            getattr(model, time_column) < cutoff,
+            model.task_id.in_(select(expired_task_ids.c.task_id)),
+        )
+        if dry_run:
+            return query.count()
+        return query.delete(synchronize_session=False)
+
+    return apply
+
+
+def _expired_task_latest_cleanup(successful: bool):
+    def apply(session: Session, cutoff: datetime, dry_run: bool) -> int:
+        query = session.query(TaskLatestDB).filter(TaskLatestDB.timestamp < cutoff)
+        if successful:
+            query = query.filter(_successful_task_filter(TaskLatestDB))
+        else:
+            query = query.filter(not_(_successful_task_filter(TaskLatestDB)))
+        if dry_run:
+            return query.count()
+        return query.delete(synchronize_session=False)
+
+    return apply
+
+
 RETENTION_TARGETS: List[RetentionTarget] = [
     RetentionTarget(
-        key="task_events",
-        label="Task events",
-        retention_days=lambda policy: policy.task_events_days,
-        apply=_delete_by_datetime(TaskEventDB, "timestamp"),
+        key="task_events_successful",
+        label="Successful task events",
+        retention_days=lambda policy: policy.task_successful_days,
+        apply=_expired_task_family_cleanup(TaskEventDB, "timestamp", True),
     ),
     RetentionTarget(
-        key="task_progress",
-        label="Task progress events",
-        retention_days=lambda policy: policy.task_progress_days,
-        apply=_delete_by_datetime(TaskProgressDB, "timestamp"),
+        key="task_events_unsuccessful",
+        label="Unsuccessful task events",
+        retention_days=lambda policy: policy.task_unsuccessful_days,
+        apply=_expired_task_family_cleanup(TaskEventDB, "timestamp", False),
+    ),
+    RetentionTarget(
+        key="task_progress_successful",
+        label="Successful task progress events",
+        retention_days=lambda policy: policy.task_successful_days,
+        apply=_expired_task_family_cleanup(TaskProgressDB, "timestamp", True),
+    ),
+    RetentionTarget(
+        key="task_progress_unsuccessful",
+        label="Unsuccessful task progress events",
+        retention_days=lambda policy: policy.task_unsuccessful_days,
+        apply=_expired_task_family_cleanup(TaskProgressDB, "timestamp", False),
+    ),
+    RetentionTarget(
+        key="task_progress_latest_successful",
+        label="Successful task progress snapshots",
+        retention_days=lambda policy: policy.task_successful_days,
+        apply=_expired_task_family_cleanup(TaskProgressLatestDB, "updated_at", True),
+    ),
+    RetentionTarget(
+        key="task_progress_latest_unsuccessful",
+        label="Unsuccessful task progress snapshots",
+        retention_days=lambda policy: policy.task_unsuccessful_days,
+        apply=_expired_task_family_cleanup(TaskProgressLatestDB, "updated_at", False),
+    ),
+    RetentionTarget(
+        key="task_steps_successful",
+        label="Successful task step definitions",
+        retention_days=lambda policy: policy.task_successful_days,
+        apply=_expired_task_family_cleanup(TaskStepsDB, "defined_at", True),
+    ),
+    RetentionTarget(
+        key="task_steps_unsuccessful",
+        label="Unsuccessful task step definitions",
+        retention_days=lambda policy: policy.task_unsuccessful_days,
+        apply=_expired_task_family_cleanup(TaskStepsDB, "defined_at", False),
+    ),
+    RetentionTarget(
+        key="task_latest_successful",
+        label="Successful task snapshots",
+        retention_days=lambda policy: policy.task_successful_days,
+        apply=_expired_task_latest_cleanup(True),
+    ),
+    RetentionTarget(
+        key="task_latest_unsuccessful",
+        label="Unsuccessful task snapshots",
+        retention_days=lambda policy: policy.task_unsuccessful_days,
+        apply=_expired_task_latest_cleanup(False),
     ),
     RetentionTarget(
         key="worker_events",

--- a/agent/services/retention_service.py
+++ b/agent/services/retention_service.py
@@ -1,0 +1,125 @@
+"""Retention policy cleanup service for operational database tables."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable, List
+
+from sqlalchemy.orm import Session
+
+from database import (
+    TaskDailyStatsDB,
+    TaskEventDB,
+    TaskProgressDB,
+    UserSessionDB,
+    WorkerEventDB,
+    WorkflowExecutionDB,
+)
+from models import DataRetentionConfig, RetentionCleanupResponse, RetentionCleanupResult
+from services.app_config_service import AppConfigService
+
+
+@dataclass(frozen=True)
+class RetentionTarget:
+    key: str
+    label: str
+    retention_days: Callable[[DataRetentionConfig], int]
+    apply: Callable[[Session, datetime, bool], int]
+
+
+class RetentionService:
+    """Calculate and execute retention cleanup against persisted data."""
+
+    def __init__(self, session: Session):
+        self.session = session
+        self.config_service = AppConfigService(session)
+
+    def get_policy(self) -> DataRetentionConfig:
+        return self.config_service.get_data_retention_config()
+
+    def cleanup(self, *, dry_run: bool = False) -> RetentionCleanupResponse:
+        policy = self.get_policy()
+        now = datetime.now(timezone.utc)
+        results: List[RetentionCleanupResult] = []
+
+        for target in RETENTION_TARGETS:
+            retention_days = target.retention_days(policy)
+            cutoff = now - timedelta(days=retention_days)
+            deleted = target.apply(self.session, cutoff, dry_run)
+            results.append(
+                RetentionCleanupResult(
+                    key=target.key,
+                    label=target.label,
+                    retention_days=retention_days,
+                    deleted=deleted,
+                )
+            )
+
+        if dry_run:
+            self.session.rollback()
+        else:
+            self.session.commit()
+
+        return RetentionCleanupResponse(
+            dry_run=dry_run,
+            total_deleted=sum(item.deleted for item in results),
+            results=results,
+        )
+
+
+def _delete_by_datetime(model, column_name: str):
+    def apply(session: Session, cutoff: datetime, dry_run: bool) -> int:
+        query = session.query(model).filter(getattr(model, column_name) < cutoff)
+        if dry_run:
+            return query.count()
+        return query.delete(synchronize_session=False)
+
+    return apply
+
+
+def _delete_daily_stats(session: Session, cutoff: datetime, dry_run: bool) -> int:
+    query = session.query(TaskDailyStatsDB).filter(TaskDailyStatsDB.date < cutoff.date())
+    if dry_run:
+        return query.count()
+    return query.delete(synchronize_session=False)
+
+
+RETENTION_TARGETS: List[RetentionTarget] = [
+    RetentionTarget(
+        key="task_events",
+        label="Task events",
+        retention_days=lambda policy: policy.task_events_days,
+        apply=_delete_by_datetime(TaskEventDB, "timestamp"),
+    ),
+    RetentionTarget(
+        key="task_progress",
+        label="Task progress events",
+        retention_days=lambda policy: policy.task_progress_days,
+        apply=_delete_by_datetime(TaskProgressDB, "timestamp"),
+    ),
+    RetentionTarget(
+        key="worker_events",
+        label="Worker events",
+        retention_days=lambda policy: policy.worker_events_days,
+        apply=_delete_by_datetime(WorkerEventDB, "timestamp"),
+    ),
+    RetentionTarget(
+        key="workflow_executions",
+        label="Workflow executions",
+        retention_days=lambda policy: policy.workflow_executions_days,
+        apply=_delete_by_datetime(WorkflowExecutionDB, "triggered_at"),
+    ),
+    RetentionTarget(
+        key="task_daily_stats",
+        label="Task daily stats",
+        retention_days=lambda policy: policy.task_daily_stats_days,
+        apply=_delete_daily_stats,
+    ),
+    RetentionTarget(
+        key="inactive_sessions",
+        label="Inactive sessions",
+        retention_days=lambda policy: policy.inactive_sessions_days,
+        apply=_delete_by_datetime(UserSessionDB, "last_active"),
+    ),
+]

--- a/agent/tests/unit/test_app_config_service.py
+++ b/agent/tests/unit/test_app_config_service.py
@@ -3,7 +3,8 @@ import unittest
 from services.app_config_service import (
     AppConfigService,
     TASK_ISSUE_LOOKBACK_KEY,
-    RETENTION_TASK_EVENTS_DAYS_KEY,
+    RETENTION_TASK_SUCCESSFUL_DAYS_KEY,
+    RETENTION_TASK_UNSUCCESSFUL_DAYS_KEY,
 )
 from models import AppSettingUpdate
 from tests.base import DatabaseTestCase
@@ -43,15 +44,21 @@ class TestAppConfigService(DatabaseTestCase):
 
     def test_get_data_retention_config_uses_defaults_and_overrides(self):
         defaults = self.service.get_data_retention_config()
-        self.assertEqual(defaults.task_events_days, 30)
+        self.assertEqual(defaults.task_successful_days, 14)
+        self.assertEqual(defaults.task_unsuccessful_days, 30)
         self.assertEqual(defaults.inactive_sessions_days, 30)
 
         self.service.upsert_setting(
-            RETENTION_TASK_EVENTS_DAYS_KEY,
+            RETENTION_TASK_SUCCESSFUL_DAYS_KEY,
+            AppSettingUpdate(value=7, value_type="number"),
+        )
+        self.service.upsert_setting(
+            RETENTION_TASK_UNSUCCESSFUL_DAYS_KEY,
             AppSettingUpdate(value=45, value_type="number"),
         )
         updated = self.service.get_data_retention_config()
-        self.assertEqual(updated.task_events_days, 45)
+        self.assertEqual(updated.task_successful_days, 7)
+        self.assertEqual(updated.task_unsuccessful_days, 45)
 
 
 if __name__ == "__main__":

--- a/agent/tests/unit/test_app_config_service.py
+++ b/agent/tests/unit/test_app_config_service.py
@@ -3,6 +3,7 @@ import unittest
 from services.app_config_service import (
     AppConfigService,
     TASK_ISSUE_LOOKBACK_KEY,
+    RETENTION_TASK_EVENTS_DAYS_KEY,
 )
 from models import AppSettingUpdate
 from tests.base import DatabaseTestCase
@@ -39,6 +40,18 @@ class TestAppConfigService(DatabaseTestCase):
                 TASK_ISSUE_LOOKBACK_KEY,
                 AppSettingUpdate(value=0, value_type="number"),
             )
+
+    def test_get_data_retention_config_uses_defaults_and_overrides(self):
+        defaults = self.service.get_data_retention_config()
+        self.assertEqual(defaults.task_events_days, 30)
+        self.assertEqual(defaults.inactive_sessions_days, 30)
+
+        self.service.upsert_setting(
+            RETENTION_TASK_EVENTS_DAYS_KEY,
+            AppSettingUpdate(value=45, value_type="number"),
+        )
+        updated = self.service.get_data_retention_config()
+        self.assertEqual(updated.task_events_days, 45)
 
 
 if __name__ == "__main__":

--- a/agent/tests/unit/test_retention_service.py
+++ b/agent/tests/unit/test_retention_service.py
@@ -1,7 +1,16 @@
 import unittest
 from datetime import date, datetime, timedelta, timezone
 
-from database import TaskDailyStatsDB, TaskProgressDB, UserSessionDB, WorkflowExecutionDB
+from constants import EventType
+from database import (
+    TaskDailyStatsDB,
+    TaskLatestDB,
+    TaskProgressDB,
+    TaskProgressLatestDB,
+    TaskStepsDB,
+    UserSessionDB,
+    WorkflowExecutionDB,
+)
 from services.retention_service import RetentionService
 from tests.base import DatabaseTestCase
 
@@ -11,32 +20,60 @@ class TestRetentionService(DatabaseTestCase):
         super().setUp()
         self.service = RetentionService(self.session)
 
-    def test_cleanup_dry_run_counts_without_deleting(self):
-        now = datetime.now(timezone.utc)
-        self.create_task_event_db(task_id="old-task", timestamp=now - timedelta(days=45))
-        self.create_task_event_db(task_id="new-task", timestamp=now - timedelta(days=2))
-        self.create_worker_event_db(hostname="old-worker", timestamp=now - timedelta(days=45))
+    def _create_task_family(self, *, task_id: str, age_days: int, event_type: str, is_orphan: bool = False):
+        timestamp = datetime.now(timezone.utc) - timedelta(days=age_days)
+        self.create_task_event_db(
+            task_id=task_id,
+            task_name=f"tasks.{task_id}",
+            event_type=event_type,
+            timestamp=timestamp,
+            is_orphan=is_orphan,
+        )
+        self.session.add(
+            TaskLatestDB(
+                task_id=task_id,
+                event_id=1,
+                task_name=f"tasks.{task_id}",
+                event_type=event_type,
+                timestamp=timestamp,
+                is_orphan=is_orphan,
+                resolved=False,
+                has_retries=False,
+                retry_count=0,
+            )
+        )
+        self.session.add(TaskProgressDB(task_id=task_id, task_name=f"tasks.{task_id}", progress=0.5, timestamp=timestamp))
+        self.session.add(TaskProgressLatestDB(task_id=task_id, task_name=f"tasks.{task_id}", progress=0.5, updated_at=timestamp))
+        self.session.add(TaskStepsDB(task_id=task_id, task_name=f"tasks.{task_id}", steps=[{"key": "one"}], defined_at=timestamp))
 
-        self.session.add(TaskProgressDB(task_id="old-task", task_name="tasks.old", progress=0.1, timestamp=now - timedelta(days=30)))
+    def test_cleanup_dry_run_counts_unsuccessful_tasks_separately(self):
+        now = datetime.now(timezone.utc)
+        self._create_task_family(task_id="old-success", age_days=20, event_type=EventType.TASK_SUCCEEDED)
+        self._create_task_family(task_id="old-failed", age_days=20, event_type=EventType.TASK_FAILED)
+        self.create_worker_event_db(hostname="old-worker", timestamp=now - timedelta(days=45))
         self.session.add(WorkflowExecutionDB(workflow_id="wf-1", trigger_type="task.failed", trigger_event={}, status="completed", triggered_at=now - timedelta(days=40)))
         self.session.add(TaskDailyStatsDB(task_name="tasks.old", date=date.today() - timedelta(days=400)))
         self.session.add(UserSessionDB(session_id="session-old", last_active=now - timedelta(days=31), created_at=now - timedelta(days=31), preferences={}))
         self.session.commit()
 
         result = self.service.cleanup(dry_run=True)
+        counts = {item.key: item.deleted for item in result.results}
 
         self.assertTrue(result.dry_run)
-        self.assertEqual(result.total_deleted, 6)
-        self.assertEqual(self.session.query(TaskProgressDB).count(), 1)
+        self.assertEqual(counts["task_events_successful"], 1)
+        self.assertEqual(counts["task_events_unsuccessful"], 0)
+        self.assertEqual(counts["task_progress_successful"], 1)
+        self.assertEqual(counts["task_latest_successful"], 1)
+        self.assertEqual(counts["task_latest_unsuccessful"], 0)
+        self.assertEqual(self.session.query(TaskProgressDB).count(), 2)
         self.assertEqual(self.session.query(WorkflowExecutionDB).count(), 1)
         self.assertEqual(self.session.query(UserSessionDB).count(), 1)
 
-    def test_cleanup_deletes_rows_older_than_policy(self):
+    def test_cleanup_deletes_successful_tasks_before_unsuccessful_ones(self):
         now = datetime.now(timezone.utc)
-        self.create_task_event_db(task_id="old-task", timestamp=now - timedelta(days=45))
-        self.create_task_event_db(task_id="new-task", timestamp=now - timedelta(days=1))
-        self.session.add(TaskProgressDB(task_id="old-task", task_name="tasks.old", progress=0.2, timestamp=now - timedelta(days=20)))
-        self.session.add(TaskProgressDB(task_id="new-task", task_name="tasks.new", progress=0.8, timestamp=now - timedelta(days=1)))
+        self._create_task_family(task_id="old-success", age_days=20, event_type=EventType.TASK_SUCCEEDED)
+        self._create_task_family(task_id="old-failed", age_days=20, event_type=EventType.TASK_FAILED)
+        self._create_task_family(task_id="very-old-failed", age_days=45, event_type=EventType.TASK_FAILED)
         self.session.add(UserSessionDB(session_id="session-old", last_active=now - timedelta(days=60), created_at=now - timedelta(days=60), preferences={}))
         self.session.add(UserSessionDB(session_id="session-new", last_active=now - timedelta(days=1), created_at=now - timedelta(days=1), preferences={}))
         self.session.commit()
@@ -44,11 +81,14 @@ class TestRetentionService(DatabaseTestCase):
         result = self.service.cleanup(dry_run=False)
 
         self.assertFalse(result.dry_run)
-        self.assertEqual(self.get_task_events_by_id("old-task"), [])
-        self.assertEqual(len(self.get_task_events_by_id("new-task")), 1)
+        self.assertEqual(self.get_task_events_by_id("old-success"), [])
+        self.assertEqual(len(self.get_task_events_by_id("old-failed")), 1)
+        self.assertEqual(self.get_task_events_by_id("very-old-failed"), [])
+        remaining_latest_ids = {row.task_id for row in self.session.query(TaskLatestDB).all()}
+        self.assertEqual(remaining_latest_ids, {"old-failed"})
         self.assertEqual(self.session.query(TaskProgressDB).count(), 1)
         self.assertEqual(self.session.query(UserSessionDB).count(), 1)
-        self.assertGreaterEqual(result.total_deleted, 3)
+        self.assertGreaterEqual(result.total_deleted, 11)
 
 
 if __name__ == "__main__":

--- a/agent/tests/unit/test_retention_service.py
+++ b/agent/tests/unit/test_retention_service.py
@@ -1,0 +1,55 @@
+import unittest
+from datetime import date, datetime, timedelta, timezone
+
+from database import TaskDailyStatsDB, TaskProgressDB, UserSessionDB, WorkflowExecutionDB
+from services.retention_service import RetentionService
+from tests.base import DatabaseTestCase
+
+
+class TestRetentionService(DatabaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.service = RetentionService(self.session)
+
+    def test_cleanup_dry_run_counts_without_deleting(self):
+        now = datetime.now(timezone.utc)
+        self.create_task_event_db(task_id="old-task", timestamp=now - timedelta(days=45))
+        self.create_task_event_db(task_id="new-task", timestamp=now - timedelta(days=2))
+        self.create_worker_event_db(hostname="old-worker", timestamp=now - timedelta(days=45))
+
+        self.session.add(TaskProgressDB(task_id="old-task", task_name="tasks.old", progress=0.1, timestamp=now - timedelta(days=30)))
+        self.session.add(WorkflowExecutionDB(workflow_id="wf-1", trigger_type="task.failed", trigger_event={}, status="completed", triggered_at=now - timedelta(days=40)))
+        self.session.add(TaskDailyStatsDB(task_name="tasks.old", date=date.today() - timedelta(days=400)))
+        self.session.add(UserSessionDB(session_id="session-old", last_active=now - timedelta(days=31), created_at=now - timedelta(days=31), preferences={}))
+        self.session.commit()
+
+        result = self.service.cleanup(dry_run=True)
+
+        self.assertTrue(result.dry_run)
+        self.assertEqual(result.total_deleted, 6)
+        self.assertEqual(self.session.query(TaskProgressDB).count(), 1)
+        self.assertEqual(self.session.query(WorkflowExecutionDB).count(), 1)
+        self.assertEqual(self.session.query(UserSessionDB).count(), 1)
+
+    def test_cleanup_deletes_rows_older_than_policy(self):
+        now = datetime.now(timezone.utc)
+        self.create_task_event_db(task_id="old-task", timestamp=now - timedelta(days=45))
+        self.create_task_event_db(task_id="new-task", timestamp=now - timedelta(days=1))
+        self.session.add(TaskProgressDB(task_id="old-task", task_name="tasks.old", progress=0.2, timestamp=now - timedelta(days=20)))
+        self.session.add(TaskProgressDB(task_id="new-task", task_name="tasks.new", progress=0.8, timestamp=now - timedelta(days=1)))
+        self.session.add(UserSessionDB(session_id="session-old", last_active=now - timedelta(days=60), created_at=now - timedelta(days=60), preferences={}))
+        self.session.add(UserSessionDB(session_id="session-new", last_active=now - timedelta(days=1), created_at=now - timedelta(days=1), preferences={}))
+        self.session.commit()
+
+        result = self.service.cleanup(dry_run=False)
+
+        self.assertFalse(result.dry_run)
+        self.assertEqual(self.get_task_events_by_id("old-task"), [])
+        self.assertEqual(len(self.get_task_events_by_id("new-task")), 1)
+        self.assertEqual(self.session.query(TaskProgressDB).count(), 1)
+        self.assertEqual(self.session.query(UserSessionDB).count(), 1)
+        self.assertGreaterEqual(result.total_deleted, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/app/composables/useDateTimeFormatters.ts
+++ b/frontend/app/composables/useDateTimeFormatters.ts
@@ -1,6 +1,8 @@
 // ============================================================================
 // ============================================================================
 
+const DATE_LOCALE = 'en-GB'
+
 const isToday = (date: Date): boolean => {
   const now = new Date()
   return (
@@ -66,7 +68,7 @@ export const formatSmartTime = (timestamp: string, currentTime?: Date): SmartTim
   const seconds = Math.floor(diff / 1000)
 
   // Time always with seconds (HH:mm:ss format)
-  const timeStr = date.toLocaleTimeString('en-US', {
+  const timeStr = date.toLocaleTimeString(DATE_LOCALE, {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
@@ -74,14 +76,14 @@ export const formatSmartTime = (timestamp: string, currentTime?: Date): SmartTim
   })
 
   // Full datetime for tooltip
-  const fullDateTime = date.toLocaleString('en-US', {
+  const fullDateTime = date.toLocaleString(DATE_LOCALE, {
     year: 'numeric',
-    month: 'long',
-    day: 'numeric',
+    month: 'short',
+    day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
-    hour12: true
+    hour12: false
   })
 
   // Determine context label and color based on recency
@@ -116,17 +118,17 @@ export const formatSmartTime = (timestamp: string, currentTime?: Date): SmartTim
     colorClass = 'text-gray-500'
   } else if (isThisWeek(date)) {
     // This week (Mon, Tue, etc.)
-    contextLabel = date.toLocaleDateString('en-US', { weekday: 'short' })
+    contextLabel = date.toLocaleDateString(DATE_LOCALE, { weekday: 'short' })
     colorClass = 'text-gray-500'
   } else if (isThisYear(date)) {
     // This year (Jan 15, Feb 3, etc.)
-    contextLabel = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    contextLabel = date.toLocaleDateString(DATE_LOCALE, { day: '2-digit', month: 'short' })
     colorClass = 'text-gray-500'
   } else {
     // Older (Jan 15, 2024)
-    contextLabel = date.toLocaleDateString('en-US', {
+    contextLabel = date.toLocaleDateString(DATE_LOCALE, {
+      day: '2-digit',
       month: 'short',
-      day: 'numeric',
       year: 'numeric'
     })
     colorClass = 'text-gray-600'
@@ -148,7 +150,7 @@ export const formatSmartTime = (timestamp: string, currentTime?: Date): SmartTim
 export const formatTime = (timestamp: string): string => {
   if (!timestamp) return '-'
   const date = new Date(timestamp)
-  return date.toLocaleTimeString('en-US', {
+  return date.toLocaleTimeString(DATE_LOCALE, {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
@@ -176,7 +178,7 @@ export const formatTimestamp = (timestamp: string): string => {
 
   if (diff < 60000) return `${Math.floor(diff / 1000)}s ago`
   if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`
-  return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })
+  return date.toLocaleTimeString(DATE_LOCALE, { hour: '2-digit', minute: '2-digit', hour12: false })
 }
 
 export const formatDuration = (seconds: number): string => {

--- a/frontend/app/pages/settings/workspace.vue
+++ b/frontend/app/pages/settings/workspace.vue
@@ -23,6 +23,93 @@
       </section>
 
       <section class="rounded-2xl border border-border-subtle bg-background-surface p-6 shadow-sm">
+        <div class="space-y-5">
+          <div>
+            <h2 class="text-base font-semibold text-text-primary">Data retention</h2>
+            <p class="mt-1 max-w-2xl text-sm text-text-secondary">
+              Keep successful task history short, and hold onto failed or retried task history longer for audit and retry analysis.
+            </p>
+          </div>
+
+          <Alert v-if="loadError" variant="destructive">
+            <span>{{ loadError }}</span>
+          </Alert>
+
+          <form class="grid gap-4 md:grid-cols-2" @submit.prevent="saveRetention">
+            <div v-for="field in retentionFields" :key="field.key" class="space-y-2">
+              <Label :for="field.key">{{ field.label }}</Label>
+              <Input
+                :id="field.key"
+                v-model.number="retentionForm[field.key]"
+                type="number"
+                min="1"
+                max="3650"
+                :disabled="isSaving || isLoading"
+              />
+              <p class="text-xs text-text-secondary">{{ field.description }}</p>
+            </div>
+
+            <div class="md:col-span-2 flex flex-wrap items-center gap-3 pt-2">
+              <Button type="submit" :disabled="isSaving || isLoading">
+                {{ isSaving ? 'Saving…' : 'Save retention settings' }}
+              </Button>
+              <Button type="button" variant="outline" :disabled="isSaving || isLoading" @click="resetRetentionForm">
+                Reset
+              </Button>
+              <span v-if="saveMessage" class="text-sm text-text-secondary">{{ saveMessage }}</span>
+            </div>
+          </form>
+
+          <div class="rounded-2xl border border-border-subtle/80 bg-background-subtle p-4 space-y-4">
+            <div>
+              <h3 class="text-sm font-semibold text-text-primary">Cleanup</h3>
+              <p class="mt-1 text-sm text-text-secondary">
+                Preview what would be removed, then run cleanup when you are ready.
+              </p>
+            </div>
+
+            <div class="flex flex-wrap items-center gap-3">
+              <Button variant="outline" :disabled="cleanupRunning" @click="previewCleanup">
+                {{ cleanupRunning && cleanupMode === 'dry' ? 'Running preview…' : 'Preview cleanup' }}
+              </Button>
+              <Button :disabled="cleanupRunning" @click="runCleanup">
+                {{ cleanupRunning && cleanupMode === 'live' ? 'Running cleanup…' : 'Run cleanup now' }}
+              </Button>
+            </div>
+
+            <Alert v-if="cleanupError" variant="destructive">
+              <span>{{ cleanupError }}</span>
+            </Alert>
+
+            <div v-if="cleanupResult" class="space-y-3">
+              <p class="text-sm text-text-primary">
+                {{ cleanupResult.dry_run ? 'Preview' : 'Cleanup complete' }} — {{ cleanupResult.total_deleted }} rows
+                {{ cleanupResult.dry_run ? 'would be removed' : 'removed' }}.
+              </p>
+              <div class="overflow-x-auto">
+                <table class="min-w-full text-sm">
+                  <thead>
+                    <tr class="border-b border-border-subtle text-left text-text-secondary">
+                      <th class="py-2 pr-4 font-medium">Target</th>
+                      <th class="py-2 pr-4 font-medium">Days</th>
+                      <th class="py-2 font-medium">Rows</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="result in cleanupResult.results" :key="result.key" class="border-b border-border-subtle/60 last:border-0">
+                      <td class="py-2 pr-4 text-text-primary">{{ result.label }}</td>
+                      <td class="py-2 pr-4 text-text-secondary">{{ result.retention_days }}</td>
+                      <td class="py-2 text-text-secondary">{{ result.deleted }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-border-subtle bg-background-surface p-6 shadow-sm">
         <div class="space-y-4">
           <div>
             <h2 class="text-base font-semibold text-text-primary">Resources</h2>
@@ -72,9 +159,118 @@
 
 <script setup lang="ts">
 import { ArrowUpRight, Github, Sparkles } from 'lucide-vue-next'
+import { computed, onMounted, ref } from 'vue'
+import Alert from '~/components/alert/Alert.vue'
 import ThemeToggle from '~/components/ThemeToggle.vue'
 import WorkflowSlackConfigPanel from '~/components/workflows/WorkflowSlackConfigPanel.vue'
 import { Button } from '~/components/ui/button'
+import { Input } from '~/components/ui/input'
+import { Label } from '~/components/ui/label'
+import { useConfigStore } from '~/stores/config'
+import type { DataRetentionConfigDTO, RetentionCleanupResponseDTO } from '~/services/apiClient'
+
+const configStore = useConfigStore()
+
+const retentionFields: Array<{ key: keyof DataRetentionConfigDTO; label: string; description: string }> = [
+  {
+    key: 'task_successful_days',
+    label: 'Successful tasks',
+    description: 'How long to keep successful task snapshots, events, progress, and steps.',
+  },
+  {
+    key: 'task_unsuccessful_days',
+    label: 'Unsuccessful tasks',
+    description: 'How long to keep failed, retried, revoked, or orphaned task history.',
+  },
+  {
+    key: 'worker_events_days',
+    label: 'Worker events',
+    description: 'How long to keep worker lifecycle and status events.',
+  },
+  {
+    key: 'workflow_executions_days',
+    label: 'Workflow executions',
+    description: 'How long to keep workflow execution records.',
+  },
+  {
+    key: 'task_daily_stats_days',
+    label: 'Daily task stats',
+    description: 'How long to keep aggregated daily task statistics.',
+  },
+  {
+    key: 'inactive_sessions_days',
+    label: 'Inactive sessions',
+    description: 'How long to keep inactive anonymous sessions before cleanup.',
+  },
+]
+
+const retentionForm = ref<DataRetentionConfigDTO>({
+  task_successful_days: 14,
+  task_unsuccessful_days: 30,
+  worker_events_days: 30,
+  workflow_executions_days: 30,
+  task_daily_stats_days: 365,
+  inactive_sessions_days: 30,
+})
+const isSaving = ref(false)
+const saveMessage = ref('')
+const cleanupRunning = ref(false)
+const cleanupMode = ref<'dry' | 'live' | null>(null)
+const cleanupResult = ref<RetentionCleanupResponseDTO | null>(null)
+const cleanupError = ref('')
+
+const isLoading = computed(() => configStore.isLoading)
+const loadError = computed(() => configStore.error)
+
+function syncFormFromStore() {
+  retentionForm.value = { ...configStore.dataRetention }
+}
+
+function resetRetentionForm() {
+  syncFormFromStore()
+  saveMessage.value = ''
+}
+
+async function saveRetention() {
+  try {
+    isSaving.value = true
+    saveMessage.value = ''
+    await configStore.updateDataRetention(retentionForm.value)
+    saveMessage.value = 'Retention settings saved.'
+  } catch (err) {
+    saveMessage.value = err instanceof Error ? err.message : 'Failed to save retention settings.'
+  } finally {
+    isSaving.value = false
+  }
+}
+
+async function executeCleanup(dryRun: boolean) {
+  try {
+    cleanupRunning.value = true
+    cleanupMode.value = dryRun ? 'dry' : 'live'
+    cleanupError.value = ''
+    cleanupResult.value = await configStore.runRetentionCleanup(dryRun)
+  } catch (err) {
+    cleanupError.value = err instanceof Error ? err.message : 'Cleanup request failed.'
+  } finally {
+    cleanupRunning.value = false
+  }
+}
+
+async function previewCleanup() {
+  await executeCleanup(true)
+}
+
+async function runCleanup() {
+  await executeCleanup(false)
+}
+
+onMounted(async () => {
+  if (!configStore.config) {
+    await configStore.fetchConfig()
+  }
+  syncFormFromStore()
+})
 
 definePageMeta({
   middleware: [],

--- a/frontend/app/pages/settings/workspace.vue
+++ b/frontend/app/pages/settings/workspace.vue
@@ -72,9 +72,21 @@
               <Button variant="outline" :disabled="cleanupRunning" @click="previewCleanup">
                 {{ cleanupRunning && cleanupMode === 'dry' ? 'Running preview…' : 'Preview cleanup' }}
               </Button>
-              <Button :disabled="cleanupRunning" @click="runCleanup">
-                {{ cleanupRunning && cleanupMode === 'live' ? 'Running cleanup…' : 'Run cleanup now' }}
-              </Button>
+              <ConfirmationDialog
+                title="Run retention cleanup?"
+                description="This will permanently delete data that falls outside the configured retention windows. Preview cleanup first if you want to inspect the impact before deleting anything."
+                confirm-text="Run cleanup"
+                cancel-text="Cancel"
+                variant="destructive"
+                :is-loading="cleanupRunning && cleanupMode === 'live'"
+                @confirm="runCleanup"
+              >
+                <template #trigger>
+                  <Button :disabled="cleanupRunning">
+                    {{ cleanupRunning && cleanupMode === 'live' ? 'Running cleanup…' : 'Run cleanup now' }}
+                  </Button>
+                </template>
+              </ConfirmationDialog>
             </div>
 
             <Alert v-if="cleanupError" variant="destructive">
@@ -161,6 +173,7 @@
 import { ArrowUpRight, Github, Sparkles } from 'lucide-vue-next'
 import { computed, onMounted, ref } from 'vue'
 import Alert from '~/components/alert/Alert.vue'
+import ConfirmationDialog from '~/components/ConfirmationDialog.vue'
 import ThemeToggle from '~/components/ThemeToggle.vue'
 import WorkflowSlackConfigPanel from '~/components/workflows/WorkflowSlackConfigPanel.vue'
 import { Button } from '~/components/ui/button'

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -65,8 +65,31 @@ export interface TaskIssueConfigDTO {
   lookback_hours: number
 }
 
+export interface DataRetentionConfigDTO {
+  task_successful_days: number
+  task_unsuccessful_days: number
+  worker_events_days: number
+  workflow_executions_days: number
+  task_daily_stats_days: number
+  inactive_sessions_days: number
+}
+
+export interface RetentionCleanupResultDTO {
+  key: string
+  label: string
+  retention_days: number
+  deleted: number
+}
+
+export interface RetentionCleanupResponseDTO {
+  dry_run: boolean
+  total_deleted: number
+  results: RetentionCleanupResultDTO[]
+}
+
 export interface AppConfigSnapshotDTO {
   task_issue_summary: TaskIssueConfigDTO
+  data_retention: DataRetentionConfigDTO
 }
 
 export interface TaskStepDefinition {
@@ -203,6 +226,22 @@ class ApiService {
       path: `/api/config/settings/${encodeURIComponent(key)}`,
       method: 'DELETE'
     })
+  }
+
+  async getRetentionConfig(): Promise<DataRetentionConfigDTO> {
+    const response = await this.api.request({
+      path: '/api/config/retention',
+      method: 'GET'
+    })
+    return response.data
+  }
+
+  async runRetentionCleanup(dryRun = true): Promise<RetentionCleanupResponseDTO> {
+    const response = await this.api.request({
+      path: `/api/config/retention/cleanup?dry_run=${dryRun ? 'true' : 'false'}`,
+      method: 'POST'
+    })
+    return response.data
   }
 
   async getAuthConfig(): Promise<AuthConfigDTO> {

--- a/frontend/app/stores/config.ts
+++ b/frontend/app/stores/config.ts
@@ -4,11 +4,29 @@ import {
   useApiService,
   type AppConfigSnapshotDTO,
   type AppSettingDTO,
-  type AppSettingInput
+  type AppSettingInput,
+  type DataRetentionConfigDTO,
+  type RetentionCleanupResponseDTO,
 } from '~/services/apiClient'
 
 const TASK_ISSUE_LOOKBACK_DEFAULT = 24
 const TASK_ISSUE_LOOKBACK_KEY = 'task_issue_summary.lookback_hours'
+const RETENTION_DEFAULTS: DataRetentionConfigDTO = {
+  task_successful_days: 14,
+  task_unsuccessful_days: 30,
+  worker_events_days: 30,
+  workflow_executions_days: 30,
+  task_daily_stats_days: 365,
+  inactive_sessions_days: 30,
+}
+const RETENTION_KEYS = {
+  task_successful_days: 'data_retention.task_successful_days',
+  task_unsuccessful_days: 'data_retention.task_unsuccessful_days',
+  worker_events_days: 'data_retention.worker_events_days',
+  workflow_executions_days: 'data_retention.workflow_executions_days',
+  task_daily_stats_days: 'data_retention.task_daily_stats_days',
+  inactive_sessions_days: 'data_retention.inactive_sessions_days',
+} as const
 
 export const useConfigStore = defineStore('config', () => {
   const apiService = useApiService()
@@ -23,6 +41,17 @@ export const useConfigStore = defineStore('config', () => {
       acc[setting.key] = setting
       return acc
     }, {} as Record<string, AppSettingDTO>)
+  })
+
+  const dataRetention = computed<DataRetentionConfigDTO>(() => {
+    return config.value?.data_retention ?? {
+      task_successful_days: Number(settingsMap.value[RETENTION_KEYS.task_successful_days]?.value ?? RETENTION_DEFAULTS.task_successful_days),
+      task_unsuccessful_days: Number(settingsMap.value[RETENTION_KEYS.task_unsuccessful_days]?.value ?? RETENTION_DEFAULTS.task_unsuccessful_days),
+      worker_events_days: Number(settingsMap.value[RETENTION_KEYS.worker_events_days]?.value ?? RETENTION_DEFAULTS.worker_events_days),
+      workflow_executions_days: Number(settingsMap.value[RETENTION_KEYS.workflow_executions_days]?.value ?? RETENTION_DEFAULTS.workflow_executions_days),
+      task_daily_stats_days: Number(settingsMap.value[RETENTION_KEYS.task_daily_stats_days]?.value ?? RETENTION_DEFAULTS.task_daily_stats_days),
+      inactive_sessions_days: Number(settingsMap.value[RETENTION_KEYS.inactive_sessions_days]?.value ?? RETENTION_DEFAULTS.inactive_sessions_days),
+    }
   })
 
   const taskIssueLookbackHours = computed(() => {
@@ -63,12 +92,32 @@ export const useConfigStore = defineStore('config', () => {
       } else {
         settings.value.push(updated)
       }
+
       if (key === TASK_ISSUE_LOOKBACK_KEY) {
         config.value = {
-          ...(config.value ?? { task_issue_summary: { lookback_hours: TASK_ISSUE_LOOKBACK_DEFAULT } }),
+          ...(config.value ?? {
+            task_issue_summary: { lookback_hours: TASK_ISSUE_LOOKBACK_DEFAULT },
+            data_retention: dataRetention.value,
+          }),
           task_issue_summary: { lookback_hours: Number(updated.value) }
         }
       }
+
+      const retentionEntry = Object.entries(RETENTION_KEYS).find(([, settingKey]) => settingKey === key)
+      if (retentionEntry) {
+        const [retentionField] = retentionEntry as [keyof DataRetentionConfigDTO, string]
+        config.value = {
+          ...(config.value ?? {
+            task_issue_summary: { lookback_hours: TASK_ISSUE_LOOKBACK_DEFAULT },
+            data_retention: dataRetention.value,
+          }),
+          data_retention: {
+            ...dataRetention.value,
+            [retentionField]: Number(updated.value),
+          },
+        }
+      }
+
       return updated
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to save setting'
@@ -86,6 +135,18 @@ export const useConfigStore = defineStore('config', () => {
           task_issue_summary: { lookback_hours: TASK_ISSUE_LOOKBACK_DEFAULT }
         }
       }
+
+      const retentionEntry = Object.entries(RETENTION_KEYS).find(([, settingKey]) => settingKey === key)
+      if (retentionEntry && config.value) {
+        const [retentionField] = retentionEntry as [keyof DataRetentionConfigDTO, string]
+        config.value = {
+          ...config.value,
+          data_retention: {
+            ...config.value.data_retention,
+            [retentionField]: RETENTION_DEFAULTS[retentionField],
+          },
+        }
+      }
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to delete setting'
       throw err
@@ -100,16 +161,34 @@ export const useConfigStore = defineStore('config', () => {
     })
   }
 
+  async function updateDataRetention(values: DataRetentionConfigDTO) {
+    const entries = Object.entries(RETENTION_KEYS) as Array<[keyof DataRetentionConfigDTO, string]>
+    for (const [field, key] of entries) {
+      await upsertSetting(key, {
+        value: Number(values[field]),
+        value_type: 'number',
+        category: 'data_retention'
+      })
+    }
+  }
+
+  async function runRetentionCleanup(dryRun = true): Promise<RetentionCleanupResponseDTO> {
+    return apiService.runRetentionCleanup(dryRun)
+  }
+
   return {
     config: readonly(config),
     settings: readonly(settings),
     isLoading: readonly(isLoading),
     error: readonly(error),
     taskIssueLookbackHours,
+    dataRetention,
     settingsMap,
     fetchConfig,
     upsertSetting,
     deleteSetting,
     updateTaskIssueLookback,
+    updateDataRetention,
+    runRetentionCleanup,
   }
 })


### PR DESCRIPTION
## Summary
- add database-backed retention policy settings for task events, progress, worker events, workflow executions, daily stats, and inactive sessions
- add a retention cleanup service plus config API endpoints to inspect policy values and run cleanup as a dry-run or real deletion pass
- add unit coverage for retention policy normalization and cleanup behavior

## Testing
- python3 -m pytest agent/tests/unit/test_app_config_service.py agent/tests/unit/test_retention_service.py

Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable data retention policies for tasks, workflows, daily stats, and inactive sessions with bounded defaults.
  * New authenticated endpoints to view retention settings and trigger cleanup (preview dry-run supported, returns per-target counts and totals).
  * Retention config included in app snapshot; client API, store actions, and workspace settings UI to view/update and run cleanup.

* **Tests**
  * Added unit tests for config retrieval and both dry-run and real cleanup behaviors.

* **Style**
  * App date/time formatting updated to en-GB locale and 24‑hour display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->