### PR TITLE
Add workflow templates

### DIFF
--- a/agent/api/workflow_routes.py
+++ b/agent/api/workflow_routes.py
@@ -13,6 +13,7 @@ from models import (
 from services.workflow_service import WorkflowService
 from services.action_executor import ActionExecutor
 from services.workflow_catalog import TRIGGER_METADATA
+from services.workflow_templates import WORKFLOW_TEMPLATES
 from config import Config
 from security.dependencies import get_auth_dependency
 
@@ -39,7 +40,8 @@ def create_router(app_state) -> APIRouter:
         """Expose supported triggers and actions."""
         return {
             "triggers": TRIGGER_METADATA,
-            "actions": ActionExecutor.get_action_catalog()
+            "actions": ActionExecutor.get_action_catalog(),
+            "templates": WORKFLOW_TEMPLATES,
         }
 
     # ==================== Workflow CRUD ====================

--- a/agent/services/workflow_templates.py
+++ b/agent/services/workflow_templates.py
@@ -1,0 +1,199 @@
+"""Built-in workflow templates for common operational scenarios."""
+
+WORKFLOW_TEMPLATES = [
+    {
+        "id": "repeated-task-failure",
+        "name": "Repeated task failure escalation",
+        "description": "Start from a failed-task trigger that retries once and leaves room for a Slack escalation.",
+        "scenario": "Repeated task failure",
+        "recommended_for": ["task.failed", "task.retried"],
+        "workflow": {
+            "name": "Repeated task failure escalation",
+            "description": "Retry a failing task once and optionally notify Slack if the pattern keeps repeating.",
+            "enabled": True,
+            "trigger": {"type": "task.failed", "config": {}},
+            "conditions": {
+                "operator": "AND",
+                "conditions": [
+                    {"field": "retry_count", "operator": "gte", "value": 1},
+                ],
+            },
+            "actions": [
+                {
+                    "type": "task.retry",
+                    "params": {"delay_seconds": 60},
+                    "continue_on_failure": False,
+                },
+                {
+                    "type": "slack.notify",
+                    "params": {
+                        "config_id": "",
+                        "template": "🚨 {{task_name}} keeps failing on {{queue}} (task {{task_id}})",
+                        "color": "#d92d20",
+                    },
+                    "continue_on_failure": True,
+                },
+            ],
+            "priority": 180,
+            "cooldown_seconds": 300,
+            "max_executions_per_hour": 10,
+            "circuit_breaker": {
+                "enabled": True,
+                "max_executions": 3,
+                "window_seconds": 900,
+                "context_field": "task_name",
+            },
+        },
+    },
+    {
+        "id": "orphaned-task-recovery",
+        "name": "Orphaned task recovery",
+        "description": "React to orphaned tasks with a guarded retry and operator notification placeholder.",
+        "scenario": "Orphaned task detected",
+        "recommended_for": ["task.orphaned"],
+        "workflow": {
+            "name": "Orphaned task recovery",
+            "description": "Retry orphaned tasks after a short delay and capture the event for operator follow-up.",
+            "enabled": True,
+            "trigger": {"type": "task.orphaned", "config": {}},
+            "conditions": None,
+            "actions": [
+                {
+                    "type": "task.retry",
+                    "params": {"delay_seconds": 120},
+                    "continue_on_failure": False,
+                },
+                {
+                    "type": "slack.notify",
+                    "params": {
+                        "config_id": "",
+                        "template": "🧵 Orphaned task {{task_name}} on worker {{worker_name}} was retried automatically.",
+                        "color": "#f59e0b",
+                    },
+                    "continue_on_failure": True,
+                },
+            ],
+            "priority": 170,
+            "cooldown_seconds": 180,
+            "max_executions_per_hour": 6,
+            "circuit_breaker": {
+                "enabled": True,
+                "max_executions": 2,
+                "window_seconds": 600,
+                "context_field": "task_name",
+            },
+        },
+    },
+    {
+        "id": "worker-offline-alert",
+        "name": "Worker offline alert",
+        "description": "Page operators when a worker drops offline with a worker-scoped circuit breaker.",
+        "scenario": "Worker offline",
+        "recommended_for": ["worker.offline", "worker.heartbeat"],
+        "workflow": {
+            "name": "Worker offline alert",
+            "description": "Notify operators when a worker goes offline or misses heartbeats.",
+            "enabled": True,
+            "trigger": {"type": "worker.offline", "config": {}},
+            "conditions": None,
+            "actions": [
+                {
+                    "type": "slack.notify",
+                    "params": {
+                        "config_id": "",
+                        "template": "🛑 Worker {{worker_name}} is offline. Check queue {{queue}} and active tasks.",
+                        "color": "#d92d20",
+                    },
+                    "continue_on_failure": False,
+                },
+            ],
+            "priority": 220,
+            "cooldown_seconds": 300,
+            "max_executions_per_hour": 12,
+            "circuit_breaker": {
+                "enabled": True,
+                "max_executions": 1,
+                "window_seconds": 900,
+                "context_field": "worker_name",
+            },
+        },
+    },
+    {
+        "id": "long-running-task-followup",
+        "name": "Long-running task follow-up",
+        "description": "Use when a task-started stream should notify after an unusually long runtime window.",
+        "scenario": "Long-running task",
+        "recommended_for": ["task.started"],
+        "workflow": {
+            "name": "Long-running task follow-up",
+            "description": "Alert on tasks that have been running longer than an agreed threshold.",
+            "enabled": True,
+            "trigger": {"type": "task.started", "config": {}},
+            "conditions": {
+                "operator": "AND",
+                "conditions": [
+                    {"field": "runtime", "operator": "gte", "value": 300},
+                ],
+            },
+            "actions": [
+                {
+                    "type": "slack.notify",
+                    "params": {
+                        "config_id": "",
+                        "template": "⏱️ {{task_name}} has been running longer than expected on {{queue}}.",
+                        "color": "#7c3aed",
+                    },
+                    "continue_on_failure": False,
+                },
+            ],
+            "priority": 150,
+            "cooldown_seconds": 600,
+            "max_executions_per_hour": 8,
+            "circuit_breaker": {
+                "enabled": True,
+                "max_executions": 1,
+                "window_seconds": 1800,
+                "context_field": "task_name",
+            },
+        },
+    },
+    {
+        "id": "error-rate-spike-escalation",
+        "name": "Error-rate spike escalation",
+        "description": "Use a high-priority failed-task template when many similar failures pile up quickly.",
+        "scenario": "Error-rate spike",
+        "recommended_for": ["task.failed"],
+        "workflow": {
+            "name": "Error-rate spike escalation",
+            "description": "Escalate when the same task family starts failing rapidly.",
+            "enabled": True,
+            "trigger": {"type": "task.failed", "config": {}},
+            "conditions": {
+                "operator": "AND",
+                "conditions": [
+                    {"field": "retry_count", "operator": "gte", "value": 3},
+                ],
+            },
+            "actions": [
+                {
+                    "type": "slack.notify",
+                    "params": {
+                        "config_id": "",
+                        "template": "📈 Error-rate spike for {{task_name}} on {{queue}}. Recent exception: {{exception}}",
+                        "color": "#d92d20",
+                    },
+                    "continue_on_failure": False,
+                },
+            ],
+            "priority": 250,
+            "cooldown_seconds": 120,
+            "max_executions_per_hour": 20,
+            "circuit_breaker": {
+                "enabled": True,
+                "max_executions": 2,
+                "window_seconds": 900,
+                "context_field": "task_name",
+            },
+        },
+    },
+]

--- a/agent/tests/unit/test_workflow_templates.py
+++ b/agent/tests/unit/test_workflow_templates.py
@@ -1,0 +1,24 @@
+from tests.base import DatabaseTestCase
+from services.workflow_templates import WORKFLOW_TEMPLATES
+from services.workflow_service import WorkflowService
+from models import WorkflowCreateRequest
+
+
+class TestWorkflowTemplates(DatabaseTestCase):
+    def test_templates_cover_expected_scenarios(self):
+        ids = {template['id'] for template in WORKFLOW_TEMPLATES}
+        self.assertEqual(ids, {
+            'repeated-task-failure',
+            'orphaned-task-recovery',
+            'worker-offline-alert',
+            'long-running-task-followup',
+            'error-rate-spike-escalation',
+        })
+
+    def test_templates_can_be_loaded_into_workflow_models(self):
+        service = WorkflowService(self.session)
+        for template in WORKFLOW_TEMPLATES:
+            payload = WorkflowCreateRequest(**template['workflow'])
+            actions = service._coerce_actions(payload.actions)
+            self.assertGreater(len(actions), 0)
+            self.assertTrue(payload.trigger.type)

--- a/frontend/app/pages/workflows/[id]/edit.vue
+++ b/frontend/app/pages/workflows/[id]/edit.vue
@@ -297,6 +297,19 @@ const isLoading = ref(true)
 // Local workflow state (editable)
 const workflow = ref<WorkflowUpdateRequest | null>(null)
 
+function isActionValid(action: NonNullable<WorkflowUpdateRequest['actions']>[number]) {
+  if (action.type === 'slack.notify') {
+    return action.params.config_id?.toString().trim().length > 0 &&
+      action.params.template?.toString().trim().length > 0
+  }
+
+  if (action.type === 'task.retry') {
+    return true
+  }
+
+  return Object.keys(action.params || {}).length > 0
+}
+
 const canSave = computed(() => {
   return workflow.value &&
          workflow.value.name &&
@@ -304,7 +317,8 @@ const canSave = computed(() => {
          workflow.value.trigger &&
          workflow.value.trigger.type.length > 0 &&
          workflow.value.actions &&
-         workflow.value.actions.length > 0
+         workflow.value.actions.length > 0 &&
+         workflow.value.actions.every(isActionValid)
 })
 
 async function saveWorkflow() {

--- a/frontend/app/pages/workflows/new.vue
+++ b/frontend/app/pages/workflows/new.vue
@@ -28,6 +28,31 @@
 
     <!-- Main Form -->
     <div class="space-y-6">
+      <div class="border border-border-subtle rounded-md p-5">
+        <div class="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <h2 class="text-sm font-medium text-text-primary">Start from a template</h2>
+            <p class="text-xs text-text-muted mt-0.5">Pick a common operational workflow and then tweak the defaults before saving.</p>
+          </div>
+          <Badge variant="outline" size="sm">{{ workflowTemplates.length }} templates</Badge>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <button
+            v-for="template in workflowTemplates"
+            :key="template.id"
+            type="button"
+            class="rounded-lg border border-border-subtle p-4 text-left hover:border-primary hover:bg-background-hover transition-colors"
+            @click="applyTemplate(template)"
+          >
+            <div class="flex items-center justify-between gap-3 mb-2">
+              <div class="text-sm font-medium text-text-primary">{{ template.name }}</div>
+              <Badge variant="secondary" size="sm">{{ template.scenario }}</Badge>
+            </div>
+            <p class="text-xs text-text-muted mb-3">{{ template.description }}</p>
+            <div class="text-[11px] text-text-muted">Recommended triggers: {{ template.recommended_for.join(', ') }}</div>
+          </button>
+        </div>
+      </div>
       <!-- Basic Info -->
       <div class="border border-border-subtle rounded-md p-5">
         <div class="mb-4">
@@ -216,10 +241,11 @@ import WorkflowTriggerSelector from '~/components/workflows/WorkflowTriggerSelec
 import WorkflowConditionBuilder from '~/components/workflows/WorkflowConditionBuilder.vue'
 import WorkflowActionsList from '~/components/workflows/WorkflowActionsList.vue'
 import WorkflowCircuitBreakerConfig from '~/components/workflows/WorkflowCircuitBreakerConfig.vue'
-import type { WorkflowCreateRequest } from '~/types/workflow'
+import type { WorkflowCreateRequest, WorkflowTemplateDefinition } from '~/types/workflow'
 
 const workflowStore = useWorkflowsStore()
 const saving = ref(false)
+const workflowTemplates = computed(() => workflowStore.workflowTemplates)
 
 // Form State
 const workflow = ref<WorkflowCreateRequest>({
@@ -237,11 +263,29 @@ const workflow = ref<WorkflowCreateRequest>({
   cooldown_seconds: 0
 })
 
+function isActionValid(action: WorkflowCreateRequest['actions'][number]) {
+  if (action.type === 'slack.notify') {
+    return action.params.config_id?.toString().trim().length > 0 &&
+      action.params.template?.toString().trim().length > 0
+  }
+
+  if (action.type === 'task.retry') {
+    return true
+  }
+
+  return Object.keys(action.params || {}).length > 0
+}
+
 const canSave = computed(() => {
   return workflow.value.name.trim().length > 0 &&
          workflow.value.trigger?.type.length > 0 &&
-         workflow.value.actions.length > 0
+         workflow.value.actions.length > 0 &&
+         workflow.value.actions.every(isActionValid)
 })
+
+function applyTemplate(template: WorkflowTemplateDefinition) {
+  workflow.value = JSON.parse(JSON.stringify(template.workflow))
+}
 
 function updateCircuitBreaker(config: any) {
   console.log('[New] updateCircuitBreaker called with:', config)

--- a/frontend/app/stores/workflows.ts
+++ b/frontend/app/stores/workflows.ts
@@ -8,7 +8,8 @@ import type {
   WorkflowExecutionRecord,
   ActionConfigDefinition,
   ActionConfigCreateRequest,
-  ActionConfigUpdateRequest
+  ActionConfigUpdateRequest,
+  WorkflowTemplateDefinition
 } from '~/types/workflow'
 
 export const useWorkflowsStore = defineStore('workflows', () => {
@@ -20,6 +21,7 @@ export const useWorkflowsStore = defineStore('workflows', () => {
   const actionConfigs = ref<ActionConfigDefinition[]>([])
   const triggerCatalog = ref<{ type: string; label: string; description: string; category: string }[]>([])
   const actionCatalog = ref<{ type: string; label: string; description: string; category: string }[]>([])
+  const workflowTemplates = ref<WorkflowTemplateDefinition[]>([])
   const metadataLoaded = ref(false)
 
   const isLoading = ref(false)
@@ -49,6 +51,7 @@ export const useWorkflowsStore = defineStore('workflows', () => {
       const metadata = await apiService.getWorkflowMetadata()
       triggerCatalog.value = metadata.triggers || []
       actionCatalog.value = metadata.actions || []
+      workflowTemplates.value = metadata.templates || []
       metadataLoaded.value = true
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to load workflow metadata'
@@ -278,6 +281,7 @@ export const useWorkflowsStore = defineStore('workflows', () => {
     workflowsByTrigger,
     triggerCatalog,
     actionCatalog,
+    workflowTemplates,
 
     fetchWorkflows,
     fetchWorkflow,

--- a/frontend/app/types/workflow.ts
+++ b/frontend/app/types/workflow.ts
@@ -176,6 +176,16 @@ export interface TriggerMetadata {
   contextFields: string[]
 }
 
+
+export interface WorkflowTemplateDefinition {
+  id: string
+  name: string
+  description: string
+  scenario: string
+  recommended_for: string[]
+  workflow: WorkflowCreateRequest
+}
+
 export interface ActionTypeMetadata {
   type: string
   label: string

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,18 @@
 /** @type {import('tailwindcss').Config} */
+const withOpacity = (cssVariable: string) => ({ opacityValue }: { opacityValue?: string }) => {
+  if (opacityValue === undefined) {
+    return `var(${cssVariable})`
+  }
+
+  const opacity = Number.parseFloat(opacityValue)
+
+  if (Number.isNaN(opacity)) {
+    return `var(${cssVariable})`
+  }
+
+  return `color-mix(in srgb, var(${cssVariable}) ${opacity * 100}%, transparent)`
+}
+
 export default {
   content: [
     "./app/**/*.{js,vue,ts}",
@@ -19,90 +33,90 @@ export default {
       colors: {
         // Backgrounds using CSS variables
         background: {
-          base: 'var(--bg-base)',
-          surface: 'var(--bg-surface)',
-          raised: 'var(--bg-raised)',
+          base: withOpacity('--bg-base'),
+          surface: withOpacity('--bg-surface'),
+          raised: withOpacity('--bg-raised'),
           overlay: 'hsl(0, 0%, 18%, 0.8)',
           // Interactive states
-          hover: 'var(--bg-hover)',
-          'hover-subtle': 'var(--bg-hover-subtle)',
-          active: 'var(--bg-active)',
-          selected: 'var(--bg-selected)'
+          hover: withOpacity('--bg-hover'),
+          'hover-subtle': withOpacity('--bg-hover-subtle'),
+          active: withOpacity('--bg-active'),
+          selected: withOpacity('--bg-selected')
         },
         // Text colors using CSS variables
         text: {
-          primary: 'var(--text-primary)',
-          secondary: 'var(--text-secondary)',
-          muted: 'var(--text-muted)',
-          disabled: 'var(--text-disabled)'
+          primary: withOpacity('--text-primary'),
+          secondary: withOpacity('--text-secondary'),
+          muted: withOpacity('--text-muted'),
+          disabled: withOpacity('--text-disabled')
         },
         // Card and borders
         card: {
-          base: 'var(--bg-surface)',
-          border: 'var(--border)',
+          base: withOpacity('--bg-surface'),
+          border: withOpacity('--border'),
         },
         // Border colors
         border: {
-          DEFAULT: 'var(--border)',
-          highlight: 'var(--highlight)',
-          subtle: 'var(--border-subtle)'
+          DEFAULT: withOpacity('--border'),
+          highlight: withOpacity('--highlight'),
+          subtle: withOpacity('--border-subtle')
         },
         // Primary/Brand colors
         primary: {
-          DEFAULT: 'var(--primary)',
-          hover: 'var(--primary-hover)',
-          bg: 'var(--primary-bg)',
-          border: 'var(--primary-border)'
+          DEFAULT: withOpacity('--primary'),
+          hover: withOpacity('--primary-hover'),
+          bg: withOpacity('--primary-bg'),
+          border: withOpacity('--primary-border')
         },
         // Semantic status colors using CSS variables
         status: {
           // Success states
           success: {
-            DEFAULT: 'var(--status-success)',
-            bg: 'var(--status-success-bg)',
-            border: 'var(--status-success-border)',
+            DEFAULT: withOpacity('--status-success'),
+            bg: withOpacity('--status-success-bg'),
+            border: withOpacity('--status-success-border'),
             hover: 'hsl(158,100%,13%)'
           },
           // Error states
           error: {
-            DEFAULT: 'var(--status-error)',
-            bg: 'var(--status-error-bg)',
-            border: 'var(--status-error-border)',
+            DEFAULT: withOpacity('--status-error'),
+            bg: withOpacity('--status-error-bg'),
+            border: withOpacity('--status-error-border'),
             hover: 'hsl(347, 77%, 18%)'
           },
           // Warning states
           warning: {
-            DEFAULT: 'var(--status-warning)',
-            bg: 'var(--status-warning-bg)',
-            border: 'var(--status-warning-border)',
+            DEFAULT: withOpacity('--status-warning'),
+            bg: withOpacity('--status-warning-bg'),
+            border: withOpacity('--status-warning-border'),
             hover: 'hsl(45, 85%, 18%)'
           },
           // Info states
           info: {
-            DEFAULT: 'var(--status-info)',
-            bg: 'var(--status-info-bg)',
-            border: 'var(--status-info-border)',
+            DEFAULT: withOpacity('--status-info'),
+            bg: withOpacity('--status-info-bg'),
+            border: withOpacity('--status-info-border'),
             hover: 'hsl(199, 89%, 18%)'
           },
           // Retry states
           retry: {
-            DEFAULT: 'var(--status-retry)',
-            bg: 'var(--status-retry-bg)',
-            border: 'var(--status-retry-border)',
+            DEFAULT: withOpacity('--status-retry'),
+            bg: withOpacity('--status-retry-bg'),
+            border: withOpacity('--status-retry-border'),
             hover: 'hsl(24, 95%, 18%)'
           },
           // Neutral states
           neutral: {
-            DEFAULT: 'var(--status-neutral)',
-            bg: 'var(--status-neutral-bg)',
-            border: 'var(--status-neutral-border)',
+            DEFAULT: withOpacity('--status-neutral'),
+            bg: withOpacity('--status-neutral-bg'),
+            border: withOpacity('--status-neutral-border'),
             hover: 'hsl(215, 20%, 18%)'
           },
           // Special states
           special: {
-            DEFAULT: 'var(--status-special)',
-            bg: 'var(--status-special-bg)',
-            border: 'var(--status-special-border)',
+            DEFAULT: withOpacity('--status-special'),
+            bg: withOpacity('--status-special-bg'),
+            border: withOpacity('--status-special-border'),
             hover: 'hsl(263, 70%, 18%)'
           }
         }


### PR DESCRIPTION
$## Summary
- add built-in workflow templates to workflow metadata and the new-workflow flow
- let operators start from a template in the create form and carry template metadata through the frontend store/types
- guard create/edit saves so Slack-backed workflows require a selected webhook config before submit

## Testing
- python3 -m unittest tests.unit.test_workflow_templates -v
- npm run build
- local Playwright verification of template apply -> Slack config selection -> workflow creation