### PR TITLE
Add failed-task suppression controls

### DIFF
--- a/agent/api/task_routes.py
+++ b/agent/api/task_routes.py
@@ -8,9 +8,9 @@ from fastapi import APIRouter, Depends, HTTPException, Header, Query
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
-from services import TaskService, EnvironmentService, SessionService, AppConfigService, ProgressService
+from services import TaskService, EnvironmentService, SessionService, AppConfigService, ProgressService, SuppressionService
 from database import TaskEventDB
-from models import TaskEvent, TaskProgressSnapshot
+from models import TaskEvent, TaskProgressSnapshot, TaskSuppressionRule, TaskSuppressionRuleCreate, TaskSuppressionMetrics
 from database import ensure_utc_isoformat
 from config import Config
 from security.auth import AuthenticatedUser
@@ -172,7 +172,41 @@ def create_router(app_state) -> APIRouter:
             limit=limit,
             exclude_retried=not include_retried
         )
+        SuppressionService(session).annotate_events(failed_tasks)
         return failed_tasks
+
+    @router.get("/task-suppressions", response_model=List[TaskSuppressionRule])
+    async def list_task_suppressions(
+        include_expired: bool = False,
+        session: Session = Depends(get_db),
+    ):
+        return SuppressionService(session).list_rules(include_expired=include_expired)
+
+    @router.post("/task-suppressions", response_model=TaskSuppressionRule)
+    async def create_task_suppression(
+        payload: TaskSuppressionRuleCreate,
+        session: Session = Depends(get_db),
+    ):
+        return SuppressionService(session).create_rule(payload)
+
+    @router.delete("/task-suppressions/{rule_id}", status_code=204)
+    async def delete_task_suppression(rule_id: str, session: Session = Depends(get_db)):
+        deleted = SuppressionService(session).delete_rule(rule_id)
+        if not deleted:
+            raise HTTPException(status_code=404, detail="Suppression rule not found")
+        return None
+
+    @router.get("/tasks/failed/suppression-metrics", response_model=TaskSuppressionMetrics)
+    async def get_failed_task_suppression_metrics(
+        hours: Optional[int] = Query(default=None, ge=1, le=168),
+        session: Session = Depends(get_db),
+        active_env = Depends(get_active_env)
+    ):
+        task_service = TaskService(session, active_env=active_env)
+        config_service = AppConfigService(session)
+        lookback_hours = hours if hours is not None else config_service.get_task_issue_lookback_hours()
+        failed_tasks = task_service.get_recent_failed_tasks(hours=lookback_hours, limit=500, exclude_retried=True)
+        return SuppressionService(session).annotate_events(failed_tasks)
 
 
     @router.post("/tasks/{task_id}/resolve")

--- a/agent/api/task_routes.py
+++ b/agent/api/task_routes.py
@@ -183,14 +183,14 @@ def create_router(app_state) -> APIRouter:
         return SuppressionService(session).list_rules(include_expired=include_expired)
 
     @router.post("/task-suppressions", response_model=TaskSuppressionRule)
-    async def create_task_suppression(
+    def create_task_suppression(
         payload: TaskSuppressionRuleCreate,
         session: Session = Depends(get_db),
     ):
         return SuppressionService(session).create_rule(payload)
 
     @router.delete("/task-suppressions/{rule_id}", status_code=204)
-    async def delete_task_suppression(rule_id: str, session: Session = Depends(get_db)):
+    def delete_task_suppression(rule_id: str, session: Session = Depends(get_db)):
         deleted = SuppressionService(session).delete_rule(rule_id)
         if not deleted:
             raise HTTPException(status_code=404, detail="Suppression rule not found")
@@ -205,7 +205,7 @@ def create_router(app_state) -> APIRouter:
         task_service = TaskService(session, active_env=active_env)
         config_service = AppConfigService(session)
         lookback_hours = hours if hours is not None else config_service.get_task_issue_lookback_hours()
-        failed_tasks = task_service.get_recent_failed_tasks(hours=lookback_hours, limit=500, exclude_retried=True)
+        failed_tasks = task_service.get_recent_failed_tasks(hours=lookback_hours, exclude_retried=True)
         return SuppressionService(session).annotate_events(failed_tasks)
 
 

--- a/agent/models.py
+++ b/agent/models.py
@@ -469,6 +469,18 @@ class TaskSuppressionRuleCreate(BaseModel):
     exception_contains: Optional[str] = None
     expires_at: Optional[datetime] = None
 
+    @field_validator('expires_at', mode='before')
+    @classmethod
+    def validate_expires_at(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        if isinstance(value, str):
+            parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+        return value
+
 
 class TaskSuppressionRule(TaskSuppressionRuleCreate):
     id: str

--- a/agent/models.py
+++ b/agent/models.py
@@ -39,6 +39,10 @@ class TaskEvent(BaseModel):
     resolved: bool = False
     resolved_by: Optional[str] = None
     resolved_at: Optional[datetime] = None
+    suppressed: bool = False
+    suppression_rule_id: Optional[str] = None
+    suppression_reason: Optional[str] = None
+    suppression_expires_at: Optional[datetime] = None
 
     model_config = {
         'from_attributes': True,
@@ -457,6 +461,23 @@ class AppSettingUpdate(BaseModel):
 class TaskIssueConfig(BaseModel):
     """Configuration for the task issue summary section."""
     lookback_hours: int = Field(default=24, ge=1, le=168)
+
+
+class TaskSuppressionRuleCreate(BaseModel):
+    task_name: str
+    reason: str
+    exception_contains: Optional[str] = None
+    expires_at: Optional[datetime] = None
+
+
+class TaskSuppressionRule(TaskSuppressionRuleCreate):
+    id: str
+    created_at: datetime
+
+
+class TaskSuppressionMetrics(BaseModel):
+    active_count: int = 0
+    suppressed_count: int = 0
 
 
 class DataRetentionConfig(BaseModel):

--- a/agent/services/__init__.py
+++ b/agent/services/__init__.py
@@ -10,6 +10,7 @@ from .environment_service import EnvironmentService
 from .session_service import SessionService
 from .auth_service import AuthService
 from .app_config_service import AppConfigService
+from .suppression_service import SuppressionService
 from .retention_service import RetentionService
 
 __all__ = [
@@ -23,5 +24,6 @@ __all__ = [
     'SessionService',
     'AuthService',
     'AppConfigService',
+    'SuppressionService',
     'RetentionService'
 ]

--- a/agent/services/suppression_service.py
+++ b/agent/services/suppression_service.py
@@ -1,0 +1,107 @@
+"""Suppression rules for noisy task failures."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from database import AppSettingDB
+from models import TaskEvent, TaskSuppressionMetrics, TaskSuppressionRule, TaskSuppressionRuleCreate
+
+SUPPRESSION_RULES_KEY = "task_issue_summary.suppression_rules"
+
+
+def _ensure_utc(dt: Optional[datetime]) -> Optional[datetime]:
+    if dt is None:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+class SuppressionService:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list_rules(self, include_expired: bool = False) -> List[TaskSuppressionRule]:
+        rules = [self._normalize_rule(item) for item in self._raw_rules()]
+        if include_expired:
+            return rules
+        now = datetime.now(timezone.utc)
+        return [rule for rule in rules if not rule.expires_at or rule.expires_at > now]
+
+    def create_rule(self, payload: TaskSuppressionRuleCreate) -> TaskSuppressionRule:
+        rules = self._raw_rules()
+        rule = TaskSuppressionRule(
+            id=str(uuid4()),
+            task_name=payload.task_name,
+            exception_contains=payload.exception_contains,
+            reason=payload.reason,
+            created_at=datetime.now(timezone.utc),
+            expires_at=_ensure_utc(payload.expires_at),
+        )
+        rules.append(rule.model_dump(mode="json"))
+        self._save_rules(rules)
+        return rule
+
+    def delete_rule(self, rule_id: str) -> bool:
+        rules = self._raw_rules()
+        filtered = [rule for rule in rules if rule.get("id") != rule_id]
+        if len(filtered) == len(rules):
+            return False
+        self._save_rules(filtered)
+        return True
+
+    def match_rule(self, event: TaskEvent) -> Optional[TaskSuppressionRule]:
+        for rule in self.list_rules():
+            if rule.task_name != event.task_name:
+                continue
+            if rule.exception_contains and rule.exception_contains not in (event.exception or ""):
+                continue
+            return rule
+        return None
+
+    def annotate_events(self, events: List[TaskEvent]) -> TaskSuppressionMetrics:
+        active = 0
+        suppressed = 0
+        for event in events:
+            rule = self.match_rule(event)
+            if rule:
+                event.suppressed = True
+                event.suppression_rule_id = rule.id
+                event.suppression_reason = rule.reason
+                event.suppression_expires_at = rule.expires_at
+                suppressed += 1
+            else:
+                event.suppressed = False
+                active += 1
+        return TaskSuppressionMetrics(active_count=active, suppressed_count=suppressed)
+
+    def _raw_rules(self) -> List[Dict[str, Any]]:
+        setting = self.session.query(AppSettingDB).filter_by(key=SUPPRESSION_RULES_KEY).first()
+        if not setting or not isinstance(setting.value, list):
+            return []
+        return setting.value
+
+    def _save_rules(self, rules: List[Dict[str, Any]]) -> None:
+        setting = self.session.query(AppSettingDB).filter_by(key=SUPPRESSION_RULES_KEY).first()
+        if setting:
+            setting.value = rules
+            setting.value_type = "json"
+            setting.label = setting.label or "Task issue suppression rules"
+            setting.description = setting.description or "Rules for muting noisy failed-task patterns."
+            setting.category = setting.category or "task_issue_summary"
+        else:
+            self.session.add(AppSettingDB(
+                key=SUPPRESSION_RULES_KEY,
+                value=rules,
+                value_type="json",
+                label="Task issue suppression rules",
+                description="Rules for muting noisy failed-task patterns.",
+                category="task_issue_summary",
+            ))
+        self.session.commit()
+
+    def _normalize_rule(self, payload: Dict[str, Any]) -> TaskSuppressionRule:
+        return TaskSuppressionRule(**payload)

--- a/agent/services/suppression_service.py
+++ b/agent/services/suppression_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from threading import RLock
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
@@ -12,6 +13,7 @@ from database import AppSettingDB
 from models import TaskEvent, TaskSuppressionMetrics, TaskSuppressionRule, TaskSuppressionRuleCreate
 
 SUPPRESSION_RULES_KEY = "task_issue_summary.suppression_rules"
+SUPPRESSION_RULES_LOCK = RLock()
 
 
 def _ensure_utc(dt: Optional[datetime]) -> Optional[datetime]:
@@ -42,26 +44,28 @@ class SuppressionService:
         return None
 
     def create_rule(self, payload: TaskSuppressionRuleCreate) -> TaskSuppressionRule:
-        rules = self._raw_rules()
-        rule = TaskSuppressionRule(
-            id=str(uuid4()),
-            task_name=payload.task_name,
-            exception_contains=payload.exception_contains,
-            reason=payload.reason,
-            created_at=datetime.now(timezone.utc),
-            expires_at=_ensure_utc(payload.expires_at),
-        )
-        rules.append(rule.model_dump(mode="json"))
-        self._save_rules(rules)
-        return rule
+        with SUPPRESSION_RULES_LOCK:
+            rules = self._raw_rules()
+            rule = TaskSuppressionRule(
+                id=str(uuid4()),
+                task_name=payload.task_name,
+                exception_contains=payload.exception_contains,
+                reason=payload.reason,
+                created_at=datetime.now(timezone.utc),
+                expires_at=_ensure_utc(payload.expires_at),
+            )
+            rules.append(rule.model_dump(mode="json"))
+            self._save_rules(rules)
+            return rule
 
     def delete_rule(self, rule_id: str) -> bool:
-        rules = self._raw_rules()
-        filtered = [rule for rule in rules if rule.get("id") != rule_id]
-        if len(filtered) == len(rules):
-            return False
-        self._save_rules(filtered)
-        return True
+        with SUPPRESSION_RULES_LOCK:
+            rules = self._raw_rules()
+            filtered = [rule for rule in rules if rule.get("id") != rule_id]
+            if len(filtered) == len(rules):
+                return False
+            self._save_rules(filtered)
+            return True
 
     def match_rule(self, event: TaskEvent, rules: Optional[List[TaskSuppressionRule]] = None) -> Optional[TaskSuppressionRule]:
         return self._match_rule_from_rules(rules or self.list_rules(), event)

--- a/agent/services/suppression_service.py
+++ b/agent/services/suppression_service.py
@@ -31,6 +31,16 @@ class SuppressionService:
         now = datetime.now(timezone.utc)
         return [rule for rule in rules if not rule.expires_at or rule.expires_at > now]
 
+    @staticmethod
+    def _match_rule_from_rules(rules: List[TaskSuppressionRule], event: TaskEvent) -> Optional[TaskSuppressionRule]:
+        for rule in rules:
+            if rule.task_name != event.task_name:
+                continue
+            if rule.exception_contains and rule.exception_contains not in (event.exception or ""):
+                continue
+            return rule
+        return None
+
     def create_rule(self, payload: TaskSuppressionRuleCreate) -> TaskSuppressionRule:
         rules = self._raw_rules()
         rule = TaskSuppressionRule(
@@ -53,20 +63,15 @@ class SuppressionService:
         self._save_rules(filtered)
         return True
 
-    def match_rule(self, event: TaskEvent) -> Optional[TaskSuppressionRule]:
-        for rule in self.list_rules():
-            if rule.task_name != event.task_name:
-                continue
-            if rule.exception_contains and rule.exception_contains not in (event.exception or ""):
-                continue
-            return rule
-        return None
+    def match_rule(self, event: TaskEvent, rules: Optional[List[TaskSuppressionRule]] = None) -> Optional[TaskSuppressionRule]:
+        return self._match_rule_from_rules(rules or self.list_rules(), event)
 
     def annotate_events(self, events: List[TaskEvent]) -> TaskSuppressionMetrics:
         active = 0
         suppressed = 0
+        rules = self.list_rules()
         for event in events:
-            rule = self.match_rule(event)
+            rule = self.match_rule(event, rules=rules)
             if rule:
                 event.suppressed = True
                 event.suppression_rule_id = rule.id

--- a/agent/services/workflow_engine.py
+++ b/agent/services/workflow_engine.py
@@ -16,6 +16,7 @@ from models import (
 from services.workflow_service import WorkflowService
 from services.workflow_executor import WorkflowExecutor
 from services.workflow_catalog import EVENT_TRIGGER_MAP, TRIGGER_METADATA
+from services.suppression_service import SuppressionService
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,16 @@ class WorkflowEngine:
         """Evaluate and execute matching workflows (async)."""
         with self.db_manager.get_session() as session:
             workflow_service = WorkflowService(session)
+            if trigger_type == "task.failed":
+                suppression_service = SuppressionService(session)
+                if isinstance(event, TaskEvent):
+                    matched_rule = suppression_service.match_rule(event)
+                    if matched_rule:
+                        context["suppressed"] = True
+                        context["suppression_reason"] = matched_rule.reason
+                        context["suppression_rule_id"] = matched_rule.id
+                        logger.info("Skipping workflow execution for suppressed failed task %s", event.task_id)
+                        return
 
             workflows = workflow_service.get_active_workflows_for_trigger(trigger_type)
 

--- a/agent/tests/unit/test_task_suppression.py
+++ b/agent/tests/unit/test_task_suppression.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timedelta, timezone
+
+from models import TaskEvent, TaskSuppressionRuleCreate
+from services.suppression_service import SuppressionService
+from tests.base import DatabaseTestCase
+
+
+class TestTaskSuppression(DatabaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.service = SuppressionService(self.session)
+
+    def _failed_event(self, task_name="tasks.noisy", exception="Timeout"):
+        return TaskEvent(
+            task_id="task-1",
+            task_name=task_name,
+            event_type="task-failed",
+            timestamp=datetime.now(timezone.utc),
+            exception=exception,
+        )
+
+    def test_matches_active_rule(self):
+        rule = self.service.create_rule(TaskSuppressionRuleCreate(task_name="tasks.noisy", reason="Known noisy", exception_contains="Timeout"))
+        event = self._failed_event()
+
+        matched = self.service.match_rule(event)
+
+        self.assertIsNotNone(matched)
+        self.assertEqual(matched.id, rule.id)
+
+    def test_expired_rule_is_ignored(self):
+        self.service.create_rule(TaskSuppressionRuleCreate(
+            task_name="tasks.noisy",
+            reason="Expired",
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        ))
+
+        self.assertIsNone(self.service.match_rule(self._failed_event(exception="anything")))
+
+    def test_annotate_events_counts_suppressed(self):
+        self.service.create_rule(TaskSuppressionRuleCreate(task_name="tasks.noisy", reason="Known noisy"))
+        events = [self._failed_event(), self._failed_event(task_name="tasks.real")]
+
+        metrics = self.service.annotate_events(events)
+
+        self.assertTrue(events[0].suppressed)
+        self.assertFalse(events[1].suppressed)
+        self.assertEqual(metrics.suppressed_count, 1)
+        self.assertEqual(metrics.active_count, 1)

--- a/agent/tests/unit/test_task_suppression.py
+++ b/agent/tests/unit/test_task_suppression.py
@@ -37,6 +37,21 @@ class TestTaskSuppression(DatabaseTestCase):
 
         self.assertIsNone(self.service.match_rule(self._failed_event(exception="anything")))
 
+    def test_list_rules_normalizes_naive_expiry_strings(self):
+        self.service._save_rules([{
+            "id": "rule-1",
+            "task_name": "tasks.noisy",
+            "reason": "naive expiry",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "expires_at": "2099-01-01T12:00:00",
+        }])
+
+        rules = self.service.list_rules()
+
+        self.assertEqual(len(rules), 1)
+        self.assertIsNotNone(rules[0].expires_at)
+        self.assertEqual(rules[0].expires_at.tzinfo, timezone.utc)
+
     def test_annotate_events_counts_suppressed(self):
         self.service.create_rule(TaskSuppressionRuleCreate(task_name="tasks.noisy", reason="Known noisy"))
         events = [self._failed_event(), self._failed_event(task_name="tasks.real")]

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -17,7 +17,7 @@
       <!-- Failure & Orphaned Tasks Overview -->
       <div class="mb-6 flex flex-col gap-4 failure-insights-section">
         <TaskIssueSummary
-          :tasks="failedTasksStore.failedTasks"
+          :tasks="failedTasksStore.activeFailedTasks"
           :is-loading="failedTasksStore.isLoading"
           :status="failedCardStatus"
           :summary-variant="failedSummaryVariant"
@@ -32,7 +32,7 @@
           latest-label="Last failure"
           time-field="timestamp"
           badge-label="Failed"
-          :badge-variant="failedTasksStore.failedTasks.length > 0 ? 'destructive': 'success'"
+          :badge-variant="failedTasksStore.activeFailedTasks.length > 0 ? 'destructive': 'success'"
           :show-retry-badge="true"
           :show-exception="true"
           :empty-state-title="failedTasksEmptyTitle"
@@ -76,6 +76,14 @@
               variant="outline"
               size="xs"
               class="gap-1"
+              @click.stop="handleSuppressAction(task)"
+            >
+              Mute
+            </Button>
+            <Button
+              variant="outline"
+              size="xs"
+              class="gap-1"
               :disabled="retryLoadingIds.includes(task.task_id)"
               @click.stop="handleFailedRetryAction(task)"
             >
@@ -87,6 +95,37 @@
               Retry
             </Button>
             </div>
+          </template>
+        </TaskIssueSummary>
+
+        <TaskIssueSummary
+          :tasks="failedTasksStore.suppressedFailedTasks"
+          :is-loading="failedTasksStore.isLoading"
+          status="neutral"
+          summary-variant="default"
+          :hide-when-empty="true"
+          title="Muted failed tasks"
+          primary-label="suppressed"
+          secondary-label="last hour"
+          recent-field="timestamp"
+          :recent-window-minutes="60"
+          latest-label="Last muted failure"
+          time-field="timestamp"
+          badge-label="Muted"
+          badge-variant="outline"
+          :show-retry-badge="true"
+          :show-exception="true"
+          empty-state-title="No muted failures"
+          empty-state-description="Suppressed noisy patterns land here instead of the active incident list."
+        >
+          <template #actions="{ task }">
+            <Button variant="outline" size="xs" class="gap-1" @click.stop="handleUnsuppressAction(task)">Unmute</Button>
+            <NuxtLink :to="`/tasks/${task.task_id}`">
+              <Button variant="outline" size="sm" class="gap-1.5">
+                <ChevronRight class="h-3.5 w-3.5" />
+                Open
+              </Button>
+            </NuxtLink>
           </template>
         </TaskIssueSummary>
 
@@ -290,8 +329,8 @@ const uniqueOrphanedTasks = computed<TaskEventResponse[]>(() => {
   return Array.from(taskMap.values())
 })
 
-const failedCardStatus = computed(() => failedTasksStore.failedTasks.length > 0 ? 'error' : 'success')
-const failedSummaryVariant = computed(() => failedTasksStore.failedTasks.length > 0 ? 'error' : 'success')
+const failedCardStatus = computed(() => failedTasksStore.activeFailedTasks.length > 0 ? 'error' : 'success')
+const failedSummaryVariant = computed(() => failedTasksStore.activeFailedTasks.length > 0 ? 'error' : 'success')
 const orphanCardStatus = computed(() => uniqueOrphanedTasks.value.length > 0 ? 'warning' : 'success')
 const orphanSummaryVariant = computed(() => uniqueOrphanedTasks.value.length > 0 ? 'warning' : 'success')
 const failedTasksLookbackHours = computed(() => failedTasksStore.lookbackHours)
@@ -319,6 +358,21 @@ const retryLoadingIds = computed(() => {
 })
 
 const resolutionLoadingIds = ref<string[]>([])
+
+const handleSuppressAction = async (task: TaskEventResponse & { exception?: string | null }) => {
+  const reason = window.prompt('Mute this noisy failure pattern. Reason?', 'Known noisy failure')
+  if (!reason) return
+  await failedTasksStore.createSuppressionRule({
+    task_name: task.task_name,
+    reason,
+    exception_contains: task.exception || undefined,
+  })
+}
+
+const handleUnsuppressAction = async (task: TaskEventResponse & { suppression_rule_id?: string | null }) => {
+  if (!task.suppression_rule_id) return
+  await failedTasksStore.deleteSuppressionRule(task.suppression_rule_id)
+}
 
 const isTaskResolved = (task: TaskEventResponse) => {
   return Boolean((task as TaskEventResponse & { resolved?: boolean }).resolved)
@@ -587,6 +641,7 @@ onMounted(async () => {
 
   await configStore.fetchConfig().catch(() => {})
   failedTasksStore.setLookbackHours(normalizeLookback(configStore.taskIssueLookbackHours))
+  failedTasksStore.fetchSuppressionRules().catch(() => {})
 
   // Initial data fetch
   await Promise.all([

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -65,6 +65,22 @@ export interface TaskIssueConfigDTO {
   lookback_hours: number
 }
 
+export interface TaskSuppressionRuleDTO {
+  id: string
+  task_name: string
+  reason: string
+  exception_contains?: string | null
+  expires_at?: string | null
+  created_at: string
+}
+
+export interface TaskSuppressionRuleInput {
+  task_name: string
+  reason: string
+  exception_contains?: string | null
+  expires_at?: string | null
+}
+
 export interface DataRetentionConfigDTO {
   task_successful_days: number
   task_unsuccessful_days: number
@@ -376,6 +392,20 @@ class ApiService {
       query: params
     })
     return response.data
+  }
+
+  async listTaskSuppressions(includeExpired = false): Promise<TaskSuppressionRuleDTO[]> {
+    const response = await this.api.request({ path: '/api/task-suppressions', method: 'GET', query: { include_expired: includeExpired } })
+    return response.data
+  }
+
+  async createTaskSuppression(payload: TaskSuppressionRuleInput): Promise<TaskSuppressionRuleDTO> {
+    const response = await this.api.request({ path: '/api/task-suppressions', method: 'POST', body: payload })
+    return response.data
+  }
+
+  async deleteTaskSuppression(ruleId: string): Promise<void> {
+    await this.api.request({ path: `/api/task-suppressions/${encodeURIComponent(ruleId)}`, method: 'DELETE' })
   }
 
   // Worker-related endpoints

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -5,6 +5,8 @@ import { Api } from '../src/types/api'
 import type {
   TaskStats,
   TaskEventResponse,
+  TaskSuppressionRule,
+  TaskSuppressionRuleCreate,
   WorkerInfo
 } from '../src/types/api'
 
@@ -65,21 +67,8 @@ export interface TaskIssueConfigDTO {
   lookback_hours: number
 }
 
-export interface TaskSuppressionRuleDTO {
-  id: string
-  task_name: string
-  reason: string
-  exception_contains?: string | null
-  expires_at?: string | null
-  created_at: string
-}
-
-export interface TaskSuppressionRuleInput {
-  task_name: string
-  reason: string
-  exception_contains?: string | null
-  expires_at?: string | null
-}
+export type TaskSuppressionRuleDTO = TaskSuppressionRule
+export type TaskSuppressionRuleInput = TaskSuppressionRuleCreate
 
 export interface DataRetentionConfigDTO {
   task_successful_days: number
@@ -395,17 +384,17 @@ class ApiService {
   }
 
   async listTaskSuppressions(includeExpired = false): Promise<TaskSuppressionRuleDTO[]> {
-    const response = await this.api.request({ path: '/api/task-suppressions', method: 'GET', query: { include_expired: includeExpired } })
+    const response = await this.api.api.listTaskSuppressionsApiTaskSuppressionsGet({ includeExpired })
     return response.data
   }
 
   async createTaskSuppression(payload: TaskSuppressionRuleInput): Promise<TaskSuppressionRuleDTO> {
-    const response = await this.api.request({ path: '/api/task-suppressions', method: 'POST', body: payload })
+    const response = await this.api.api.createTaskSuppressionApiTaskSuppressionsPost(payload)
     return response.data
   }
 
   async deleteTaskSuppression(ruleId: string): Promise<void> {
-    await this.api.request({ path: `/api/task-suppressions/${encodeURIComponent(ruleId)}`, method: 'DELETE' })
+    await this.api.api.deleteTaskSuppressionApiTaskSuppressionsRuleIdDelete(ruleId)
   }
 
   // Worker-related endpoints

--- a/frontend/app/src/types/api.ts
+++ b/frontend/app/src/types/api.ts
@@ -39,7 +39,7 @@ export interface ActionConfig {
   /** Config Id */
   config_id?: string | null;
   /** Params */
-  params?: object;
+  params?: Record<string, any>;
   /**
    * Continue On Failure
    * @default true
@@ -59,7 +59,7 @@ export interface ActionConfigCreateRequest {
   /** Action Type */
   action_type: string;
   /** Config */
-  config: object;
+  config: Record<string, any>;
 }
 
 /**
@@ -76,7 +76,7 @@ export interface ActionConfigDefinition {
   /** Action Type */
   action_type: string;
   /** Config */
-  config: object;
+  config: Record<string, any>;
   /** Created At */
   created_at?: string | null;
   /** Updated At */
@@ -102,7 +102,67 @@ export interface ActionConfigUpdateRequest {
   /** Description */
   description?: string | null;
   /** Config */
-  config?: object | null;
+  config?: Record<string, any> | null;
+}
+
+/**
+ * AppConfigSnapshot
+ * Grouped configuration snapshot returned to clients.
+ */
+export interface AppConfigSnapshot {
+  /** Configuration for the task issue summary section. */
+  task_issue_summary: TaskIssueConfig;
+  /** Retention policy for stored operational data. */
+  data_retention: DataRetentionConfig;
+}
+
+/**
+ * AppSetting
+ * Database-backed application setting.
+ */
+export interface AppSetting {
+  /** Key */
+  key: string;
+  /** Value */
+  value: any;
+  /**
+   * Value Type
+   * @default "string"
+   */
+  value_type?: "string" | "number" | "boolean" | "json";
+  /** Label */
+  label?: string | null;
+  /** Description */
+  description?: string | null;
+  /** Category */
+  category?: string | null;
+  /**
+   * Created At
+   * @format date-time
+   */
+  created_at: string;
+  /**
+   * Updated At
+   * @format date-time
+   */
+  updated_at: string;
+}
+
+/**
+ * AppSettingUpdate
+ * Create/update payload for an application setting.
+ */
+export interface AppSettingUpdate {
+  /** Value */
+  value: any;
+  /** Value Type */
+  value_type?: "string" | "number" | "boolean" | "json" | null;
+  /** Label */
+  label?: string | null;
+  /** Description */
+  description?: string | null;
+  /** Category */
+  category?: string | null;
 }
 
 /**
@@ -228,6 +288,55 @@ export interface ConditionGroupOutput {
 }
 
 /**
+ * DataRetentionConfig
+ * Retention policy for stored operational data.
+ */
+export interface DataRetentionConfig {
+  /**
+   * Task Successful Days
+   * @min 1
+   * @max 3650
+   * @default 14
+   */
+  task_successful_days?: number;
+  /**
+   * Task Unsuccessful Days
+   * @min 1
+   * @max 3650
+   * @default 30
+   */
+  task_unsuccessful_days?: number;
+  /**
+   * Worker Events Days
+   * @min 1
+   * @max 3650
+   * @default 30
+   */
+  worker_events_days?: number;
+  /**
+   * Workflow Executions Days
+   * @min 1
+   * @max 3650
+   * @default 30
+   */
+  workflow_executions_days?: number;
+  /**
+   * Task Daily Stats Days
+   * @min 1
+   * @max 3650
+   * @default 365
+   */
+  task_daily_stats_days?: number;
+  /**
+   * Inactive Sessions Days
+   * @min 1
+   * @max 3650
+   * @default 30
+   */
+  inactive_sessions_days?: number;
+}
+
+/**
  * EnvironmentCreate
  * Environment creation request model
  */
@@ -319,7 +428,7 @@ export interface LogEntry {
   /** Timestamp */
   timestamp?: string | null;
   /** Context */
-  context?: object | null;
+  context?: Record<string, any> | null;
 }
 
 /**
@@ -351,6 +460,69 @@ export interface LogoutRequest {
 export interface RefreshRequest {
   /** Refresh Token */
   refresh_token: string;
+}
+
+/** ResolveTaskRequest */
+export interface ResolveTaskRequest {
+  /** Resolved By */
+  resolved_by?: string | null;
+}
+
+/**
+ * RetentionCleanupResponse
+ * Summary of a retention cleanup run.
+ */
+export interface RetentionCleanupResponse {
+  /**
+   * Dry Run
+   * @default false
+   */
+  dry_run?: boolean;
+  /**
+   * Total Deleted
+   * @min 0
+   */
+  total_deleted: number;
+  /** Results */
+  results?: RetentionCleanupResult[];
+}
+
+/**
+ * RetentionCleanupResult
+ * Result for a single retention target cleanup.
+ */
+export interface RetentionCleanupResult {
+  /** Key */
+  key: string;
+  /** Label */
+  label: string;
+  /**
+   * Retention Days
+   * @min 1
+   */
+  retention_days: number;
+  /**
+   * Deleted
+   * @min 0
+   */
+  deleted: number;
+}
+
+/**
+ * StepDefinition
+ * Single step definition for task progress.
+ */
+export interface StepDefinition {
+  /** Key */
+  key: string;
+  /** Label */
+  label: string;
+  /** Description */
+  description?: string | null;
+  /** Total */
+  total?: number | null;
+  /** Order */
+  order?: number | null;
 }
 
 /**
@@ -437,7 +609,7 @@ export interface TaskEvent {
   /** Args */
   args?: any[];
   /** Kwargs */
-  kwargs?: object;
+  kwargs?: Record<string, any>;
   /**
    * Retries
    * @default 0
@@ -500,6 +672,83 @@ export interface TaskEvent {
   is_orphan?: boolean;
   /** Orphaned At */
   orphaned_at?: string | null;
+  /**
+   * Resolved
+   * @default false
+   */
+  resolved?: boolean;
+  /** Resolved By */
+  resolved_by?: string | null;
+  /** Resolved At */
+  resolved_at?: string | null;
+  /**
+   * Suppressed
+   * @default false
+   */
+  suppressed?: boolean;
+  /** Suppression Rule Id */
+  suppression_rule_id?: string | null;
+  /** Suppression Reason */
+  suppression_reason?: string | null;
+  /** Suppression Expires At */
+  suppression_expires_at?: string | null;
+}
+
+/**
+ * TaskIssueConfig
+ * Configuration for the task issue summary section.
+ */
+export interface TaskIssueConfig {
+  /**
+   * Lookback Hours
+   * @min 1
+   * @max 168
+   * @default 24
+   */
+  lookback_hours?: number;
+}
+
+/**
+ * TaskProgressEvent
+ * Task progress update event.
+ */
+export interface TaskProgressEvent {
+  /** Task Id */
+  task_id: string;
+  /** Task Name */
+  task_name: string;
+  /** Progress */
+  progress: number;
+  /**
+   * Timestamp
+   * @format date-time
+   */
+  timestamp: string;
+  /** Step Key */
+  step_key?: string | null;
+  /** Message */
+  message?: string | null;
+  /** Meta */
+  meta?: Record<string, any> | null;
+  /**
+   * Event Type
+   * @default "kanchi-task-progress"
+   */
+  event_type?: "kanchi-task-progress";
+}
+
+/**
+ * TaskProgressSnapshot
+ * Aggregate view of progress and steps for a task.
+ */
+export interface TaskProgressSnapshot {
+  /** Task Id */
+  task_id: string;
+  latest?: TaskProgressEvent | null;
+  /** Steps */
+  steps?: StepDefinition[];
+  /** History */
+  history?: TaskProgressEvent[];
 }
 
 /**
@@ -590,6 +839,51 @@ export interface TaskRegistryUpdate {
   tags?: string[] | null;
 }
 
+/** TaskSuppressionMetrics */
+export interface TaskSuppressionMetrics {
+  /**
+   * Active Count
+   * @default 0
+   */
+  active_count?: number;
+  /**
+   * Suppressed Count
+   * @default 0
+   */
+  suppressed_count?: number;
+}
+
+/** TaskSuppressionRule */
+export interface TaskSuppressionRule {
+  /** Task Name */
+  task_name: string;
+  /** Reason */
+  reason: string;
+  /** Exception Contains */
+  exception_contains?: string | null;
+  /** Expires At */
+  expires_at?: string | null;
+  /** Id */
+  id: string;
+  /**
+   * Created At
+   * @format date-time
+   */
+  created_at: string;
+}
+
+/** TaskSuppressionRuleCreate */
+export interface TaskSuppressionRuleCreate {
+  /** Task Name */
+  task_name: string;
+  /** Reason */
+  reason: string;
+  /** Exception Contains */
+  exception_contains?: string | null;
+  /** Expires At */
+  expires_at?: string | null;
+}
+
 /**
  * TaskTimelineResponse
  * Timeline response showing execution frequency over time
@@ -653,7 +947,7 @@ export interface TriggerConfig {
   /** Type */
   type: string;
   /** Config */
-  config?: object;
+  config?: Record<string, any>;
 }
 
 /**
@@ -683,7 +977,7 @@ export interface UserSessionResponse {
   /** Active Environment Id */
   active_environment_id?: string | null;
   /** Preferences */
-  preferences?: object;
+  preferences?: Record<string, any>;
   /**
    * Created At
    * @format date-time
@@ -704,7 +998,7 @@ export interface UserSessionUpdate {
   /** Active Environment Id */
   active_environment_id?: string | null;
   /** Preferences */
-  preferences?: object | null;
+  preferences?: Record<string, any> | null;
 }
 
 /** ValidationError */
@@ -863,7 +1157,7 @@ export interface WorkflowExecutionRecord {
   /** Trigger Type */
   trigger_type: string;
   /** Trigger Event */
-  trigger_event: object;
+  trigger_event: Record<string, any>;
   /** Status */
   status:
     | "pending"
@@ -873,7 +1167,7 @@ export interface WorkflowExecutionRecord {
     | "rate_limited"
     | "circuit_open";
   /** Actions Executed */
-  actions_executed?: object[] | null;
+  actions_executed?: Record<string, any>[] | null;
   /** Error Message */
   error_message?: string | null;
   /** Stack Trace */
@@ -885,7 +1179,7 @@ export interface WorkflowExecutionRecord {
   /** Duration Ms */
   duration_ms?: number | null;
   /** Workflow Snapshot */
-  workflow_snapshot?: object | null;
+  workflow_snapshot?: Record<string, any> | null;
   /** Circuit Breaker Key */
   circuit_breaker_key?: string | null;
 }
@@ -1150,7 +1444,7 @@ export class Api<
       },
       params: RequestParams = {},
     ) =>
-      this.request<object, HTTPValidationError>({
+      this.request<Record<string, any>, HTTPValidationError>({
         path: `/api/events/recent`,
         method: "GET",
         query: query,
@@ -1172,6 +1466,25 @@ export class Api<
     ) =>
       this.request<TaskEvent[], HTTPValidationError>({
         path: `/api/events/${taskId}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Get latest progress, steps, and recent history for a task.
+     *
+     * @tags tasks
+     * @name GetTaskProgressApiTasksTaskIdProgressGet
+     * @summary Get Task Progress
+     * @request GET:/api/tasks/{task_id}/progress
+     */
+    getTaskProgressApiTasksTaskIdProgressGet: (
+      taskId: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<TaskProgressSnapshot, HTTPValidationError>({
+        path: `/api/tasks/${taskId}/progress`,
         method: "GET",
         format: "json",
         ...params,
@@ -1221,9 +1534,9 @@ export class Api<
       query?: {
         /**
          * Hours
-         * @default 24
+         * Lookback window in hours (defaults to configured value)
          */
-        hours?: number;
+        hours?: number | null;
         /**
          * Limit
          * @default 50
@@ -1241,6 +1554,135 @@ export class Api<
         path: `/api/tasks/failed/recent`,
         method: "GET",
         query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags tasks
+     * @name ListTaskSuppressionsApiTaskSuppressionsGet
+     * @summary List Task Suppressions
+     * @request GET:/api/task-suppressions
+     */
+    listTaskSuppressionsApiTaskSuppressionsGet: (
+      query?: {
+        /**
+         * Include Expired
+         * @default false
+         */
+        include_expired?: boolean;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TaskSuppressionRule[], HTTPValidationError>({
+        path: `/api/task-suppressions`,
+        method: "GET",
+        query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags tasks
+     * @name CreateTaskSuppressionApiTaskSuppressionsPost
+     * @summary Create Task Suppression
+     * @request POST:/api/task-suppressions
+     */
+    createTaskSuppressionApiTaskSuppressionsPost: (
+      data: TaskSuppressionRuleCreate,
+      params: RequestParams = {},
+    ) =>
+      this.request<TaskSuppressionRule, HTTPValidationError>({
+        path: `/api/task-suppressions`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags tasks
+     * @name DeleteTaskSuppressionApiTaskSuppressionsRuleIdDelete
+     * @summary Delete Task Suppression
+     * @request DELETE:/api/task-suppressions/{rule_id}
+     */
+    deleteTaskSuppressionApiTaskSuppressionsRuleIdDelete: (
+      ruleId: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, HTTPValidationError>({
+        path: `/api/task-suppressions/${ruleId}`,
+        method: "DELETE",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags tasks
+     * @name GetFailedTaskSuppressionMetricsApiTasksFailedSuppressionMetricsGet
+     * @summary Get Failed Task Suppression Metrics
+     * @request GET:/api/tasks/failed/suppression-metrics
+     */
+    getFailedTaskSuppressionMetricsApiTasksFailedSuppressionMetricsGet: (
+      query?: {
+        /** Hours */
+        hours?: number | null;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TaskSuppressionMetrics, HTTPValidationError>({
+        path: `/api/tasks/failed/suppression-metrics`,
+        method: "GET",
+        query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Manually mark a task as resolved without altering its state.
+     *
+     * @tags tasks
+     * @name ResolveTaskApiTasksTaskIdResolvePost
+     * @summary Resolve Task
+     * @request POST:/api/tasks/{task_id}/resolve
+     */
+    resolveTaskApiTasksTaskIdResolvePost: (
+      taskId: string,
+      data: ResolveTaskRequest | null,
+      params: RequestParams = {},
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/api/tasks/${taskId}/resolve`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Remove manual resolution mark from a task.
+     *
+     * @tags tasks
+     * @name ClearTaskResolutionApiTasksTaskIdResolveDelete
+     * @summary Clear Task Resolution
+     * @request DELETE:/api/tasks/{task_id}/resolve
+     */
+    clearTaskResolutionApiTasksTaskIdResolveDelete: (
+      taskId: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/api/tasks/${taskId}/resolve`,
+        method: "DELETE",
         format: "json",
         ...params,
       }),
@@ -1565,7 +2007,7 @@ export class Api<
       },
       params: RequestParams = {},
     ) =>
-      this.request<object, HTTPValidationError>({
+      this.request<Record<string, any>, HTTPValidationError>({
         path: `/api/registry/tasks/${taskName}/trend`,
         method: "GET",
         query: query,
@@ -1987,7 +2429,7 @@ export class Api<
      */
     testWorkflowApiWorkflowsWorkflowIdTestPost: (
       workflowId: string,
-      data: object,
+      data: Record<string, any>,
       params: RequestParams = {},
     ) =>
       this.request<any, HTTPValidationError>({
@@ -2263,6 +2705,139 @@ export class Api<
       }),
 
     /**
+     * @description Get grouped application configuration with defaults applied.
+     *
+     * @tags config
+     * @name GetConfigSnapshotApiConfigGet
+     * @summary Get Config Snapshot
+     * @request GET:/api/config
+     */
+    getConfigSnapshotApiConfigGet: (params: RequestParams = {}) =>
+      this.request<AppConfigSnapshot, any>({
+        path: `/api/config`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description List all application settings.
+     *
+     * @tags config
+     * @name ListSettingsApiConfigSettingsGet
+     * @summary List Settings
+     * @request GET:/api/config/settings
+     */
+    listSettingsApiConfigSettingsGet: (params: RequestParams = {}) =>
+      this.request<AppSetting[], any>({
+        path: `/api/config/settings`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Get a single application setting.
+     *
+     * @tags config
+     * @name GetSettingApiConfigSettingsKeyGet
+     * @summary Get Setting
+     * @request GET:/api/config/settings/{key}
+     */
+    getSettingApiConfigSettingsKeyGet: (
+      key: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<AppSetting, HTTPValidationError>({
+        path: `/api/config/settings/${key}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Create or update an application setting.
+     *
+     * @tags config
+     * @name UpsertSettingApiConfigSettingsKeyPut
+     * @summary Upsert Setting
+     * @request PUT:/api/config/settings/{key}
+     */
+    upsertSettingApiConfigSettingsKeyPut: (
+      key: string,
+      data: AppSettingUpdate,
+      params: RequestParams = {},
+    ) =>
+      this.request<AppSetting, HTTPValidationError>({
+        path: `/api/config/settings/${key}`,
+        method: "PUT",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Delete a setting (falls back to default).
+     *
+     * @tags config
+     * @name DeleteSettingApiConfigSettingsKeyDelete
+     * @summary Delete Setting
+     * @request DELETE:/api/config/settings/{key}
+     */
+    deleteSettingApiConfigSettingsKeyDelete: (
+      key: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, HTTPValidationError>({
+        path: `/api/config/settings/${key}`,
+        method: "DELETE",
+        ...params,
+      }),
+
+    /**
+     * @description Get normalized data retention policy values.
+     *
+     * @tags config
+     * @name GetRetentionPolicyApiConfigRetentionGet
+     * @summary Get Retention Policy
+     * @request GET:/api/config/retention
+     */
+    getRetentionPolicyApiConfigRetentionGet: (params: RequestParams = {}) =>
+      this.request<DataRetentionConfig, any>({
+        path: `/api/config/retention`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Run retention cleanup, optionally as a dry-run preview.
+     *
+     * @tags config
+     * @name RunRetentionCleanupApiConfigRetentionCleanupPost
+     * @summary Run Retention Cleanup
+     * @request POST:/api/config/retention/cleanup
+     */
+    runRetentionCleanupApiConfigRetentionCleanupPost: (
+      query?: {
+        /**
+         * Dry Run
+         * @default true
+         */
+        dry_run?: boolean;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<RetentionCleanupResponse, HTTPValidationError>({
+        path: `/api/config/retention/cleanup`,
+        method: "POST",
+        query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
      * @description Public health endpoint without sensitive data.
      *
      * @name HealthCheckApiHealthGet
@@ -2287,6 +2862,22 @@ export class Api<
     healthDetailsApiHealthDetailsGet: (params: RequestParams = {}) =>
       this.request<any, any>({
         path: `/api/health/details`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+  };
+  metrics = {
+    /**
+     * No description
+     *
+     * @name MetricsMetricsGet
+     * @summary Metrics
+     * @request GET:/metrics
+     */
+    metricsMetricsGet: (params: RequestParams = {}) =>
+      this.request<any, any>({
+        path: `/metrics`,
         method: "GET",
         format: "json",
         ...params,

--- a/frontend/app/stores/failedTasks.ts
+++ b/frontend/app/stores/failedTasks.ts
@@ -1,7 +1,14 @@
 import { defineStore } from 'pinia'
 import { ref, computed, readonly } from 'vue'
 import { useApiService } from '../services/apiClient'
-import type { TaskEventResponse } from '../services/apiClient'
+import type { TaskEventResponse, TaskSuppressionRuleDTO } from '../services/apiClient'
+
+export type SuppressedTaskEvent = TaskEventResponse & {
+  suppressed?: boolean
+  suppression_rule_id?: string | null
+  suppression_reason?: string | null
+  suppression_expires_at?: string | null
+}
 
 const DEFAULT_LOOKBACK_HOURS = 24
 const MIN_LOOKBACK_HOURS = 1
@@ -18,17 +25,20 @@ function parseTimestamp(timestamp?: string | null): number | null {
 export const useFailedTasksStore = defineStore('failedTasks', () => {
   const apiService = useApiService()
 
-  const failedTasks = ref<TaskEventResponse[]>([])
+  const failedTasks = ref<SuppressedTaskEvent[]>([])
+  const suppressionRules = ref<TaskSuppressionRuleDTO[]>([])
   const isLoading = ref(false)
   const error = ref<string | null>(null)
   const lastFetchedAt = ref<Date | null>(null)
   const lookbackHours = ref(DEFAULT_LOOKBACK_HOURS)
   const lookbackWindowMs = computed(() => lookbackHours.value * 60 * 60 * 1000)
 
-  const totalFailedTasks = computed(() => failedTasks.value.length)
+  const activeFailedTasks = computed(() => failedTasks.value.filter(task => !task.suppressed))
+  const suppressedFailedTasks = computed(() => failedTasks.value.filter(task => task.suppressed))
+  const totalFailedTasks = computed(() => activeFailedTasks.value.length)
   const latestFailedTask = computed(() => failedTasks.value[0] || null)
 
-  function sortTasks(tasks: TaskEventResponse[]): TaskEventResponse[] {
+  function sortTasks(tasks: SuppressedTaskEvent[]): SuppressedTaskEvent[] {
     return [...tasks].sort((a, b) => {
       const aTime = parseTimestamp(a.timestamp) ?? 0
       const bTime = parseTimestamp(b.timestamp) ?? 0
@@ -36,7 +46,7 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     })
   }
 
-  function setTasks(tasks: TaskEventResponse[]) {
+  function setTasks(tasks: SuppressedTaskEvent[]) {
     failedTasks.value = sortTasks(tasks)
   }
 
@@ -48,7 +58,7 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     })
   }
 
-  function upsertFailedTask(task: TaskEventResponse) {
+  function upsertFailedTask(task: SuppressedTaskEvent) {
     if (!task.task_id) {
       return
     }
@@ -113,7 +123,7 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
         include_retried: options?.includeRetried ?? false
       })
 
-      const filtered = response.filter(task => !shouldExclude(task))
+      const filtered = response.filter(task => !shouldExclude(task)) as SuppressedTaskEvent[]
       setTasks(filtered)
       pruneExpired()
       lastFetchedAt.value = new Date()
@@ -152,7 +162,7 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     }
   }
 
-  function updateFromLiveEvent(event: TaskEventResponse) {
+  function updateFromLiveEvent(event: SuppressedTaskEvent) {
     const environmentStore = useEnvironmentStore()
     const { matchesEnvironment } = useEnvironmentMatcher()
 
@@ -189,8 +199,27 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     }
   }
 
+  async function fetchSuppressionRules() {
+    suppressionRules.value = await apiService.listTaskSuppressions()
+  }
+
+  async function createSuppressionRule(payload: { task_name: string; reason: string; exception_contains?: string | null; expires_at?: string | null }) {
+    await apiService.createTaskSuppression(payload)
+    await fetchSuppressionRules()
+    await fetchFailedTasks({ hours: lookbackHours.value })
+  }
+
+  async function deleteSuppressionRule(ruleId: string) {
+    await apiService.deleteTaskSuppression(ruleId)
+    await fetchSuppressionRules()
+    await fetchFailedTasks({ hours: lookbackHours.value })
+  }
+
   return {
     failedTasks: readonly(failedTasks),
+    activeFailedTasks,
+    suppressedFailedTasks,
+    suppressionRules: readonly(suppressionRules),
     isLoading: readonly(isLoading),
     error: readonly(error),
     lastFetchedAt: readonly(lastFetchedAt),
@@ -200,6 +229,9 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     latestFailedTask,
 
     fetchFailedTasks,
+    fetchSuppressionRules,
+    createSuppressionRule,
+    deleteSuppressionRule,
     setLookbackHours,
     updateFromLiveEvent,
     pruneExpired,

--- a/frontend/app/stores/failedTasks.ts
+++ b/frontend/app/stores/failedTasks.ts
@@ -91,6 +91,43 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     })
   }
 
+  function matchesSuppressionRule(task: SuppressedTaskEvent, rule: TaskSuppressionRuleDTO): boolean {
+    if (rule.task_name !== task.task_name) {
+      return false
+    }
+    if (rule.expires_at) {
+      const expiresAt = parseTimestamp(rule.expires_at)
+      if (expiresAt !== null && expiresAt <= Date.now()) {
+        return false
+      }
+    }
+    if (rule.exception_contains) {
+      return (task.exception ?? '').includes(rule.exception_contains)
+    }
+    return true
+  }
+
+  function annotateSuppression(task: SuppressedTaskEvent): SuppressedTaskEvent {
+    const matchedRule = suppressionRules.value.find(rule => matchesSuppressionRule(task, rule))
+    if (!matchedRule) {
+      return {
+        ...task,
+        suppressed: false,
+        suppression_rule_id: null,
+        suppression_reason: null,
+        suppression_expires_at: null,
+      }
+    }
+
+    return {
+      ...task,
+      suppressed: true,
+      suppression_rule_id: matchedRule.id,
+      suppression_reason: matchedRule.reason,
+      suppression_expires_at: matchedRule.expires_at ?? null,
+    }
+  }
+
   function shouldExclude(task: TaskEventResponse): boolean {
     if (task.has_retries) {
       return true
@@ -123,7 +160,9 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
         include_retried: options?.includeRetried ?? false
       })
 
-      const filtered = response.filter(task => !shouldExclude(task)) as SuppressedTaskEvent[]
+      const filtered = response
+        .map(task => annotateSuppression(task as SuppressedTaskEvent))
+        .filter(task => !shouldExclude(task))
       setTasks(filtered)
       pruneExpired()
       lastFetchedAt.value = new Date()
@@ -173,12 +212,14 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     const eventType = event.event_type
 
     if (eventType === 'task-failed') {
-      if (shouldExclude(event)) {
-        removeFailedTask(event.task_id)
+      const annotatedEvent = annotateSuppression(event)
+
+      if (shouldExclude(annotatedEvent)) {
+        removeFailedTask(annotatedEvent.task_id)
         return
       }
 
-      const timestamp = parseTimestamp(event.timestamp)
+      const timestamp = parseTimestamp(annotatedEvent.timestamp)
       if (timestamp === null) {
         return
       }
@@ -188,7 +229,7 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
         return
       }
 
-      upsertFailedTask(event)
+      upsertFailedTask(annotatedEvent)
       pruneExpired()
       return
     }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,18 @@
 /** @type {import('tailwindcss').Config} */
+const withOpacity = (cssVariable: string) => ({ opacityValue }: { opacityValue?: string }) => {
+  if (opacityValue === undefined) {
+    return `var(${cssVariable})`
+  }
+
+  const opacity = Number.parseFloat(opacityValue)
+
+  if (Number.isNaN(opacity)) {
+    return `var(${cssVariable})`
+  }
+
+  return `color-mix(in srgb, var(${cssVariable}) ${opacity * 100}%, transparent)`
+}
+
 export default {
   content: [
     "./app/**/*.{js,vue,ts}",
@@ -19,90 +33,90 @@ export default {
       colors: {
         // Backgrounds using CSS variables
         background: {
-          base: 'var(--bg-base)',
-          surface: 'var(--bg-surface)',
-          raised: 'var(--bg-raised)',
+          base: withOpacity('--bg-base'),
+          surface: withOpacity('--bg-surface'),
+          raised: withOpacity('--bg-raised'),
           overlay: 'hsl(0, 0%, 18%, 0.8)',
           // Interactive states
-          hover: 'var(--bg-hover)',
-          'hover-subtle': 'var(--bg-hover-subtle)',
-          active: 'var(--bg-active)',
-          selected: 'var(--bg-selected)'
+          hover: withOpacity('--bg-hover'),
+          'hover-subtle': withOpacity('--bg-hover-subtle'),
+          active: withOpacity('--bg-active'),
+          selected: withOpacity('--bg-selected')
         },
         // Text colors using CSS variables
         text: {
-          primary: 'var(--text-primary)',
-          secondary: 'var(--text-secondary)',
-          muted: 'var(--text-muted)',
-          disabled: 'var(--text-disabled)'
+          primary: withOpacity('--text-primary'),
+          secondary: withOpacity('--text-secondary'),
+          muted: withOpacity('--text-muted'),
+          disabled: withOpacity('--text-disabled')
         },
         // Card and borders
         card: {
-          base: 'var(--bg-surface)',
-          border: 'var(--border)',
+          base: withOpacity('--bg-surface'),
+          border: withOpacity('--border'),
         },
         // Border colors
         border: {
-          DEFAULT: 'var(--border)',
-          highlight: 'var(--highlight)',
-          subtle: 'var(--border-subtle)'
+          DEFAULT: withOpacity('--border'),
+          highlight: withOpacity('--highlight'),
+          subtle: withOpacity('--border-subtle')
         },
         // Primary/Brand colors
         primary: {
-          DEFAULT: 'var(--primary)',
-          hover: 'var(--primary-hover)',
-          bg: 'var(--primary-bg)',
-          border: 'var(--primary-border)'
+          DEFAULT: withOpacity('--primary'),
+          hover: withOpacity('--primary-hover'),
+          bg: withOpacity('--primary-bg'),
+          border: withOpacity('--primary-border')
         },
         // Semantic status colors using CSS variables
         status: {
           // Success states
           success: {
-            DEFAULT: 'var(--status-success)',
-            bg: 'var(--status-success-bg)',
-            border: 'var(--status-success-border)',
+            DEFAULT: withOpacity('--status-success'),
+            bg: withOpacity('--status-success-bg'),
+            border: withOpacity('--status-success-border'),
             hover: 'hsl(158,100%,13%)'
           },
           // Error states
           error: {
-            DEFAULT: 'var(--status-error)',
-            bg: 'var(--status-error-bg)',
-            border: 'var(--status-error-border)',
+            DEFAULT: withOpacity('--status-error'),
+            bg: withOpacity('--status-error-bg'),
+            border: withOpacity('--status-error-border'),
             hover: 'hsl(347, 77%, 18%)'
           },
           // Warning states
           warning: {
-            DEFAULT: 'var(--status-warning)',
-            bg: 'var(--status-warning-bg)',
-            border: 'var(--status-warning-border)',
+            DEFAULT: withOpacity('--status-warning'),
+            bg: withOpacity('--status-warning-bg'),
+            border: withOpacity('--status-warning-border'),
             hover: 'hsl(45, 85%, 18%)'
           },
           // Info states
           info: {
-            DEFAULT: 'var(--status-info)',
-            bg: 'var(--status-info-bg)',
-            border: 'var(--status-info-border)',
+            DEFAULT: withOpacity('--status-info'),
+            bg: withOpacity('--status-info-bg'),
+            border: withOpacity('--status-info-border'),
             hover: 'hsl(199, 89%, 18%)'
           },
           // Retry states
           retry: {
-            DEFAULT: 'var(--status-retry)',
-            bg: 'var(--status-retry-bg)',
-            border: 'var(--status-retry-border)',
+            DEFAULT: withOpacity('--status-retry'),
+            bg: withOpacity('--status-retry-bg'),
+            border: withOpacity('--status-retry-border'),
             hover: 'hsl(24, 95%, 18%)'
           },
           // Neutral states
           neutral: {
-            DEFAULT: 'var(--status-neutral)',
-            bg: 'var(--status-neutral-bg)',
-            border: 'var(--status-neutral-border)',
+            DEFAULT: withOpacity('--status-neutral'),
+            bg: withOpacity('--status-neutral-bg'),
+            border: withOpacity('--status-neutral-border'),
             hover: 'hsl(215, 20%, 18%)'
           },
           // Special states
           special: {
-            DEFAULT: 'var(--status-special)',
-            bg: 'var(--status-special-bg)',
-            border: 'var(--status-special-border)',
+            DEFAULT: withOpacity('--status-special'),
+            bg: withOpacity('--status-special-bg'),
+            border: withOpacity('--status-special-border'),
             hover: 'hsl(263, 70%, 18%)'
           }
         }


### PR DESCRIPTION
$## Summary
- add suppression rules for noisy failed-task patterns backed by app settings
- split failed-task dashboard into active vs muted sections with mute/unmute controls
- skip workflow execution for suppressed failed-task events

## Verification
- python3 -m unittest tests.unit.test_task_suppression -v
- npm run build
- local API-assisted browser proof with seeded failures: `/data/.openclaw/workspace/tmp/kanchi-105-suppression-noise-management.mp4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mute/unmute functionality for failed task patterns with optional reasons and expiration dates
  * Introduced dedicated "Muted failed tasks" section displaying suppressed items with unmute and open actions
  * Implemented suppression rule management endpoints for creating, listing, and deleting rules
  * Added suppression metrics to track active versus suppressed failures

* **Tests**
  * Added comprehensive test coverage for suppression functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->