### PR TITLE
Recommend next actions during incident triage

### DIFF
--- a/agent/api/task_routes.py
+++ b/agent/api/task_routes.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from services import TaskService, EnvironmentService, SessionService, AppConfigService, ProgressService
 from database import TaskEventDB
-from models import TaskEvent, TaskProgressSnapshot, RuntimeAnomaly
+from models import TaskEvent, TaskProgressSnapshot, RuntimeAnomaly, TriageRecommendation
 from database import ensure_utc_isoformat
 from config import Config
 from security.auth import AuthenticatedUser
@@ -193,6 +193,19 @@ def create_router(app_state) -> APIRouter:
             exclude_retried=not include_retried
         )
         return failed_tasks
+
+    @router.get("/tasks/triage-recommendations", response_model=List[TriageRecommendation])
+    async def get_triage_recommendations(
+        hours: Optional[int] = Query(default=None, ge=1, le=168),
+        limit: int = Query(default=100, ge=1, le=500),
+        session: Session = Depends(get_db),
+        active_env = Depends(get_active_env)
+    ):
+        """Get suggested next actions for incident triage."""
+        task_service = TaskService(session, active_env=active_env)
+        config_service = AppConfigService(session)
+        lookback_hours = hours if hours is not None else config_service.get_task_issue_lookback_hours()
+        return task_service.get_triage_recommendations(failed_hours=lookback_hours, failed_limit=limit)
 
 
     @router.post("/tasks/{task_id}/resolve")

--- a/agent/models.py
+++ b/agent/models.py
@@ -220,6 +220,25 @@ class RuntimeAnomaly(BaseModel):
     detail: str
 
 
+class TriageRecommendation(BaseModel):
+    """Suggested next action for incident triage."""
+    recommendation_id: str
+    recommendation_type: Literal[
+        "stalled_progress",
+        "orphaned_task",
+        "repeating_failures",
+        "long_running",
+    ]
+    severity: Literal["critical", "warning", "info"]
+    title: str
+    summary: str
+    detail: str
+    task_id: Optional[str] = None
+    task_name: Optional[str] = None
+    hostname: Optional[str] = None
+    supporting_task_ids: List[str] = Field(default_factory=list)
+
+
 class WorkerInfo(BaseModel):
     """Worker information model"""
     hostname: str

--- a/agent/services/task_service.py
+++ b/agent/services/task_service.py
@@ -12,7 +12,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 
 from database import TaskEventDB, RetryRelationshipDB, TaskLatestDB, TaskResolutionDB, TaskProgressLatestDB
-from models import TaskEvent, RuntimeAnomaly
+from models import TaskEvent, RuntimeAnomaly, TriageRecommendation
 from constants import TaskState, EventType, STATE_TO_EVENT_MAP, ACTIVE_EVENT_TYPES
 from services.utils import EnvironmentFilter, GenericFilter, parse_filter_string
 from utils.payload_sanitizer import find_placeholder_paths
@@ -316,6 +316,100 @@ class TaskService:
         anomalies.sort(key=lambda item: (item.anomaly_type, item.runtime_seconds), reverse=True)
         return anomalies
 
+    def get_triage_recommendations(
+        self,
+        now: Optional[datetime] = None,
+        failed_hours: int = 24,
+        failed_limit: int = 100,
+    ) -> List[TriageRecommendation]:
+        """Suggest next actions for the current incident picture."""
+        current_time = _ensure_utc(now) or datetime.now(timezone.utc)
+        recommendations: List[TriageRecommendation] = []
+
+        runtime_anomalies = self.get_runtime_anomalies(now=current_time)
+        stalled = [item for item in runtime_anomalies if item.anomaly_type == "stalled_progress"]
+        long_running = [item for item in runtime_anomalies if item.anomaly_type == "long_running"]
+
+        orphaned_tasks = self.get_unretried_orphaned_tasks()
+        failed_tasks = self.get_recent_failed_tasks(hours=failed_hours, limit=failed_limit, exclude_retried=True, now=current_time)
+
+        if stalled:
+            oldest = max(stalled, key=lambda item: item.progress_age_seconds or 0)
+            recommendations.append(TriageRecommendation(
+                recommendation_id=f"stalled-progress:{oldest.task.task_id}",
+                recommendation_type="stalled_progress",
+                severity="critical",
+                title="Investigate stalled task progress",
+                summary=f"{len(stalled)} active task(s) have stopped reporting progress.",
+                detail=oldest.detail,
+                task_id=oldest.task.task_id,
+                task_name=oldest.task.task_name,
+                hostname=oldest.task.hostname,
+                supporting_task_ids=[item.task.task_id for item in stalled],
+            ))
+
+        if orphaned_tasks:
+            latest_orphan = max(orphaned_tasks, key=lambda task: _ensure_utc(task.orphaned_at) or current_time)
+            recommendations.append(TriageRecommendation(
+                recommendation_id=f"orphaned:{latest_orphan.task_id}",
+                recommendation_type="orphaned_task",
+                severity="critical",
+                title="Recover orphaned tasks",
+                summary=f"{len(orphaned_tasks)} orphaned task(s) are waiting on an offline worker.",
+                detail="Confirm the worker is healthy, then retry the orphaned tasks that are still needed.",
+                task_id=latest_orphan.task_id,
+                task_name=latest_orphan.task_name,
+                hostname=latest_orphan.hostname,
+                supporting_task_ids=[task.task_id for task in orphaned_tasks],
+            ))
+
+        failed_by_task: Dict[str, List[TaskEvent]] = {}
+        for task in failed_tasks:
+            failed_by_task.setdefault(task.task_name or "unknown", []).append(task)
+
+        repeating_group: Optional[Tuple[str, List[TaskEvent]]] = None
+        for task_name, grouped in failed_by_task.items():
+            if len(grouped) < 3:
+                continue
+            if repeating_group is None or len(grouped) > len(repeating_group[1]):
+                repeating_group = (task_name, grouped)
+
+        if repeating_group is not None:
+            task_name, grouped = repeating_group
+            latest_failure = max(grouped, key=lambda task: _ensure_utc(task.timestamp) or current_time)
+            recommendations.append(TriageRecommendation(
+                recommendation_id=f"repeating-failures:{task_name}",
+                recommendation_type="repeating_failures",
+                severity="warning",
+                title="Escalate repeating failures",
+                summary=f"{len(grouped)} recent failures share the same task family.",
+                detail="Treat this as a likely incident cluster: inspect the latest failure, check the runbook, and avoid blind retries until the common cause is clear.",
+                task_id=latest_failure.task_id,
+                task_name=task_name,
+                hostname=latest_failure.hostname,
+                supporting_task_ids=[task.task_id for task in grouped],
+            ))
+
+        if long_running:
+            longest = max(long_running, key=lambda item: item.runtime_seconds)
+            recommendations.append(TriageRecommendation(
+                recommendation_id=f"long-running:{longest.task.task_id}",
+                recommendation_type="long_running",
+                severity="info",
+                title="Review long-running tasks",
+                summary=f"{len(long_running)} task(s) are running well past their baseline.",
+                detail=longest.detail,
+                task_id=longest.task.task_id,
+                task_name=longest.task.task_name,
+                hostname=longest.task.hostname,
+                supporting_task_ids=[item.task.task_id for item in long_running],
+            ))
+
+        severity_rank = {"critical": 0, "warning": 1, "info": 2}
+        type_rank = {"orphaned_task": 0, "stalled_progress": 1, "repeating_failures": 2, "long_running": 3}
+        recommendations.sort(key=lambda item: (severity_rank.get(item.severity, 99), type_rank.get(item.recommendation_type, 99), item.title))
+        return recommendations
+
     def get_unretried_orphaned_tasks(self) -> List[TaskEvent]:
         """Get orphaned tasks that have not been retried and have no final-state event."""
         FINAL_STATES = {
@@ -403,7 +497,8 @@ class TaskService:
         self,
         hours: int = 24,
         limit: int = 50,
-        exclude_retried: bool = True
+        exclude_retried: bool = True,
+        now: Optional[datetime] = None,
     ) -> List[TaskEvent]:
         """
         Get failed tasks in the last ``hours`` where the latest event is a failure.
@@ -416,7 +511,8 @@ class TaskService:
         Returns:
             List of failed task events ordered by most recent failure first
         """
-        since = datetime.now(timezone.utc) - timedelta(hours=hours)
+        current_time = _ensure_utc(now) or datetime.now(timezone.utc)
+        since = current_time - timedelta(hours=hours)
 
         latest_subquery = (
             self.session.query(

--- a/agent/tests/unit/test_triage_recommendations.py
+++ b/agent/tests/unit/test_triage_recommendations.py
@@ -1,0 +1,91 @@
+import unittest
+from datetime import datetime, timezone, timedelta
+
+from database import TaskProgressLatestDB
+from services.task_service import TaskService
+from tests.base import DatabaseTestCase
+
+
+class TestTriageRecommendations(DatabaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.service = TaskService(self.session)
+        self.base_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def _successful_baseline(self, task_name: str, runtimes: list[float]):
+        for idx, runtime in enumerate(runtimes):
+            self.create_task_event_db(
+                task_id=f"baseline-{task_name}-{idx}",
+                task_name=task_name,
+                event_type="task-succeeded",
+                timestamp=self.base_time - timedelta(hours=6, minutes=idx),
+                runtime=runtime,
+            )
+
+    def _active_task(self, task_id: str, task_name: str, started_seconds_ago: int, hostname: str = "worker-1"):
+        self.create_task_event_db(
+            task_id=task_id,
+            task_name=task_name,
+            event_type="task-started",
+            timestamp=self.base_time - timedelta(seconds=started_seconds_ago),
+            hostname=hostname,
+        )
+
+    def test_prioritizes_stalled_and_orphaned_recommendations(self):
+        self._active_task("stalled-1", "tasks.sync", started_seconds_ago=900, hostname="worker-a")
+        self.session.add(TaskProgressLatestDB(
+            task_id="stalled-1",
+            task_name="tasks.sync",
+            progress=55,
+            message="Waiting",
+            updated_at=self.base_time - timedelta(seconds=700),
+        ))
+        self.session.commit()
+
+        self.create_task_event_db(
+            task_id="orphan-1",
+            task_name="tasks.cleanup",
+            event_type="task-started",
+            timestamp=self.base_time - timedelta(minutes=20),
+            hostname="worker-b",
+            is_orphan=True,
+            orphaned_at=self.base_time - timedelta(minutes=5),
+        )
+
+        recommendations = self.service.get_triage_recommendations(now=self.base_time)
+
+        self.assertEqual(recommendations[0].recommendation_type, "orphaned_task")
+        self.assertEqual(recommendations[1].recommendation_type, "stalled_progress")
+        self.assertTrue(all(item.severity == "critical" for item in recommendations[:2]))
+
+    def test_detects_repeating_failures_for_same_task_family(self):
+        for idx in range(3):
+            self.create_task_event_db(
+                task_id=f"failed-{idx}",
+                task_name="tasks.billing.sync",
+                event_type="task-failed",
+                timestamp=self.base_time - timedelta(minutes=idx),
+                hostname="worker-c",
+                exception="boom",
+            )
+
+        recommendations = self.service.get_triage_recommendations(now=self.base_time, failed_hours=24)
+
+        repeating = next(item for item in recommendations if item.recommendation_type == "repeating_failures")
+        self.assertEqual(repeating.task_name, "tasks.billing.sync")
+        self.assertEqual(len(repeating.supporting_task_ids), 3)
+        self.assertEqual(repeating.severity, "warning")
+
+    def test_detects_long_running_recommendation(self):
+        self._successful_baseline("tasks.reports.generate", [20.0, 22.0, 18.0])
+        self._active_task("long-1", "tasks.reports.generate", started_seconds_ago=360, hostname="worker-z")
+
+        recommendations = self.service.get_triage_recommendations(now=self.base_time)
+
+        long_running = next(item for item in recommendations if item.recommendation_type == "long_running")
+        self.assertEqual(long_running.task_id, "long-1")
+        self.assertEqual(long_running.severity, "info")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/app/components/TriageRecommendationSummary.vue
+++ b/frontend/app/components/TriageRecommendationSummary.vue
@@ -1,0 +1,95 @@
+<template>
+  <div v-if="recommendations.length > 0 || !hideWhenEmpty" class="border border-border-subtle rounded-md bg-background-surface glow-border">
+    <div class="flex items-center justify-between border-b border-border-subtle px-4 py-3 gap-4">
+      <div class="flex items-center gap-3">
+        <StatusDot :status="status" :pulse="recommendations.length > 0" class="scale-110" />
+        <div>
+          <div class="text-sm font-medium text-text-primary">{{ title }}</div>
+          <div class="text-xs text-text-secondary">{{ recommendations.length }} active recommendation<span v-if="recommendations.length !== 1">s</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="recommendations.length > 0" class="divide-y divide-border-subtle">
+      <div v-for="item in recommendations" :key="item.recommendation_id" class="px-4 py-3">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div class="min-w-0 flex-1">
+            <div class="flex flex-wrap items-center gap-2">
+              <Badge :variant="severityVariant(item.severity)" class="text-[11px] px-2 py-0.5">{{ severityLabel(item.severity) }}</Badge>
+              <Badge variant="outline" class="text-[11px] px-2 py-0.5 border-border-subtle text-text-secondary">{{ typeLabel(item.recommendation_type) }}</Badge>
+              <span class="text-sm font-medium text-text-primary">{{ item.title }}</span>
+            </div>
+            <p class="mt-2 text-sm text-text-secondary">{{ item.summary }}</p>
+            <p class="mt-1 text-xs text-text-muted">{{ item.detail }}</p>
+            <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-text-secondary">
+              <Badge v-if="item.task_name" variant="outline" class="gap-2 border-border-subtle text-text-secondary">
+                <span class="uppercase tracking-wide text-[9px] text-text-muted">Task</span>
+                <span class="font-mono">{{ item.task_name }}</span>
+              </Badge>
+              <Badge v-if="item.hostname" variant="outline" class="gap-2 border-border-subtle text-text-secondary">
+                <span class="uppercase tracking-wide text-[9px] text-text-muted">Worker</span>
+                <span class="font-mono">{{ item.hostname }}</span>
+              </Badge>
+              <Badge variant="outline" class="gap-2 border-border-subtle text-text-secondary">
+                <span class="uppercase tracking-wide text-[9px] text-text-muted">Scope</span>
+                <span class="font-mono">{{ item.supporting_task_ids.length }} task<span v-if="item.supporting_task_ids.length !== 1">s</span></span>
+              </Badge>
+            </div>
+          </div>
+          <div v-if="item.task_id" class="flex items-center gap-2">
+            <NuxtLink :to="`/tasks/${item.task_id}`">
+              <Button variant="outline" size="sm" class="gap-1.5">
+                <ChevronRight class="h-3.5 w-3.5" />
+                Open
+              </Button>
+            </NuxtLink>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-else class="px-6 py-8 text-center text-sm text-text-secondary">
+      No active triage recommendations.
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import StatusDot from '~/components/StatusDot.vue'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { ChevronRight } from 'lucide-vue-next'
+import type { TriageRecommendationListItem } from '~/stores/triageRecommendations'
+
+withDefaults(defineProps<{
+  title?: string
+  recommendations: TriageRecommendationListItem[]
+  status?: 'success' | 'warning' | 'error' | 'info'
+  hideWhenEmpty?: boolean
+}>(), {
+  title: 'Triage recommendations',
+  status: 'info',
+  hideWhenEmpty: true,
+})
+
+const severityVariant = (severity: TriageRecommendationListItem['severity']) => {
+  if (severity === 'critical') return 'destructive'
+  if (severity === 'warning') return 'warning'
+  return 'secondary'
+}
+
+const severityLabel = (severity: TriageRecommendationListItem['severity']) => {
+  if (severity === 'critical') return 'Critical'
+  if (severity === 'warning') return 'Warning'
+  return 'Info'
+}
+
+const typeLabel = (type: TriageRecommendationListItem['recommendation_type']) => {
+  switch (type) {
+    case 'stalled_progress': return 'Stalled progress'
+    case 'orphaned_task': return 'Orphaned task'
+    case 'repeating_failures': return 'Repeating failures'
+    case 'long_running': return 'Long-running'
+  }
+}
+</script>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -16,6 +16,11 @@
 
       <!-- Failure & Orphaned Tasks Overview -->
       <div class="mb-6 flex flex-col gap-4 failure-insights-section">
+        <TriageRecommendationSummary
+          :recommendations="triageRecommendationsStore.recommendations"
+          :status="triageRecommendationsStore.criticalCount > 0 ? 'error' : 'warning'"
+        />
+
         <TaskIssueSummary
           :tasks="runtimeAnomaliesStore.anomalies"
           :is-loading="runtimeAnomaliesStore.isLoading"
@@ -276,6 +281,7 @@ import DataTable from "~/components/data-table.vue"
 import WorkerStatusSummary from "~/components/WorkerStatusSummary.vue"
 import CommandPalette from "~/components/CommandPalette.vue"
 import TaskIssueSummary from "~/components/TaskIssueSummary.vue"
+import TriageRecommendationSummary from '~/components/TriageRecommendationSummary.vue'
 import RetryTaskConfirmDialog from "~/components/RetryTaskConfirmDialog.vue"
 import { Button } from '~/components/ui/button'
 import { Badge } from '~/components/ui/badge'
@@ -294,6 +300,7 @@ const workersStore = useWorkersStore()
 const orphanTasksStore = useOrphanTasksStore()
 const failedTasksStore = useFailedTasksStore()
 const runtimeAnomaliesStore = useRuntimeAnomaliesStore()
+const triageRecommendationsStore = useTriageRecommendationsStore()
 const configStore = useConfigStore()
 const wsStore = useWebSocketStore()
 const environmentStore = useEnvironmentStore()
@@ -645,7 +652,8 @@ watch(() => environmentStore.activeEnvironment, async () => {
     workersStore.fetchWorkers(),
     orphanTasksStore.fetchOrphanedTasks(),
     failedTasksStore.fetchFailedTasks({ hours: failedTasksStore.lookbackHours }),
-    runtimeAnomaliesStore.fetchRuntimeAnomalies().catch(() => {})
+    runtimeAnomaliesStore.fetchRuntimeAnomalies().catch(() => {}),
+    triageRecommendationsStore.fetchTriageRecommendations().catch(() => {})
   ])
 })
 
@@ -678,7 +686,8 @@ onMounted(async () => {
     workersStore.fetchWorkers(),
     orphanTasksStore.fetchOrphanedTasks(),
     failedTasksStore.fetchFailedTasks({ hours: failedTasksStore.lookbackHours }),
-    runtimeAnomaliesStore.fetchRuntimeAnomalies().catch(() => {})
+    runtimeAnomaliesStore.fetchRuntimeAnomalies().catch(() => {}),
+    triageRecommendationsStore.fetchTriageRecommendations().catch(() => {})
   ])
 
   tasksStore.setLiveMode(wsStore.clientMode === 'live')
@@ -696,6 +705,7 @@ onMounted(async () => {
 
   runtimeAnomaliesInterval = setInterval(() => {
     runtimeAnomaliesStore.fetchRuntimeAnomalies().catch(() => {})
+    triageRecommendationsStore.fetchTriageRecommendations().catch(() => {})
   }, 60000)
 
   workerInterval = setInterval(() => {

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -137,6 +137,19 @@ export interface RuntimeAnomaliesQuery {
 
 export type RuntimeAnomalyResponse = RuntimeAnomaly
 
+export interface TriageRecommendationResponse {
+  recommendation_id: string
+  recommendation_type: 'stalled_progress' | 'orphaned_task' | 'repeating_failures' | 'long_running'
+  severity: 'critical' | 'warning' | 'info'
+  title: string
+  summary: string
+  detail: string
+  task_id?: string | null
+  task_name?: string | null
+  hostname?: string | null
+  supporting_task_ids: string[]
+}
+
 class ApiService {
   private api: Api<unknown>
 
@@ -355,6 +368,14 @@ class ApiService {
 
   async getRuntimeAnomalies(query?: RuntimeAnomaliesQuery): Promise<RuntimeAnomalyResponse[]> {
     const response = await this.api.api.getRuntimeAnomaliesApiTasksRuntimeAnomaliesGet(query)
+    return response.data
+  }
+
+  async getTriageRecommendations(): Promise<TriageRecommendationResponse[]> {
+    const response = await this.api.request({
+      path: '/api/tasks/triage-recommendations',
+      method: 'GET'
+    })
     return response.data
   }
 

--- a/frontend/app/stores/triageRecommendations.ts
+++ b/frontend/app/stores/triageRecommendations.ts
@@ -1,0 +1,75 @@
+import { defineStore } from 'pinia'
+import { ref, computed, readonly } from 'vue'
+import { useApiService, type TaskEventResponse, type TriageRecommendationResponse } from '../services/apiClient'
+
+export interface TriageRecommendationListItem extends TriageRecommendationResponse {
+  task_id: string
+  task_name: string
+  event_type: TaskEventResponse['event_type']
+  timestamp: string
+}
+
+function toEventType(severity: TriageRecommendationResponse['severity']): TaskEventResponse['event_type'] {
+  if (severity === 'critical') return 'task-failed'
+  if (severity === 'warning') return 'task-received'
+  return 'task-started'
+}
+
+function toListItem(item: TriageRecommendationResponse): TriageRecommendationListItem {
+  return {
+    ...item,
+    task_id: item.task_id || item.recommendation_id,
+    task_name: item.task_name || item.title,
+    event_type: toEventType(item.severity),
+    timestamp: new Date().toISOString(),
+    hostname: item.hostname ?? null,
+    supporting_task_ids: item.supporting_task_ids ?? [],
+  }
+}
+
+export const useTriageRecommendationsStore = defineStore('triageRecommendations', () => {
+  const apiService = useApiService()
+
+  const recommendations = ref<TriageRecommendationListItem[]>([])
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+  const lastFetchedAt = ref<Date | null>(null)
+
+  const criticalCount = computed(() => recommendations.value.filter(item => item.severity === 'critical').length)
+
+  async function fetchTriageRecommendations() {
+    try {
+      isLoading.value = true
+      error.value = null
+      const response = await apiService.getTriageRecommendations()
+      recommendations.value = response.map(toListItem)
+      lastFetchedAt.value = new Date()
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch triage recommendations'
+      throw err
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  function clearResolvedTask(taskId: string) {
+    recommendations.value = recommendations.value.filter(item => item.task_id !== taskId && !item.supporting_task_ids.includes(taskId))
+  }
+
+  function updateFromLiveEvent(event: TaskEventResponse) {
+    if (['task-succeeded', 'task-failed', 'task-retried', 'task-revoked', 'task-rejected'].includes(event.event_type)) {
+      clearResolvedTask(event.task_id)
+    }
+  }
+
+  return {
+    recommendations: readonly(recommendations),
+    isLoading: readonly(isLoading),
+    error: readonly(error),
+    lastFetchedAt: readonly(lastFetchedAt),
+    criticalCount,
+    fetchTriageRecommendations,
+    clearResolvedTask,
+    updateFromLiveEvent,
+  }
+})

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,18 @@
 /** @type {import('tailwindcss').Config} */
+const withOpacity = (cssVariable: string) => ({ opacityValue }: { opacityValue?: string }) => {
+  if (opacityValue === undefined) {
+    return `var(${cssVariable})`
+  }
+
+  const opacity = Number.parseFloat(opacityValue)
+
+  if (Number.isNaN(opacity)) {
+    return `var(${cssVariable})`
+  }
+
+  return `color-mix(in srgb, var(${cssVariable}) ${opacity * 100}%, transparent)`
+}
+
 export default {
   content: [
     "./app/**/*.{js,vue,ts}",
@@ -19,90 +33,90 @@ export default {
       colors: {
         // Backgrounds using CSS variables
         background: {
-          base: 'var(--bg-base)',
-          surface: 'var(--bg-surface)',
-          raised: 'var(--bg-raised)',
+          base: withOpacity('--bg-base'),
+          surface: withOpacity('--bg-surface'),
+          raised: withOpacity('--bg-raised'),
           overlay: 'hsl(0, 0%, 18%, 0.8)',
           // Interactive states
-          hover: 'var(--bg-hover)',
-          'hover-subtle': 'var(--bg-hover-subtle)',
-          active: 'var(--bg-active)',
-          selected: 'var(--bg-selected)'
+          hover: withOpacity('--bg-hover'),
+          'hover-subtle': withOpacity('--bg-hover-subtle'),
+          active: withOpacity('--bg-active'),
+          selected: withOpacity('--bg-selected')
         },
         // Text colors using CSS variables
         text: {
-          primary: 'var(--text-primary)',
-          secondary: 'var(--text-secondary)',
-          muted: 'var(--text-muted)',
-          disabled: 'var(--text-disabled)'
+          primary: withOpacity('--text-primary'),
+          secondary: withOpacity('--text-secondary'),
+          muted: withOpacity('--text-muted'),
+          disabled: withOpacity('--text-disabled')
         },
         // Card and borders
         card: {
-          base: 'var(--bg-surface)',
-          border: 'var(--border)',
+          base: withOpacity('--bg-surface'),
+          border: withOpacity('--border'),
         },
         // Border colors
         border: {
-          DEFAULT: 'var(--border)',
-          highlight: 'var(--highlight)',
-          subtle: 'var(--border-subtle)'
+          DEFAULT: withOpacity('--border'),
+          highlight: withOpacity('--highlight'),
+          subtle: withOpacity('--border-subtle')
         },
         // Primary/Brand colors
         primary: {
-          DEFAULT: 'var(--primary)',
-          hover: 'var(--primary-hover)',
-          bg: 'var(--primary-bg)',
-          border: 'var(--primary-border)'
+          DEFAULT: withOpacity('--primary'),
+          hover: withOpacity('--primary-hover'),
+          bg: withOpacity('--primary-bg'),
+          border: withOpacity('--primary-border')
         },
         // Semantic status colors using CSS variables
         status: {
           // Success states
           success: {
-            DEFAULT: 'var(--status-success)',
-            bg: 'var(--status-success-bg)',
-            border: 'var(--status-success-border)',
+            DEFAULT: withOpacity('--status-success'),
+            bg: withOpacity('--status-success-bg'),
+            border: withOpacity('--status-success-border'),
             hover: 'hsl(158,100%,13%)'
           },
           // Error states
           error: {
-            DEFAULT: 'var(--status-error)',
-            bg: 'var(--status-error-bg)',
-            border: 'var(--status-error-border)',
+            DEFAULT: withOpacity('--status-error'),
+            bg: withOpacity('--status-error-bg'),
+            border: withOpacity('--status-error-border'),
             hover: 'hsl(347, 77%, 18%)'
           },
           // Warning states
           warning: {
-            DEFAULT: 'var(--status-warning)',
-            bg: 'var(--status-warning-bg)',
-            border: 'var(--status-warning-border)',
+            DEFAULT: withOpacity('--status-warning'),
+            bg: withOpacity('--status-warning-bg'),
+            border: withOpacity('--status-warning-border'),
             hover: 'hsl(45, 85%, 18%)'
           },
           // Info states
           info: {
-            DEFAULT: 'var(--status-info)',
-            bg: 'var(--status-info-bg)',
-            border: 'var(--status-info-border)',
+            DEFAULT: withOpacity('--status-info'),
+            bg: withOpacity('--status-info-bg'),
+            border: withOpacity('--status-info-border'),
             hover: 'hsl(199, 89%, 18%)'
           },
           // Retry states
           retry: {
-            DEFAULT: 'var(--status-retry)',
-            bg: 'var(--status-retry-bg)',
-            border: 'var(--status-retry-border)',
+            DEFAULT: withOpacity('--status-retry'),
+            bg: withOpacity('--status-retry-bg'),
+            border: withOpacity('--status-retry-border'),
             hover: 'hsl(24, 95%, 18%)'
           },
           // Neutral states
           neutral: {
-            DEFAULT: 'var(--status-neutral)',
-            bg: 'var(--status-neutral-bg)',
-            border: 'var(--status-neutral-border)',
+            DEFAULT: withOpacity('--status-neutral'),
+            bg: withOpacity('--status-neutral-bg'),
+            border: withOpacity('--status-neutral-border'),
             hover: 'hsl(215, 20%, 18%)'
           },
           // Special states
           special: {
-            DEFAULT: 'var(--status-special)',
-            bg: 'var(--status-special-bg)',
-            border: 'var(--status-special-border)',
+            DEFAULT: withOpacity('--status-special'),
+            bg: withOpacity('--status-special-bg'),
+            border: withOpacity('--status-special-border'),
             hover: 'hsl(263, 70%, 18%)'
           }
         }


### PR DESCRIPTION
## Summary
- add triage recommendations built from stalled-progress, orphaned-task, repeating-failure, and long-running signals
- expose `GET /api/tasks/triage-recommendations`
- add a dashboard triage recommendations card with severity/type/scope metadata and task links

Closes #95.

Stacked on #113 because this reuses the runtime anomaly model from #94.

## Validation
- `python3 -m unittest tests.unit.test_triage_recommendations -v`
- `npm run build`
- local API check returned orphaned/stalled/repeating/long-running recommendations
- Playwright proof captured and converted to MP4: `/data/.openclaw/workspace/tmp/kanchi-95-triage-recommendations.mp4`