### PR TITLE
Add queue and worker operations surface

### DIFF
--- a/agent/api/worker_routes.py
+++ b/agent/api/worker_routes.py
@@ -1,12 +1,13 @@
 """API routes for worker-related endpoints."""
 
 from datetime import datetime, timezone
-from typing import List
+from typing import List, Optional, Literal
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
+from pydantic import BaseModel, Field
 
 from services import WorkerService
-from models import WorkerInfo
+from models import WorkerInfo, QueueWorkerSurfaceResponse, QueueWorkerNote
 from config import Config
 from security.dependencies import get_auth_dependency
 
@@ -28,16 +29,22 @@ def create_router(app_state) -> APIRouter:
         with app_state.db_manager.get_session() as session:
             yield session
 
+    class OperatorNoteRequest(BaseModel):
+        entity_type: Literal['queue', 'worker']
+        entity_key: str = Field(min_length=1, max_length=255)
+        note: str = Field(min_length=1, max_length=4000)
+        author: Optional[str] = Field(default=None, max_length=255)
+
 
     @router.get("/workers", response_model=List[WorkerInfo])
     async def get_workers():
         """Get information about all workers."""
         if not app_state.monitor_instance:
             return []
-        
+
         workers_data = app_state.monitor_instance.get_workers_info()
         worker_list = []
-        
+
         for hostname, data in workers_data.items():
             worker_info = WorkerInfo(
                 hostname=hostname,
@@ -52,20 +59,44 @@ def create_router(app_state) -> APIRouter:
                 freq=data.get('freq')
             )
             worker_list.append(worker_info)
-        
+
         return worker_list
 
+
+    @router.get("/workers/events/recent")
+    async def get_recent_worker_events(limit: int = 50, session: Session = Depends(get_db)):
+        """Get recent worker events."""
+        worker_service = WorkerService(session)
+        return worker_service.get_recent_worker_events(limit)
+
+    @router.get("/worker-operations", response_model=QueueWorkerSurfaceResponse)
+    async def get_queue_worker_surface(session: Session = Depends(get_db)):
+        """Get queue/worker operational summaries and contextual notes."""
+        worker_service = WorkerService(session)
+        workers_data = app_state.monitor_instance.get_workers_info() if app_state.monitor_instance else {}
+        return worker_service.get_queue_worker_surface(workers_data)
+
+    @router.post("/workers/notes", response_model=QueueWorkerNote)
+    async def save_operator_note(payload: OperatorNoteRequest, session: Session = Depends(get_db)):
+        """Create or update an operator note for a queue or worker."""
+        worker_service = WorkerService(session)
+        return worker_service.save_operator_note(
+            entity_type=payload.entity_type,
+            entity_key=payload.entity_key,
+            note=payload.note,
+            author=payload.author,
+        )
 
     @router.get("/workers/{hostname}", response_model=WorkerInfo)
     async def get_worker(hostname: str):
         """Get information about a specific worker."""
         if not app_state.monitor_instance:
             raise HTTPException(status_code=404, detail="Monitor not initialized")
-        
+
         workers_data = app_state.monitor_instance.get_workers_info()
         if hostname not in workers_data:
             raise HTTPException(status_code=404, detail="Worker not found")
-        
+
         data = workers_data[hostname]
         return WorkerInfo(
             hostname=hostname,
@@ -79,12 +110,5 @@ def create_router(app_state) -> APIRouter:
             loadavg=data.get('loadavg'),
             freq=data.get('freq')
         )
-
-
-    @router.get("/workers/events/recent")
-    async def get_recent_worker_events(limit: int = 50, session: Session = Depends(get_db)):
-        """Get recent worker events."""
-        worker_service = WorkerService(session)
-        return worker_service.get_recent_worker_events(limit)
 
     return router

--- a/agent/models.py
+++ b/agent/models.py
@@ -268,6 +268,43 @@ class WorkerEvent(BaseModel):
         )
 
 
+class QueueHealthSummary(BaseModel):
+    queue_name: str
+    active_tasks: int = 0
+    recent_failures: int = 0
+    throughput_last_hour: int = 0
+    workers: List[str] = Field(default_factory=list)
+    status: Literal['healthy', 'warning', 'critical'] = 'healthy'
+    summary: str
+
+
+class QueueWorkerNote(BaseModel):
+    entity_type: Literal['queue', 'worker']
+    entity_key: str
+    note: str
+    author: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class WorkerOperationalSummary(BaseModel):
+    hostname: str
+    status: str
+    active_tasks: int = 0
+    processed_tasks: int = 0
+    recent_failures: int = 0
+    active_queues: List[str] = Field(default_factory=list)
+    maintenance_state: Optional[str] = None
+    drain_state: Optional[str] = None
+    summary: str
+
+
+class QueueWorkerSurfaceResponse(BaseModel):
+    queues: List[QueueHealthSummary] = Field(default_factory=list)
+    workers: List[WorkerOperationalSummary] = Field(default_factory=list)
+    notes: List[QueueWorkerNote] = Field(default_factory=list)
+
+
 class ConnectionInfo(BaseModel):
     """WebSocket connection info"""
     status: str

--- a/agent/services/worker_service.py
+++ b/agent/services/worker_service.py
@@ -1,13 +1,15 @@
 """Service layer for worker-related operations."""
 
 import logging
-from typing import List, Dict, Any
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import List, Dict, Any, Optional
 
 from sqlalchemy.orm import Session
 from sqlalchemy import desc
 
-from database import WorkerEventDB
-from models import WorkerEvent, WorkerInfo
+from database import WorkerEventDB, TaskLatestDB, AppSettingDB
+from models import WorkerEvent, QueueHealthSummary, QueueWorkerNote, WorkerOperationalSummary, QueueWorkerSurfaceResponse
 from constants import WORKER_STATUS_MAP
 
 logger = logging.getLogger(__name__)
@@ -70,3 +72,162 @@ class WorkerService:
             .all()
         )
         return [event.to_dict() for event in events_db]
+
+    def get_queue_worker_surface(self, workers_data: Optional[Dict[str, Dict[str, Any]]] = None) -> QueueWorkerSurfaceResponse:
+        workers_data = workers_data or {}
+        now = datetime.now(timezone.utc)
+        one_hour_ago = now - timedelta(hours=1)
+
+        active_rows = (
+            self.session.query(TaskLatestDB)
+            .filter(TaskLatestDB.event_type.in_(['task-received', 'task-started']))
+            .all()
+        )
+        recent_failures = (
+            self.session.query(TaskLatestDB)
+            .filter(TaskLatestDB.event_type == 'task-failed', TaskLatestDB.timestamp >= one_hour_ago)
+            .all()
+        )
+        recent_successes = (
+            self.session.query(TaskLatestDB)
+            .filter(TaskLatestDB.event_type == 'task-succeeded', TaskLatestDB.timestamp >= one_hour_ago)
+            .all()
+        )
+
+        queue_active_counts: Dict[str, int] = defaultdict(int)
+        queue_workers: Dict[str, set[str]] = defaultdict(set)
+        worker_active_queues: Dict[str, set[str]] = defaultdict(set)
+        worker_active_counts: Dict[str, int] = defaultdict(int)
+        for row in active_rows:
+            queue_name = row.queue or row.routing_key or 'default'
+            queue_active_counts[queue_name] += 1
+            if row.hostname:
+                queue_workers[queue_name].add(row.hostname)
+                worker_active_queues[row.hostname].add(queue_name)
+                worker_active_counts[row.hostname] += 1
+
+        queue_failure_counts: Dict[str, int] = defaultdict(int)
+        worker_failure_counts: Dict[str, int] = defaultdict(int)
+        for row in recent_failures:
+            queue_name = row.queue or row.routing_key or 'default'
+            queue_failure_counts[queue_name] += 1
+            if row.hostname:
+                worker_failure_counts[row.hostname] += 1
+
+        queue_throughput_counts: Dict[str, int] = defaultdict(int)
+        for row in recent_successes:
+            queue_name = row.queue or row.routing_key or 'default'
+            queue_throughput_counts[queue_name] += 1
+
+        queue_names = set(queue_active_counts) | set(queue_failure_counts) | set(queue_throughput_counts)
+        queue_summaries: List[QueueHealthSummary] = []
+        for queue_name in sorted(queue_names):
+            active = queue_active_counts.get(queue_name, 0)
+            failures = queue_failure_counts.get(queue_name, 0)
+            throughput = queue_throughput_counts.get(queue_name, 0)
+            if failures >= 3:
+                status = 'critical'
+                summary = f'{failures} failures in the last hour'
+            elif active >= 5 and throughput == 0:
+                status = 'warning'
+                summary = f'{active} active tasks with no completions in the last hour'
+            else:
+                status = 'healthy'
+                summary = f'{throughput} completions in the last hour'
+            queue_summaries.append(QueueHealthSummary(
+                queue_name=queue_name,
+                active_tasks=active,
+                recent_failures=failures,
+                throughput_last_hour=throughput,
+                workers=sorted(queue_workers.get(queue_name, set())),
+                status=status,
+                summary=summary,
+            ))
+
+        worker_summaries: List[WorkerOperationalSummary] = []
+        for hostname, data in sorted(workers_data.items()):
+            maintenance_state = data.get('maintenance_state') or data.get('maintenance')
+            drain_state = data.get('drain_state') or data.get('drain')
+            active_tasks = int(data.get('active', 0) or 0)
+            recent_failures_count = worker_failure_counts.get(hostname, 0)
+            summary = 'Online and processing normally'
+            if data.get('status') == 'offline':
+                summary = 'Offline or heartbeat missing'
+            elif drain_state:
+                summary = f'Drain state: {drain_state}'
+            elif maintenance_state:
+                summary = f'Maintenance state: {maintenance_state}'
+            elif recent_failures_count:
+                summary = f'{recent_failures_count} recent failures tied to this worker'
+            worker_summaries.append(WorkerOperationalSummary(
+                hostname=hostname,
+                status=data.get('status', 'unknown'),
+                active_tasks=active_tasks,
+                processed_tasks=int(data.get('processed', 0) or 0),
+                recent_failures=recent_failures_count,
+                active_queues=sorted(worker_active_queues.get(hostname, set())),
+                maintenance_state=maintenance_state,
+                drain_state=drain_state,
+                summary=summary,
+            ))
+
+        note_rows = (
+            self.session.query(AppSettingDB)
+            .filter(AppSettingDB.key.like('operator_notes.%'))
+            .order_by(desc(AppSettingDB.updated_at))
+            .all()
+        )
+        notes: List[QueueWorkerNote] = []
+        for row in note_rows:
+            value = row.value or {}
+            entity_type = value.get('entity_type')
+            entity_key = value.get('entity_key')
+            note = value.get('note')
+            if entity_type in {'queue', 'worker'} and entity_key and note:
+                notes.append(QueueWorkerNote(
+                    entity_type=entity_type,
+                    entity_key=entity_key,
+                    note=note,
+                    author=value.get('author'),
+                    created_at=row.created_at,
+                    updated_at=row.updated_at,
+                ))
+
+        return QueueWorkerSurfaceResponse(queues=queue_summaries, workers=worker_summaries, notes=notes)
+
+    def save_operator_note(self, entity_type: str, entity_key: str, note: str, author: Optional[str] = None) -> QueueWorkerNote:
+        key = f'operator_notes.{entity_type}.{entity_key}'
+        existing = self.session.query(AppSettingDB).filter_by(key=key).first()
+        value = {
+            'entity_type': entity_type,
+            'entity_key': entity_key,
+            'note': note,
+            'author': author,
+        }
+        if existing:
+            existing.value = value
+            existing.value_type = 'json'
+            existing.category = 'operator_notes'
+            existing.label = f'{entity_type}:{entity_key}'
+            existing.description = 'Operator note for queue/worker incident context'
+            row = existing
+        else:
+            row = AppSettingDB(
+                key=key,
+                value=value,
+                value_type='json',
+                category='operator_notes',
+                label=f'{entity_type}:{entity_key}',
+                description='Operator note for queue/worker incident context',
+            )
+            self.session.add(row)
+        self.session.commit()
+        self.session.refresh(row)
+        return QueueWorkerNote(
+            entity_type=entity_type,
+            entity_key=entity_key,
+            note=note,
+            author=author,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )

--- a/agent/tests/unit/test_worker_operations.py
+++ b/agent/tests/unit/test_worker_operations.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timedelta, timezone
+
+from database import TaskLatestDB, AppSettingDB
+from services.worker_service import WorkerService
+from tests.base import DatabaseTestCase
+
+
+class TestWorkerOperations(DatabaseTestCase):
+    def test_builds_queue_and_worker_surface_with_notes(self):
+        now = datetime.now(timezone.utc)
+        self.session.add_all([
+            TaskLatestDB(task_id='active-1', event_id=1, task_name='tasks.alpha', event_type='task-started', timestamp=now, hostname='worker-a', queue='priority'),
+            TaskLatestDB(task_id='active-2', event_id=2, task_name='tasks.alpha', event_type='task-received', timestamp=now, hostname='worker-a', queue='priority'),
+            TaskLatestDB(task_id='fail-1', event_id=3, task_name='tasks.alpha', event_type='task-failed', timestamp=now, hostname='worker-a', queue='priority'),
+            TaskLatestDB(task_id='done-1', event_id=4, task_name='tasks.alpha', event_type='task-succeeded', timestamp=now - timedelta(minutes=5), hostname='worker-a', queue='priority'),
+            AppSettingDB(key='operator_notes.worker.worker-a', value={'entity_type': 'worker', 'entity_key': 'worker-a', 'note': 'Investigating memory pressure', 'author': 'ops'}, value_type='json', category='operator_notes'),
+        ])
+        self.session.commit()
+
+        service = WorkerService(self.session)
+        surface = service.get_queue_worker_surface({
+            'worker-a': {'status': 'online', 'active': 2, 'processed': 11},
+        })
+
+        self.assertEqual(len(surface.queues), 1)
+        self.assertEqual(surface.queues[0].queue_name, 'priority')
+        self.assertEqual(surface.queues[0].active_tasks, 2)
+        self.assertEqual(surface.queues[0].recent_failures, 1)
+        self.assertEqual(surface.queues[0].throughput_last_hour, 1)
+
+        self.assertEqual(len(surface.workers), 1)
+        self.assertEqual(surface.workers[0].hostname, 'worker-a')
+        self.assertEqual(surface.workers[0].active_queues, ['priority'])
+        self.assertEqual(surface.workers[0].recent_failures, 1)
+
+        self.assertEqual(len(surface.notes), 1)
+        self.assertEqual(surface.notes[0].entity_key, 'worker-a')
+
+    def test_save_operator_note_upserts(self):
+        service = WorkerService(self.session)
+        note = service.save_operator_note('queue', 'priority', 'Drain after deploy', 'bernhard')
+        self.assertEqual(note.entity_type, 'queue')
+        self.assertEqual(note.entity_key, 'priority')
+        self.assertEqual(note.note, 'Drain after deploy')
+
+        updated = service.save_operator_note('queue', 'priority', 'Drain completed', 'bernhard')
+        self.assertEqual(updated.note, 'Drain completed')
+        rows = self.session.query(AppSettingDB).filter_by(key='operator_notes.queue.priority').all()
+        self.assertEqual(len(rows), 1)

--- a/frontend/app/components/QueueWorkerOperationsCard.vue
+++ b/frontend/app/components/QueueWorkerOperationsCard.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="rounded-lg border border-border-subtle bg-background-surface p-4 space-y-4 glow-border">
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <h3 class="text-sm font-medium text-text-primary">Queue & worker operations</h3>
+        <p class="text-xs text-text-secondary">Operational context only — direct revoke/pause controls stay guarded for now.</p>
+      </div>
+      <span class="text-xs text-text-muted">{{ criticalQueues.length }} critical queues</span>
+    </div>
+
+    <div class="grid gap-3 lg:grid-cols-2">
+      <div class="space-y-2">
+        <div class="text-xs font-medium text-text-secondary uppercase tracking-wide">Queues</div>
+        <div v-if="surface.queues.length === 0" class="text-xs text-text-muted">No queue activity yet.</div>
+        <div v-for="queue in surface.queues.slice(0, 4)" :key="queue.queue_name" class="rounded-md border border-border-subtle p-3 space-y-1">
+          <div class="flex items-center justify-between gap-2">
+            <span class="font-mono text-xs">{{ queue.queue_name }}</span>
+            <Badge :variant="queue.status === 'critical' ? 'destructive' : queue.status === 'warning' ? 'secondary' : 'success'">{{ queue.status }}</Badge>
+          </div>
+          <div class="text-xs text-text-secondary">{{ queue.summary }}</div>
+          <div class="text-[11px] text-text-muted">{{ queue.active_tasks }} active · {{ queue.recent_failures }} failed · {{ queue.throughput_last_hour }} completed/hr</div>
+        </div>
+      </div>
+
+      <div class="space-y-2">
+        <div class="text-xs font-medium text-text-secondary uppercase tracking-wide">Workers</div>
+        <div v-if="surface.workers.length === 0" class="text-xs text-text-muted">No workers detected.</div>
+        <div v-for="worker in surface.workers.slice(0, 4)" :key="worker.hostname" class="rounded-md border border-border-subtle p-3 space-y-1">
+          <div class="flex items-center justify-between gap-2">
+            <span class="font-mono text-xs">{{ worker.hostname }}</span>
+            <Badge variant="outline">{{ worker.status }}</Badge>
+          </div>
+          <div class="text-xs text-text-secondary">{{ worker.summary }}</div>
+          <div class="text-[11px] text-text-muted">{{ worker.active_tasks }} active · {{ worker.recent_failures }} failures · queues: {{ worker.active_queues.join(', ') || '—' }}</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <div class="text-xs font-medium text-text-secondary uppercase tracking-wide">Operator note</div>
+      <div class="flex flex-col gap-2 md:flex-row">
+        <select v-model="entityType" class="rounded-md border border-border-subtle bg-background px-3 py-2 text-xs">
+          <option value="queue">Queue</option>
+          <option value="worker">Worker</option>
+        </select>
+        <input v-model="entityKey" placeholder="priority or worker-a" class="rounded-md border border-border-subtle bg-background px-3 py-2 text-xs flex-1" />
+      </div>
+      <textarea v-model="note" rows="2" placeholder="Record maintenance, drain, deploy, or investigation context." class="w-full rounded-md border border-border-subtle bg-background px-3 py-2 text-xs" />
+      <div class="flex items-center justify-between gap-3">
+        <div class="text-[11px] text-text-muted">Saved notes appear below and help future incident triage.</div>
+        <Button size="sm" variant="outline" :disabled="!entityKey || !note || isSaving" @click="submit">{{ isSaving ? 'Saving…' : 'Save note' }}</Button>
+      </div>
+      <div class="space-y-2">
+        <div v-for="saved in surface.notes.slice(0, 5)" :key="`${saved.entity_type}:${saved.entity_key}`" class="rounded-md border border-border-subtle p-2 text-xs">
+          <div class="flex items-center justify-between gap-2">
+            <span class="font-mono">{{ saved.entity_type }}:{{ saved.entity_key }}</span>
+            <span class="text-text-muted">{{ saved.author || 'operator' }}</span>
+          </div>
+          <div class="mt-1 text-text-secondary">{{ saved.note }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Badge } from '~/components/ui/badge'
+import { Button } from '~/components/ui/button'
+import type { QueueWorkerSurfaceResponse } from '~/services/apiClient'
+
+const props = defineProps<{
+  surface: QueueWorkerSurfaceResponse
+  criticalQueues: Array<{ queue_name: string }>
+}>()
+
+const emit = defineEmits<{
+  save: [payload: { entity_type: 'queue' | 'worker'; entity_key: string; note: string }]
+}>()
+
+const entityType = ref<'queue' | 'worker'>('queue')
+const entityKey = ref('')
+const note = ref('')
+const isSaving = ref(false)
+
+async function submit() {
+  if (!entityKey.value || !note.value) return
+  isSaving.value = true
+  try {
+    emit('save', { entity_type: entityType.value, entity_key: entityKey.value.trim(), note: note.value.trim() })
+    note.value = ''
+  } finally {
+    isSaving.value = false
+  }
+}
+</script>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -14,6 +14,14 @@
         />
       </div>
 
+      <div class="mb-6">
+        <QueueWorkerOperationsCard
+          :surface="queueWorkerSurfaceStore.surface"
+          :critical-queues="queueWorkerSurfaceStore.criticalQueues"
+          @save="handleSaveQueueWorkerNote"
+        />
+      </div>
+
       <!-- Failure & Orphaned Tasks Overview -->
       <div class="mb-6 flex flex-col gap-4 failure-insights-section">
         <TaskIssueSummary
@@ -207,6 +215,7 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { getTaskColumns } from "~/config/tableColumns"
 import DataTable from "~/components/data-table.vue"
 import WorkerStatusSummary from "~/components/WorkerStatusSummary.vue"
+import QueueWorkerOperationsCard from "~/components/QueueWorkerOperationsCard.vue"
 import CommandPalette from "~/components/CommandPalette.vue"
 import TaskIssueSummary from "~/components/TaskIssueSummary.vue"
 import RetryTaskConfirmDialog from "~/components/RetryTaskConfirmDialog.vue"
@@ -224,6 +233,7 @@ import {IconButton} from "~/components/common";
 
 const tasksStore = useTasksStore()
 const workersStore = useWorkersStore()
+const queueWorkerSurfaceStore = useQueueWorkerSurfaceStore()
 const orphanTasksStore = useOrphanTasksStore()
 const failedTasksStore = useFailedTasksStore()
 const configStore = useConfigStore()
@@ -415,6 +425,10 @@ async function handleRerunTask(taskId: string) {
   }
 }
 
+async function handleSaveQueueWorkerNote(payload: { entity_type: 'queue' | 'worker'; entity_key: string; note: string }) {
+  await queueWorkerSurfaceStore.saveNote(payload)
+}
+
 function openRetryDialog(task: TaskEventResponse, type: 'failed' | 'orphan') {
   retryDialogState.value = { task, type }
   retryDialogRef.value?.open()
@@ -562,6 +576,7 @@ watch(() => environmentStore.activeEnvironment, async () => {
     tasksStore.fetchRecentEvents(),
     tasksStore.fetchStats(),
     workersStore.fetchWorkers(),
+    queueWorkerSurfaceStore.fetchSurface(),
     orphanTasksStore.fetchOrphanedTasks(),
     failedTasksStore.fetchFailedTasks({ hours: failedTasksStore.lookbackHours })
   ])
@@ -593,6 +608,7 @@ onMounted(async () => {
     tasksStore.fetchRecentEvents(),
     tasksStore.fetchStats(),
     workersStore.fetchWorkers(),
+    queueWorkerSurfaceStore.fetchSurface(),
     orphanTasksStore.fetchOrphanedTasks(),
     failedTasksStore.fetchFailedTasks({ hours: failedTasksStore.lookbackHours })
   ])
@@ -614,6 +630,7 @@ onMounted(async () => {
     // Only fetch if WebSocket is not connected
     if (!wsStore.isConnected) {
       workersStore.fetchWorkers()
+      queueWorkerSurfaceStore.fetchSurface().catch(() => {})
     }
   }, 30000)
 })

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -126,6 +126,43 @@ export interface TaskProgressSnapshotResponse {
   history: TaskProgressEventResponse[]
 }
 
+export interface QueueHealthSummaryResponse {
+  queue_name: string
+  active_tasks: number
+  recent_failures: number
+  throughput_last_hour: number
+  workers: string[]
+  status: 'healthy' | 'warning' | 'critical'
+  summary: string
+}
+
+export interface WorkerOperationalSummaryResponse {
+  hostname: string
+  status: string
+  active_tasks: number
+  processed_tasks: number
+  recent_failures: number
+  active_queues: string[]
+  maintenance_state?: string | null
+  drain_state?: string | null
+  summary: string
+}
+
+export interface QueueWorkerNoteResponse {
+  entity_type: 'queue' | 'worker'
+  entity_key: string
+  note: string
+  author?: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface QueueWorkerSurfaceResponse {
+  queues: QueueHealthSummaryResponse[]
+  workers: WorkerOperationalSummaryResponse[]
+  notes: QueueWorkerNoteResponse[]
+}
+
 class ApiService {
   private api: Api<unknown>
 
@@ -391,6 +428,23 @@ class ApiService {
 
   async getRecentWorkerEvents(limit = 50): Promise<any> {
     const response = await this.api.api.getRecentWorkerEventsApiWorkersEventsRecentGet({ limit })
+    return response.data
+  }
+
+  async getQueueWorkerSurface(): Promise<QueueWorkerSurfaceResponse> {
+    const response = await this.api.request({
+      path: '/api/worker-operations',
+      method: 'GET'
+    })
+    return response.data
+  }
+
+  async saveQueueWorkerNote(payload: { entity_type: 'queue' | 'worker'; entity_key: string; note: string; author?: string | null }): Promise<QueueWorkerNoteResponse> {
+    const response = await this.api.request({
+      path: '/api/workers/notes',
+      method: 'POST',
+      body: payload
+    })
     return response.data
   }
 
@@ -765,7 +819,9 @@ export type {
   AppConfigSnapshotDTO,
   AppSettingDTO,
   AppSettingInput,
-  TaskIssueConfigDTO
+  TaskIssueConfigDTO,
+  QueueWorkerSurfaceResponse,
+  QueueWorkerNoteResponse
 }
 
 // Re-export session types from auto-generated API

--- a/frontend/app/stores/queueWorkerSurface.ts
+++ b/frontend/app/stores/queueWorkerSurface.ts
@@ -1,0 +1,45 @@
+import { defineStore } from 'pinia'
+import { computed, readonly, ref } from 'vue'
+import { useApiService, type QueueWorkerSurfaceResponse } from '../services/apiClient'
+
+export const useQueueWorkerSurfaceStore = defineStore('queueWorkerSurface', () => {
+  const api = useApiService()
+  const surface = ref<QueueWorkerSurfaceResponse>({ queues: [], workers: [], notes: [] })
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+
+  const criticalQueues = computed(() => surface.value.queues.filter(queue => queue.status === 'critical'))
+  const notedEntities = computed(() => new Set(surface.value.notes.map(note => `${note.entity_type}:${note.entity_key}`)))
+
+  async function fetchSurface() {
+    try {
+      isLoading.value = true
+      error.value = null
+      surface.value = await api.getQueueWorkerSurface()
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch queue/worker surface'
+      throw err
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function saveNote(payload: { entity_type: 'queue' | 'worker'; entity_key: string; note: string; author?: string | null }) {
+    const note = await api.saveQueueWorkerNote(payload)
+    surface.value.notes = [
+      note,
+      ...surface.value.notes.filter(existing => !(existing.entity_type === note.entity_type && existing.entity_key === note.entity_key)),
+    ]
+    return note
+  }
+
+  return {
+    surface: readonly(surface),
+    isLoading: readonly(isLoading),
+    error: readonly(error),
+    criticalQueues,
+    notedEntities,
+    fetchSurface,
+    saveNote,
+  }
+})

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,18 @@
 /** @type {import('tailwindcss').Config} */
+const withOpacity = (cssVariable: string) => ({ opacityValue }: { opacityValue?: string }) => {
+  if (opacityValue === undefined) {
+    return `var(${cssVariable})`
+  }
+
+  const opacity = Number.parseFloat(opacityValue)
+
+  if (Number.isNaN(opacity)) {
+    return `var(${cssVariable})`
+  }
+
+  return `color-mix(in srgb, var(${cssVariable}) ${opacity * 100}%, transparent)`
+}
+
 export default {
   content: [
     "./app/**/*.{js,vue,ts}",
@@ -19,90 +33,90 @@ export default {
       colors: {
         // Backgrounds using CSS variables
         background: {
-          base: 'var(--bg-base)',
-          surface: 'var(--bg-surface)',
-          raised: 'var(--bg-raised)',
+          base: withOpacity('--bg-base'),
+          surface: withOpacity('--bg-surface'),
+          raised: withOpacity('--bg-raised'),
           overlay: 'hsl(0, 0%, 18%, 0.8)',
           // Interactive states
-          hover: 'var(--bg-hover)',
-          'hover-subtle': 'var(--bg-hover-subtle)',
-          active: 'var(--bg-active)',
-          selected: 'var(--bg-selected)'
+          hover: withOpacity('--bg-hover'),
+          'hover-subtle': withOpacity('--bg-hover-subtle'),
+          active: withOpacity('--bg-active'),
+          selected: withOpacity('--bg-selected')
         },
         // Text colors using CSS variables
         text: {
-          primary: 'var(--text-primary)',
-          secondary: 'var(--text-secondary)',
-          muted: 'var(--text-muted)',
-          disabled: 'var(--text-disabled)'
+          primary: withOpacity('--text-primary'),
+          secondary: withOpacity('--text-secondary'),
+          muted: withOpacity('--text-muted'),
+          disabled: withOpacity('--text-disabled')
         },
         // Card and borders
         card: {
-          base: 'var(--bg-surface)',
-          border: 'var(--border)',
+          base: withOpacity('--bg-surface'),
+          border: withOpacity('--border'),
         },
         // Border colors
         border: {
-          DEFAULT: 'var(--border)',
-          highlight: 'var(--highlight)',
-          subtle: 'var(--border-subtle)'
+          DEFAULT: withOpacity('--border'),
+          highlight: withOpacity('--highlight'),
+          subtle: withOpacity('--border-subtle')
         },
         // Primary/Brand colors
         primary: {
-          DEFAULT: 'var(--primary)',
-          hover: 'var(--primary-hover)',
-          bg: 'var(--primary-bg)',
-          border: 'var(--primary-border)'
+          DEFAULT: withOpacity('--primary'),
+          hover: withOpacity('--primary-hover'),
+          bg: withOpacity('--primary-bg'),
+          border: withOpacity('--primary-border')
         },
         // Semantic status colors using CSS variables
         status: {
           // Success states
           success: {
-            DEFAULT: 'var(--status-success)',
-            bg: 'var(--status-success-bg)',
-            border: 'var(--status-success-border)',
+            DEFAULT: withOpacity('--status-success'),
+            bg: withOpacity('--status-success-bg'),
+            border: withOpacity('--status-success-border'),
             hover: 'hsl(158,100%,13%)'
           },
           // Error states
           error: {
-            DEFAULT: 'var(--status-error)',
-            bg: 'var(--status-error-bg)',
-            border: 'var(--status-error-border)',
+            DEFAULT: withOpacity('--status-error'),
+            bg: withOpacity('--status-error-bg'),
+            border: withOpacity('--status-error-border'),
             hover: 'hsl(347, 77%, 18%)'
           },
           // Warning states
           warning: {
-            DEFAULT: 'var(--status-warning)',
-            bg: 'var(--status-warning-bg)',
-            border: 'var(--status-warning-border)',
+            DEFAULT: withOpacity('--status-warning'),
+            bg: withOpacity('--status-warning-bg'),
+            border: withOpacity('--status-warning-border'),
             hover: 'hsl(45, 85%, 18%)'
           },
           // Info states
           info: {
-            DEFAULT: 'var(--status-info)',
-            bg: 'var(--status-info-bg)',
-            border: 'var(--status-info-border)',
+            DEFAULT: withOpacity('--status-info'),
+            bg: withOpacity('--status-info-bg'),
+            border: withOpacity('--status-info-border'),
             hover: 'hsl(199, 89%, 18%)'
           },
           // Retry states
           retry: {
-            DEFAULT: 'var(--status-retry)',
-            bg: 'var(--status-retry-bg)',
-            border: 'var(--status-retry-border)',
+            DEFAULT: withOpacity('--status-retry'),
+            bg: withOpacity('--status-retry-bg'),
+            border: withOpacity('--status-retry-border'),
             hover: 'hsl(24, 95%, 18%)'
           },
           // Neutral states
           neutral: {
-            DEFAULT: 'var(--status-neutral)',
-            bg: 'var(--status-neutral-bg)',
-            border: 'var(--status-neutral-border)',
+            DEFAULT: withOpacity('--status-neutral'),
+            bg: withOpacity('--status-neutral-bg'),
+            border: withOpacity('--status-neutral-border'),
             hover: 'hsl(215, 20%, 18%)'
           },
           // Special states
           special: {
-            DEFAULT: 'var(--status-special)',
-            bg: 'var(--status-special-bg)',
-            border: 'var(--status-special-border)',
+            DEFAULT: withOpacity('--status-special'),
+            bg: withOpacity('--status-special-bg'),
+            border: withOpacity('--status-special-border'),
             hover: 'hsl(263, 70%, 18%)'
           }
         }


### PR DESCRIPTION
$## Summary
- add queue/worker operational summaries plus operator notes API surface
- add dashboard queue & worker operations card with note capture and contextual status summaries
- avoid route collisions by serving the dashboard surface from `/api/worker-operations`

## Verification
- python3 -m unittest tests.unit.test_worker_operations -v
- npm run build
- local API check against seeded SQLite scenario for `/api/worker-operations`
- local Playwright proof: `/data/.openclaw/workspace/tmp/kanchi-99-queue-worker-operations.mp4`