### PR TITLE
Make task retry controls safer and more configurable

### DIFF
--- a/agent/api/task_routes.py
+++ b/agent/api/task_routes.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from services import TaskService, EnvironmentService, SessionService, AppConfigService, ProgressService
 from database import TaskEventDB
-from models import TaskEvent, TaskProgressSnapshot
+from models import TaskEvent, TaskProgressSnapshot, RetryImpactPreview, RetryTaskRequest
 from database import ensure_utc_isoformat
 from config import Config
 from security.auth import AuthenticatedUser
@@ -221,13 +221,38 @@ def create_router(app_state) -> APIRouter:
         }
 
 
+    @router.get("/tasks/{task_id}/retry/preview", response_model=RetryImpactPreview)
+    async def get_retry_preview(
+        task_id: str,
+        max_attempts: int = Query(default=3, ge=1, le=25),
+        session: Session = Depends(get_db),
+    ):
+        """Preview retry-chain impact and guardrails before requeueing."""
+        task_service = TaskService(session)
+        try:
+            return task_service.get_retry_impact_preview(task_id, max_attempts=max_attempts)
+        except ValueError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
     @router.post("/tasks/{task_id}/retry")
-    async def retry_task(task_id: str, session: Session = Depends(get_db)):
+    async def retry_task(
+        task_id: str,
+        payload: Optional[RetryTaskRequest] = None,
+        session: Session = Depends(get_db),
+    ):
         """Retry a failed task by creating a new task with the same parameters."""
         if not app_state.monitor_instance:
             raise HTTPException(status_code=500, detail="Monitor not initialized")
 
         task_service = TaskService(session)
+
+        retry_policy = payload or RetryTaskRequest()
+        preview = task_service.get_retry_impact_preview(task_id, max_attempts=retry_policy.max_attempts)
+        if not preview.allowed:
+            raise HTTPException(status_code=409, detail={
+                "message": "Retry blocked by configured safety policy",
+                "preview": preview.model_dump(mode="json"),
+            })
 
         # Find the original task
         task_events = task_service.get_task_events(task_id)
@@ -243,6 +268,8 @@ def create_router(app_state) -> APIRouter:
 
         args = tuple(original_task.args) if original_task.args else ()
         kwargs = original_task.kwargs if original_task.kwargs else {}
+        if retry_policy.override_kwargs:
+            kwargs = {**kwargs, **retry_policy.override_kwargs}
 
         queue_name = original_task.queue if original_task.queue else 'default'
 
@@ -251,12 +278,18 @@ def create_router(app_state) -> APIRouter:
         task_service.create_retry_relationship(task_id, new_task_id)
         session.commit()
 
+        send_task_kwargs = {
+            "queue": queue_name,
+            "task_id": new_task_id,
+        }
+        if retry_policy.mode == "delayed" and retry_policy.delay_seconds > 0:
+            send_task_kwargs["countdown"] = retry_policy.delay_seconds
+
         result = app_state.monitor_instance.app.send_task(
             original_task.task_name,
             args=args,
             kwargs=kwargs,
-            queue=queue_name,
-            task_id=new_task_id  # Use our pre-generated ID
+            **send_task_kwargs,
         )
         
         return {
@@ -265,6 +298,11 @@ def create_router(app_state) -> APIRouter:
             "original_task_id": task_id,
             "new_task_id": new_task_id,
             "task_name": original_task.task_name,
+            "retry_mode": retry_policy.mode,
+            "delay_seconds": retry_policy.delay_seconds,
+            "max_attempts": retry_policy.max_attempts,
+            "operator_comment": retry_policy.operator_comment,
+            "warnings": [warning.model_dump(mode="json") for warning in preview.warnings],
             "was_orphaned": orphaned_task is not None,
             "timestamp": datetime.now(timezone.utc).isoformat()
         }

--- a/agent/models.py
+++ b/agent/models.py
@@ -71,6 +71,7 @@ class TaskEvent(BaseModel):
             traceback=event.get('traceback'),
         )
 
+
     @field_validator('args', mode='before')
     @classmethod
     def validate_args(cls, v):
@@ -131,6 +132,34 @@ class TaskEvent(BaseModel):
 
 
 TaskEvent.model_rebuild()
+
+class RetryTaskRequest(BaseModel):
+    """Operator-selected retry policy for a manual retry."""
+    mode: Literal["immediate", "delayed"] = "immediate"
+    delay_seconds: int = Field(default=0, ge=0, le=86400)
+    max_attempts: int = Field(default=3, ge=1, le=25)
+    operator_comment: Optional[str] = Field(default=None, max_length=500)
+    override_kwargs: Optional[Dict[str, Any]] = None
+
+
+class RetryWarning(BaseModel):
+    """Risk warning emitted before or after a retry action."""
+    code: str
+    severity: Literal["warning", "critical"]
+    message: str
+
+
+class RetryImpactPreview(BaseModel):
+    """Preview of retry-chain impact and policy guardrails."""
+    task_id: str
+    task_name: Optional[str] = None
+    queue: Optional[str] = None
+    retry_count: int = 0
+    retry_chain: List[str] = Field(default_factory=list)
+    max_attempts: int
+    remaining_attempts: int
+    warnings: List[RetryWarning] = Field(default_factory=list)
+    allowed: bool = True
 
 
 class StepDefinition(BaseModel):

--- a/agent/services/task_service.py
+++ b/agent/services/task_service.py
@@ -12,7 +12,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 
 from database import TaskEventDB, RetryRelationshipDB, TaskLatestDB, TaskResolutionDB
-from models import TaskEvent
+from models import TaskEvent, RetryImpactPreview, RetryWarning
 from constants import TaskState, EventType, STATE_TO_EVENT_MAP, ACTIVE_EVENT_TYPES
 from services.utils import EnvironmentFilter, GenericFilter, parse_filter_string
 from utils.payload_sanitizer import find_placeholder_paths
@@ -427,6 +427,68 @@ class TaskService:
             self.session.rollback()
             logger.error(f"Failed to create retry relationship: {e}")
             raise
+
+    def get_retry_impact_preview(self, task_id: str, max_attempts: int = 3) -> RetryImpactPreview:
+        """Preview retry-chain impact and unsafe retry conditions before requeueing."""
+        events = self.get_task_events(task_id)
+        if not events:
+            raise ValueError("Task not found")
+
+        task = events[-1]
+        retry_rel = (
+            self.session.query(RetryRelationshipDB)
+            .filter_by(task_id=task_id)
+            .first()
+        )
+        retry_chain = list(retry_rel.retry_chain or []) if retry_rel else []
+        retry_count = retry_rel.total_retries if retry_rel else task.retry_count or len(retry_chain)
+        remaining_attempts = max(max_attempts - retry_count, 0)
+        warnings: List[RetryWarning] = []
+
+        if retry_count >= max_attempts:
+            warnings.append(RetryWarning(
+                code="max_attempts_reached",
+                severity="critical",
+                message=f"This retry chain already reached the configured cap of {max_attempts} attempt(s).",
+            ))
+        elif retry_count >= max_attempts - 1:
+            warnings.append(RetryWarning(
+                code="last_attempt",
+                severity="warning",
+                message="This retry will consume the final configured retry attempt for this chain.",
+            ))
+
+        same_name_failures = (
+            self.session.query(TaskEventDB)
+            .filter(TaskEventDB.task_name == task.task_name)
+            .filter(TaskEventDB.event_type == EventType.TASK_FAILED.value)
+            .count()
+        )
+        if same_name_failures >= 3:
+            warnings.append(RetryWarning(
+                code="repeating_failure_family",
+                severity="warning",
+                message=f"{same_name_failures} failures share this task name; inspect the common cause before retrying blindly.",
+            ))
+
+        if task.is_orphan:
+            warnings.append(RetryWarning(
+                code="orphaned_worker",
+                severity="warning",
+                message="This task was orphaned by an offline worker; confirm the worker is healthy or route the retry elsewhere.",
+            ))
+
+        return RetryImpactPreview(
+            task_id=task.task_id,
+            task_name=task.task_name,
+            queue=task.queue,
+            retry_count=retry_count,
+            retry_chain=retry_chain,
+            max_attempts=max_attempts,
+            remaining_attempts=remaining_attempts,
+            warnings=warnings,
+            allowed=not any(warning.code == "max_attempts_reached" for warning in warnings),
+        )
 
     def mark_new_task_as_retry(self, new_task_id: str, original_task_id: str):
         """

--- a/agent/tests/unit/test_retry_safety.py
+++ b/agent/tests/unit/test_retry_safety.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timezone
+
+from database import RetryRelationshipDB
+from services.task_service import TaskService
+from tests.base import DatabaseTestCase
+
+
+class TestRetrySafety(DatabaseTestCase):
+    def test_preview_blocks_retry_when_attempt_cap_reached(self):
+        self.create_task_event_db(
+            task_id="failed-1",
+            task_name="tasks.billing.sync",
+            event_type="task-failed",
+            timestamp=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            queue="billing",
+            exception="timeout",
+        )
+        self.session.add(RetryRelationshipDB(
+            task_id="failed-1",
+            original_id="failed-1",
+            retry_chain=["retry-1", "retry-2", "retry-3"],
+            total_retries=3,
+        ))
+        self.session.commit()
+
+        preview = TaskService(self.session).get_retry_impact_preview("failed-1", max_attempts=3)
+
+        self.assertFalse(preview.allowed)
+        self.assertEqual(preview.retry_count, 3)
+        self.assertEqual(preview.remaining_attempts, 0)
+        self.assertIn("max_attempts_reached", [warning.code for warning in preview.warnings])
+
+    def test_preview_warns_on_repeating_failure_family_and_orphaned_task(self):
+        for idx in range(3):
+            self.create_task_event_db(
+                task_id=f"failed-{idx}",
+                task_name="tasks.import.sync",
+                event_type="task-failed",
+                timestamp=datetime(2024, 1, 1, 12, idx, 0, tzinfo=timezone.utc),
+                exception="upstream unavailable",
+                is_orphan=idx == 2,
+            )
+
+        preview = TaskService(self.session).get_retry_impact_preview("failed-2", max_attempts=5)
+
+        self.assertTrue(preview.allowed)
+        warning_codes = [warning.code for warning in preview.warnings]
+        self.assertIn("repeating_failure_family", warning_codes)
+        self.assertIn("orphaned_worker", warning_codes)

--- a/frontend/app/components/RetryTaskConfirmDialog.vue
+++ b/frontend/app/components/RetryTaskConfirmDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import ConfirmationDialog from '~/components/ConfirmationDialog.vue'
 import TaskName from '~/components/TaskName.vue'
 import CopyButton from '~/components/CopyButton.vue'
@@ -21,18 +21,43 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const emit = defineEmits<{
-  confirm: []
+  confirm: [policy: Record<string, unknown>]
   cancel: []
 }>()
 
 const confirmationDialogRef = ref<InstanceType<typeof ConfirmationDialog> | null>(null)
+const tasksStore = useTasksStore()
+const mode = ref<'immediate' | 'delayed'>('immediate')
+const delaySeconds = ref(300)
+const maxAttempts = ref(3)
+const operatorComment = ref('')
+const preview = ref<any>(null)
+const isPreviewLoading = ref(false)
 
-const open = () => {
+const retryPolicy = computed(() => ({
+  mode: mode.value,
+  delay_seconds: mode.value === 'delayed' ? delaySeconds.value : 0,
+  max_attempts: maxAttempts.value,
+  operator_comment: operatorComment.value || null,
+}))
+
+const loadPreview = async () => {
+  if (!props.task?.task_id) return
+  isPreviewLoading.value = true
+  try {
+    preview.value = await tasksStore.getRetryPreview(props.task.task_id, maxAttempts.value)
+  } finally {
+    isPreviewLoading.value = false
+  }
+}
+
+const open = async () => {
+  await loadPreview()
   confirmationDialogRef.value?.open()
 }
 
 const handleConfirm = () => {
-  emit('confirm')
+  emit('confirm', retryPolicy.value)
 }
 
 const handleCancel = () => {
@@ -114,6 +139,45 @@ defineExpose({ open })
         <Alert variant="warning" title="This will create a new task instance">
           The task will be re-queued and executed again by an available worker.
         </Alert>
+
+        <div class="rounded-lg border border-border bg-background-muted/30 p-4 space-y-3 text-sm">
+          <div class="flex items-center justify-between gap-3">
+            <label class="text-text-secondary">Retry mode</label>
+            <select v-model="mode" class="rounded-md border border-border bg-background-base px-3 py-2 text-text-primary">
+              <option value="immediate">Immediate</option>
+              <option value="delayed">Delayed</option>
+            </select>
+          </div>
+
+          <div v-if="mode === 'delayed'" class="flex items-center justify-between gap-3">
+            <label class="text-text-secondary">Delay seconds</label>
+            <input v-model.number="delaySeconds" type="number" min="1" max="86400" class="w-32 rounded-md border border-border bg-background-base px-3 py-2 text-right text-text-primary" />
+          </div>
+
+          <div class="flex items-center justify-between gap-3">
+            <label class="text-text-secondary">Cap attempts</label>
+            <input v-model.number="maxAttempts" type="number" min="1" max="25" @change="loadPreview" class="w-24 rounded-md border border-border bg-background-base px-3 py-2 text-right text-text-primary" />
+          </div>
+
+          <textarea v-model="operatorComment" rows="2" maxlength="500" placeholder="Operator comment (optional)" class="w-full rounded-md border border-border bg-background-base px-3 py-2 text-text-primary placeholder:text-text-muted" />
+        </div>
+
+        <div v-if="preview" class="rounded-lg border border-border p-4 space-y-2 text-sm">
+          <div class="font-medium text-text-primary">Retry-chain impact</div>
+          <p class="text-text-secondary">
+            {{ preview.retry_count }} existing retry attempt(s), {{ preview.remaining_attempts }} remaining under cap {{ preview.max_attempts }}.
+          </p>
+          <Alert
+            v-for="warning in preview.warnings"
+            :key="warning.code"
+            :variant="warning.severity === 'critical' ? 'error' : 'warning'"
+            :title="warning.code.replaceAll('_', ' ')"
+          >
+            {{ warning.message }}
+          </Alert>
+        </div>
+
+        <p v-else-if="isPreviewLoading" class="text-sm text-text-muted">Loading retry impact preview…</p>
       </div>
     </template>
   </ConfirmationDialog>

--- a/frontend/app/components/data-table.vue
+++ b/frontend/app/components/data-table.vue
@@ -114,11 +114,11 @@ const toggleRowExpansion = (taskId: string | undefined) => {
   }
 }
 
-const handleRetryConfirm = async () => {
+const handleRetryConfirm = async (policy?: Record<string, unknown>) => {
   if (!currentRetryTaskId.value) return
   
   try {
-    const result = await tasksStore.retryTask(currentRetryTaskId.value)
+    const result = await tasksStore.retryTask(currentRetryTaskId.value, policy)
     // Reset current retry task ID
     currentRetryTaskId.value = null
   } catch (error) {

--- a/frontend/app/components/tasks/TaskDetailSheet.vue
+++ b/frontend/app/components/tasks/TaskDetailSheet.vue
@@ -444,11 +444,11 @@ function handleRetryFailure(taskId: string) {
   retryDialogRef.value?.open()
 }
 
-async function handleRetryConfirm() {
+async function handleRetryConfirm(policy?: Record<string, unknown>) {
   if (!currentRetryTaskId.value) return
 
   try {
-    await tasksStore.retryTask(currentRetryTaskId.value)
+    await tasksStore.retryTask(currentRetryTaskId.value, policy)
     currentRetryTaskId.value = null
   } catch (error) {
     console.error('Failed to retry task:', error)

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -428,15 +428,15 @@ function handleOrphanRetryAction(task: TaskEventResponse) {
   openRetryDialog(task, 'orphan')
 }
 
-async function confirmRetry() {
+async function confirmRetry(policy?: Record<string, unknown>) {
   if (!retryDialogState.value) return
   isRetryingTask.value = true
   const { task, type } = retryDialogState.value
   try {
     if (type === 'orphan') {
-      await orphanTasksStore.retryOrphanedTask(task.task_id)
+      await orphanTasksStore.retryOrphanedTask(task.task_id, policy)
     } else {
-      await tasksStore.retryTask(task.task_id)
+      await tasksStore.retryTask(task.task_id, policy)
     }
     retryDialogState.value = null
   } catch (error) {

--- a/frontend/app/pages/tasks/[id].vue
+++ b/frontend/app/pages/tasks/[id].vue
@@ -503,11 +503,11 @@ const openRetryDialog = () => {
   retryDialogRef.value?.open()
 }
 
-const handleRetryConfirm = async () => {
+const handleRetryConfirm = async (policy?: Record<string, unknown>) => {
   if (!task.value?.task_id) return
 
   try {
-    await tasksStore.retryTask(task.value.task_id)
+    await tasksStore.retryTask(task.value.task_id, policy)
     await fetchTaskData()
   } catch (error) {
     console.error('Failed to rerun task:', error)

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -342,8 +342,21 @@ class ApiService {
     return response.data
   }
 
-  async retryTask(taskId: string): Promise<any> {
-    const response = await this.api.api.retryTaskApiTasksTaskIdRetryPost(taskId)
+  async getRetryPreview(taskId: string, maxAttempts = 3): Promise<any> {
+    const response = await this.api.request({
+      path: `/api/tasks/${encodeURIComponent(taskId)}/retry/preview`,
+      method: 'GET',
+      query: { max_attempts: maxAttempts }
+    })
+    return response.data
+  }
+
+  async retryTask(taskId: string, policy?: Record<string, unknown>): Promise<any> {
+    const response = await this.api.request({
+      path: `/api/tasks/${encodeURIComponent(taskId)}/retry`,
+      method: 'POST',
+      body: policy
+    })
     return response.data
   }
 

--- a/frontend/app/stores/orphanTasks.ts
+++ b/frontend/app/stores/orphanTasks.ts
@@ -47,10 +47,10 @@ export const useOrphanTasksStore = defineStore('orphanTasks', () => {
     }
   }
 
-  async function retryOrphanedTask(taskId: string) {
+  async function retryOrphanedTask(taskId: string, policy?: Record<string, unknown>) {
     try {
       error.value = null
-      await apiService.retryTask(taskId)
+      await apiService.retryTask(taskId, policy)
       orphanedTasks.value = orphanedTasks.value.filter(task => task.task_id !== taskId)
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to retry orphaned task'

--- a/frontend/app/stores/tasks.ts
+++ b/frontend/app/stores/tasks.ts
@@ -132,10 +132,20 @@ export const useTasksStore = defineStore('tasks', () => {
     }
   }
 
-  async function retryTask(taskId: string) {
+  async function getRetryPreview(taskId: string, maxAttempts = 3) {
     try {
       error.value = null
-      const result = await apiService.retryTask(taskId)
+      return await apiService.getRetryPreview(taskId, maxAttempts)
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to preview retry impact'
+      throw err
+    }
+  }
+
+  async function retryTask(taskId: string, policy?: Record<string, unknown>) {
+    try {
+      error.value = null
+      const result = await apiService.retryTask(taskId, policy)
       await fetchRecentEvents()
       return result
     } catch (err) {
@@ -346,6 +356,7 @@ export const useTasksStore = defineStore('tasks', () => {
     fetchStats,
     fetchRecentEvents,
     fetchActiveTasks,
+    getRetryPreview,
     retryTask,
     getTaskEvents,
     getTaskProgress,

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,18 @@
 /** @type {import('tailwindcss').Config} */
+const withOpacity = (cssVariable: string) => ({ opacityValue }: { opacityValue?: string }) => {
+  if (opacityValue === undefined) {
+    return `var(${cssVariable})`
+  }
+
+  const opacity = Number.parseFloat(opacityValue)
+
+  if (Number.isNaN(opacity)) {
+    return `var(${cssVariable})`
+  }
+
+  return `color-mix(in srgb, var(${cssVariable}) ${opacity * 100}%, transparent)`
+}
+
 export default {
   content: [
     "./app/**/*.{js,vue,ts}",
@@ -19,90 +33,90 @@ export default {
       colors: {
         // Backgrounds using CSS variables
         background: {
-          base: 'var(--bg-base)',
-          surface: 'var(--bg-surface)',
-          raised: 'var(--bg-raised)',
+          base: withOpacity('--bg-base'),
+          surface: withOpacity('--bg-surface'),
+          raised: withOpacity('--bg-raised'),
           overlay: 'hsl(0, 0%, 18%, 0.8)',
           // Interactive states
-          hover: 'var(--bg-hover)',
-          'hover-subtle': 'var(--bg-hover-subtle)',
-          active: 'var(--bg-active)',
-          selected: 'var(--bg-selected)'
+          hover: withOpacity('--bg-hover'),
+          'hover-subtle': withOpacity('--bg-hover-subtle'),
+          active: withOpacity('--bg-active'),
+          selected: withOpacity('--bg-selected')
         },
         // Text colors using CSS variables
         text: {
-          primary: 'var(--text-primary)',
-          secondary: 'var(--text-secondary)',
-          muted: 'var(--text-muted)',
-          disabled: 'var(--text-disabled)'
+          primary: withOpacity('--text-primary'),
+          secondary: withOpacity('--text-secondary'),
+          muted: withOpacity('--text-muted'),
+          disabled: withOpacity('--text-disabled')
         },
         // Card and borders
         card: {
-          base: 'var(--bg-surface)',
-          border: 'var(--border)',
+          base: withOpacity('--bg-surface'),
+          border: withOpacity('--border'),
         },
         // Border colors
         border: {
-          DEFAULT: 'var(--border)',
-          highlight: 'var(--highlight)',
-          subtle: 'var(--border-subtle)'
+          DEFAULT: withOpacity('--border'),
+          highlight: withOpacity('--highlight'),
+          subtle: withOpacity('--border-subtle')
         },
         // Primary/Brand colors
         primary: {
-          DEFAULT: 'var(--primary)',
-          hover: 'var(--primary-hover)',
-          bg: 'var(--primary-bg)',
-          border: 'var(--primary-border)'
+          DEFAULT: withOpacity('--primary'),
+          hover: withOpacity('--primary-hover'),
+          bg: withOpacity('--primary-bg'),
+          border: withOpacity('--primary-border')
         },
         // Semantic status colors using CSS variables
         status: {
           // Success states
           success: {
-            DEFAULT: 'var(--status-success)',
-            bg: 'var(--status-success-bg)',
-            border: 'var(--status-success-border)',
+            DEFAULT: withOpacity('--status-success'),
+            bg: withOpacity('--status-success-bg'),
+            border: withOpacity('--status-success-border'),
             hover: 'hsl(158,100%,13%)'
           },
           // Error states
           error: {
-            DEFAULT: 'var(--status-error)',
-            bg: 'var(--status-error-bg)',
-            border: 'var(--status-error-border)',
+            DEFAULT: withOpacity('--status-error'),
+            bg: withOpacity('--status-error-bg'),
+            border: withOpacity('--status-error-border'),
             hover: 'hsl(347, 77%, 18%)'
           },
           // Warning states
           warning: {
-            DEFAULT: 'var(--status-warning)',
-            bg: 'var(--status-warning-bg)',
-            border: 'var(--status-warning-border)',
+            DEFAULT: withOpacity('--status-warning'),
+            bg: withOpacity('--status-warning-bg'),
+            border: withOpacity('--status-warning-border'),
             hover: 'hsl(45, 85%, 18%)'
           },
           // Info states
           info: {
-            DEFAULT: 'var(--status-info)',
-            bg: 'var(--status-info-bg)',
-            border: 'var(--status-info-border)',
+            DEFAULT: withOpacity('--status-info'),
+            bg: withOpacity('--status-info-bg'),
+            border: withOpacity('--status-info-border'),
             hover: 'hsl(199, 89%, 18%)'
           },
           // Retry states
           retry: {
-            DEFAULT: 'var(--status-retry)',
-            bg: 'var(--status-retry-bg)',
-            border: 'var(--status-retry-border)',
+            DEFAULT: withOpacity('--status-retry'),
+            bg: withOpacity('--status-retry-bg'),
+            border: withOpacity('--status-retry-border'),
             hover: 'hsl(24, 95%, 18%)'
           },
           // Neutral states
           neutral: {
-            DEFAULT: 'var(--status-neutral)',
-            bg: 'var(--status-neutral-bg)',
-            border: 'var(--status-neutral-border)',
+            DEFAULT: withOpacity('--status-neutral'),
+            bg: withOpacity('--status-neutral-bg'),
+            border: withOpacity('--status-neutral-border'),
             hover: 'hsl(215, 20%, 18%)'
           },
           // Special states
           special: {
-            DEFAULT: 'var(--status-special)',
-            bg: 'var(--status-special-bg)',
-            border: 'var(--status-special-border)',
+            DEFAULT: withOpacity('--status-special'),
+            bg: withOpacity('--status-special-bg'),
+            border: withOpacity('--status-special-border'),
             hover: 'hsl(263, 70%, 18%)'
           }
         }


### PR DESCRIPTION
## Summary
- add retry impact preview API with retry-chain counts, attempt caps, and safety warnings
- support retry policies for immediate/delayed retries, max attempts, operator comments, and kwargs overrides
- expand retry confirmation UI with mode/cap/comment controls and warning previews

Closes #98.

## Validation
- `python3 -m unittest tests.unit.test_retry_safety -v`
- `npm run build`
- local API preview returned last-attempt, repeating-failure, and orphaned-worker warnings
- Playwright proof captured and converted to MP4: `/data/.openclaw/workspace/tmp/kanchi-98-safer-retry-controls.mp4`