### PR TITLE
Add workflow simulation previews

### DIFF
--- a/agent/api/workflow_routes.py
+++ b/agent/api/workflow_routes.py
@@ -8,11 +8,14 @@ from models import (
     WorkflowDefinition,
     WorkflowCreateRequest,
     WorkflowUpdateRequest,
-    WorkflowExecutionRecord
+    WorkflowExecutionRecord,
+    WorkflowSimulationRequest,
+    WorkflowSimulationResponse,
 )
 from services.workflow_service import WorkflowService
 from services.action_executor import ActionExecutor
 from services.workflow_catalog import TRIGGER_METADATA
+from services.workflow_simulation_service import WorkflowSimulationService
 from config import Config
 from security.dependencies import get_auth_dependency
 
@@ -74,6 +77,22 @@ def create_router(app_state) -> APIRouter:
             offset=offset
         )
         return workflows
+
+    @router.post("/simulate", response_model=WorkflowSimulationResponse)
+    async def simulate_workflow(
+        request: WorkflowSimulationRequest,
+        session: Session = Depends(get_db)
+    ):
+        """Dry-run a workflow definition without executing external actions."""
+        simulation_service = WorkflowSimulationService(
+            session=session,
+            db_manager=app_state.db_manager,
+            monitor_instance=app_state.monitor_instance,
+        )
+        try:
+            return simulation_service.simulate(request.workflow, request.test_context)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
 
     @router.get("/{workflow_id}", response_model=WorkflowDefinition)
     async def get_workflow(

--- a/agent/api/workflow_routes.py
+++ b/agent/api/workflow_routes.py
@@ -92,7 +92,7 @@ def create_router(app_state) -> APIRouter:
         try:
             return simulation_service.simulate(request.workflow, request.test_context)
         except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e))
+            raise HTTPException(status_code=400, detail=str(e)) from e
 
     @router.get("/{workflow_id}", response_model=WorkflowDefinition)
     async def get_workflow(

--- a/agent/models.py
+++ b/agent/models.py
@@ -751,6 +751,44 @@ class WorkflowUpdateRequest(BaseModel):
     circuit_breaker: Optional[CircuitBreakerConfig] = None
 
 
+class WorkflowSimulationRequest(BaseModel):
+    """Request model for workflow dry-run simulation."""
+    workflow: WorkflowCreateRequest
+    test_context: Dict[str, Any] = Field(default_factory=dict)
+
+
+class WorkflowSimulationActionPreview(BaseModel):
+    """Dry-run preview for an individual workflow action."""
+    action_type: str
+    status: Literal["would_execute", "blocked"]
+    summary: str
+    details: Dict[str, Any] = Field(default_factory=dict)
+    warnings: List[str] = Field(default_factory=list)
+
+
+class WorkflowSimulationRecord(BaseModel):
+    """Stored workflow simulation result summary."""
+    simulated_at: datetime
+    workflow_name: str
+    trigger_type: str
+    conditions_met: bool
+    would_execute: bool
+    warnings: List[str] = Field(default_factory=list)
+    action_previews: List[WorkflowSimulationActionPreview] = Field(default_factory=list)
+
+
+class WorkflowSimulationResponse(BaseModel):
+    """Workflow dry-run simulation result."""
+    workflow_name: str
+    trigger_type: str
+    test_context: Dict[str, Any] = Field(default_factory=dict)
+    conditions_met: bool
+    would_execute: bool
+    warnings: List[str] = Field(default_factory=list)
+    action_previews: List[WorkflowSimulationActionPreview] = Field(default_factory=list)
+    simulation_history: List[WorkflowSimulationRecord] = Field(default_factory=list)
+
+
 class WorkflowExecutionRecord(BaseModel):
     """Execution history record."""
     id: int

--- a/agent/models.py
+++ b/agent/models.py
@@ -776,6 +776,11 @@ class WorkflowSimulationRecord(BaseModel):
     warnings: List[str] = Field(default_factory=list)
     action_previews: List[WorkflowSimulationActionPreview] = Field(default_factory=list)
 
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.replace(tzinfo=timezone.utc).isoformat() if v.tzinfo is None else v.isoformat()
+        }
+
 
 class WorkflowSimulationResponse(BaseModel):
     """Workflow dry-run simulation result."""

--- a/agent/services/actions/retry_action.py
+++ b/agent/services/actions/retry_action.py
@@ -227,6 +227,10 @@ class RetryActionHandler(ActionHandler):
 
         return raw_value if raw_value is not None else default
 
+    def count_workflow_retries(self, task_id: str, root_id: Optional[str]) -> int:
+        """Public wrapper for computing workflow retry depth."""
+        return self._count_workflow_retries(task_id, root_id)
+
     def _count_workflow_retries(self, task_id: str, root_id: Optional[str]) -> int:
         """
         Count how many times this task chain has been retried by workflows.

--- a/agent/services/workflow_simulation_service.py
+++ b/agent/services/workflow_simulation_service.py
@@ -182,7 +182,7 @@ class WorkflowSimulationService:
             "max_retries": params.get("max_retries", 10),
         }
         if task_events:
-            original_task = task_events[-1]
+            original_task = task_events[0]
             current_retry_count = handler.count_workflow_retries(task_id, original_task.root_id)
             details.update({
                 "task_name": original_task.task_name,

--- a/agent/services/workflow_simulation_service.py
+++ b/agent/services/workflow_simulation_service.py
@@ -205,6 +205,23 @@ class WorkflowSimulationService:
             warnings.append("Task history was not found in the database; retry preview is based only on the provided context.")
             details["task_name"] = test_context.get("task_name")
             details["queue"] = test_context.get("queue") or "default"
+            current_retry_count = test_context.get("retry_count", 0)
+            if isinstance(current_retry_count, bool) or not isinstance(current_retry_count, int):
+                current_retry_count = 0
+            details["current_retry_depth"] = current_retry_count
+            if current_retry_count >= details["max_retries"]:
+                return WorkflowSimulationActionPreview(
+                    action_type="task.retry",
+                    status="blocked",
+                    summary="Would NOT enqueue a retry because the retry cap has already been reached.",
+                    details=details,
+                    warnings=[
+                        *warnings,
+                        f"Workflow retries are already at {current_retry_count}/{details['max_retries']}; a real execution would be rejected.",
+                    ],
+                )
+            if current_retry_count + 1 >= details["max_retries"]:
+                warnings.append("This dry run is near the retry cap; later real executions may be blocked soon.")
 
         return WorkflowSimulationActionPreview(
             action_type="task.retry",

--- a/agent/services/workflow_simulation_service.py
+++ b/agent/services/workflow_simulation_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any
 
 from models import (
     AppSettingUpdate,
@@ -37,7 +37,7 @@ class WorkflowSimulationService:
         self.app_config_service = AppConfigService(session)
         self.task_service = TaskService(session)
 
-    def simulate(self, workflow_data: WorkflowCreateRequest, test_context: Dict[str, Any]) -> WorkflowSimulationResponse:
+    def simulate(self, workflow_data: WorkflowCreateRequest, test_context: dict[str, Any]) -> WorkflowSimulationResponse:
         actions = self.workflow_service._coerce_actions(workflow_data.actions)
         self.workflow_service._validate_workflow_definition(workflow_data.trigger, actions)
 
@@ -81,8 +81,8 @@ class WorkflowSimulationService:
             simulation_history=history,
         )
 
-    def _collect_warnings(self, workflow_data: WorkflowCreateRequest, test_context: Dict[str, Any]) -> List[str]:
-        warnings: List[str] = []
+    def _collect_warnings(self, workflow_data: WorkflowCreateRequest, test_context: dict[str, Any]) -> list[str]:
+        warnings: list[str] = []
         if not workflow_data.conditions or not workflow_data.conditions.conditions:
             warnings.append("No conditions configured: this workflow will match every event for the selected trigger.")
         if workflow_data.trigger.type in {"task.failed", "task.orphaned", "worker.offline"} and len(workflow_data.actions) > 1:
@@ -99,8 +99,8 @@ class WorkflowSimulationService:
             warnings.append("Test context is missing task_id, so task-linked actions may be blocked in the dry run.")
         return warnings
 
-    def _build_action_previews(self, workflow_data: WorkflowCreateRequest, test_context: Dict[str, Any], conditions_met: bool) -> List[WorkflowSimulationActionPreview]:
-        previews: List[WorkflowSimulationActionPreview] = []
+    def _build_action_previews(self, workflow_data: WorkflowCreateRequest, test_context: dict[str, Any], conditions_met: bool) -> list[WorkflowSimulationActionPreview]:
+        previews: list[WorkflowSimulationActionPreview] = []
         for action in workflow_data.actions:
             if not conditions_met:
                 previews.append(WorkflowSimulationActionPreview(
@@ -121,7 +121,7 @@ class WorkflowSimulationService:
                 ))
         return previews
 
-    def _preview_slack_action(self, params: Dict[str, Any], test_context: Dict[str, Any]) -> WorkflowSimulationActionPreview:
+    def _preview_slack_action(self, params: dict[str, Any], test_context: dict[str, Any]) -> WorkflowSimulationActionPreview:
         handler = SlackActionHandler(self.session, self.db_manager, self.monitor_instance)
         is_valid, error = handler.validate_params(params)
         if not is_valid:
@@ -140,7 +140,7 @@ class WorkflowSimulationService:
             )
 
         rendered = handler.render_template(params.get("template", ""), test_context)
-        warnings: List[str] = []
+        warnings: list[str] = []
         if len(rendered) > 280:
             warnings.append("Rendered Slack message is fairly long and may be noisy in production.")
 
@@ -156,7 +156,7 @@ class WorkflowSimulationService:
             warnings=warnings,
         )
 
-    def _preview_retry_action(self, params: Dict[str, Any], test_context: Dict[str, Any]) -> WorkflowSimulationActionPreview:
+    def _preview_retry_action(self, params: dict[str, Any], test_context: dict[str, Any]) -> WorkflowSimulationActionPreview:
         handler = RetryActionHandler(self.session, self.db_manager, self.monitor_instance)
         is_valid, error = handler.validate_params(params)
         if not is_valid:
@@ -175,15 +175,15 @@ class WorkflowSimulationService:
             )
 
         task_events = self.task_service.get_task_events(task_id)
-        warnings: List[str] = []
-        details: Dict[str, Any] = {
+        warnings: list[str] = []
+        details: dict[str, Any] = {
             "task_id": task_id,
             "delay_seconds": params.get("delay_seconds", 0),
             "max_retries": params.get("max_retries", 10),
         }
         if task_events:
-            original_task = task_events[-1]
-            current_retry_count = handler._count_workflow_retries(task_id, original_task.root_id)
+            original_task = task_events[0]
+            current_retry_count = handler.count_workflow_retries(task_id, original_task.root_id)
             details.update({
                 "task_name": original_task.task_name,
                 "queue": original_task.queue or "default",
@@ -208,7 +208,7 @@ class WorkflowSimulationService:
         slug = f"{workflow_name}:{trigger_type}".lower().replace(" ", "-")
         return f"workflow_simulations.{slug}"
 
-    def _store_history(self, workflow_name: str, trigger_type: str, record: WorkflowSimulationRecord) -> List[WorkflowSimulationRecord]:
+    def _store_history(self, workflow_name: str, trigger_type: str, record: WorkflowSimulationRecord) -> list[WorkflowSimulationRecord]:
         key = self._history_key(workflow_name, trigger_type)
         current = self.app_config_service.get_setting_value(key, default=[])
         items = current if isinstance(current, list) else []

--- a/agent/services/workflow_simulation_service.py
+++ b/agent/services/workflow_simulation_service.py
@@ -182,13 +182,23 @@ class WorkflowSimulationService:
             "max_retries": params.get("max_retries", 10),
         }
         if task_events:
-            original_task = task_events[0]
+            original_task = task_events[-1]
             current_retry_count = handler.count_workflow_retries(task_id, original_task.root_id)
             details.update({
                 "task_name": original_task.task_name,
                 "queue": original_task.queue or "default",
                 "current_retry_depth": current_retry_count,
             })
+            if current_retry_count >= details["max_retries"]:
+                return WorkflowSimulationActionPreview(
+                    action_type="task.retry",
+                    status="blocked",
+                    summary="Retry cap already reached for this task chain.",
+                    details=details,
+                    warnings=[
+                        f"Workflow retries are already at {current_retry_count}/{details['max_retries']}; a real execution would be rejected."
+                    ],
+                )
             if current_retry_count + 1 >= details["max_retries"]:
                 warnings.append("This dry run is near the retry cap; later real executions may be blocked soon.")
         else:

--- a/agent/services/workflow_simulation_service.py
+++ b/agent/services/workflow_simulation_service.py
@@ -1,0 +1,227 @@
+"""Dry-run workflow simulation helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from models import (
+    AppSettingUpdate,
+    WorkflowCreateRequest,
+    WorkflowDefinition,
+    WorkflowSimulationActionPreview,
+    WorkflowSimulationRecord,
+    WorkflowSimulationResponse,
+)
+from services.action_config_service import ActionConfigService
+from services.app_config_service import AppConfigService
+from services.task_service import TaskService
+from services.workflow_engine import WorkflowEngine
+from services.workflow_service import WorkflowService
+from services.actions.retry_action import RetryActionHandler
+from services.actions.slack_action import SlackActionHandler
+
+
+class WorkflowSimulationService:
+    """Evaluate workflows safely without executing actions."""
+
+    HISTORY_LIMIT = 10
+
+    def __init__(self, session, db_manager=None, monitor_instance=None):
+        self.session = session
+        self.db_manager = db_manager
+        self.monitor_instance = monitor_instance
+        self.workflow_service = WorkflowService(session)
+        self.workflow_engine = WorkflowEngine(db_manager=db_manager, monitor_instance=monitor_instance)
+        self.action_config_service = ActionConfigService(session)
+        self.app_config_service = AppConfigService(session)
+        self.task_service = TaskService(session)
+
+    def simulate(self, workflow_data: WorkflowCreateRequest, test_context: Dict[str, Any]) -> WorkflowSimulationResponse:
+        actions = self.workflow_service._coerce_actions(workflow_data.actions)
+        self.workflow_service._validate_workflow_definition(workflow_data.trigger, actions)
+
+        workflow = WorkflowDefinition(
+            name=workflow_data.name,
+            description=workflow_data.description,
+            enabled=workflow_data.enabled,
+            trigger=workflow_data.trigger,
+            conditions=workflow_data.conditions,
+            actions=actions,
+            priority=workflow_data.priority,
+            max_executions_per_hour=workflow_data.max_executions_per_hour,
+            cooldown_seconds=workflow_data.cooldown_seconds,
+            circuit_breaker=workflow_data.circuit_breaker,
+        )
+
+        conditions_met = self.workflow_engine._evaluate_conditions(workflow, test_context)
+        warnings = self._collect_warnings(workflow_data, test_context)
+        action_previews = self._build_action_previews(workflow_data, test_context, conditions_met)
+        would_execute = conditions_met and any(preview.status == "would_execute" for preview in action_previews)
+
+        record = WorkflowSimulationRecord(
+            simulated_at=datetime.now(timezone.utc),
+            workflow_name=workflow.name,
+            trigger_type=workflow.trigger.type,
+            conditions_met=conditions_met,
+            would_execute=would_execute,
+            warnings=warnings,
+            action_previews=action_previews,
+        )
+        history = self._store_history(workflow.name, workflow.trigger.type, record)
+
+        return WorkflowSimulationResponse(
+            workflow_name=workflow.name,
+            trigger_type=workflow.trigger.type,
+            test_context=test_context,
+            conditions_met=conditions_met,
+            would_execute=would_execute,
+            warnings=warnings,
+            action_previews=action_previews,
+            simulation_history=history,
+        )
+
+    def _collect_warnings(self, workflow_data: WorkflowCreateRequest, test_context: Dict[str, Any]) -> List[str]:
+        warnings: List[str] = []
+        if not workflow_data.conditions or not workflow_data.conditions.conditions:
+            warnings.append("No conditions configured: this workflow will match every event for the selected trigger.")
+        if workflow_data.trigger.type in {"task.failed", "task.orphaned", "worker.offline"} and len(workflow_data.actions) > 1:
+            warnings.append("Multiple actions on a high-signal trigger can create noisy or risky automation when an incident spikes.")
+        for action in workflow_data.actions:
+            if action.type == "task.retry":
+                if action.params.get("delay_seconds", 0) == 0:
+                    warnings.append("Retry action runs immediately; consider adding a delay to avoid retry storms.")
+                if action.params.get("max_retries") in (None, ""):
+                    warnings.append("Retry action has no custom retry cap; it will fall back to the default handler limit.")
+            if action.type == "slack.notify" and not action.params.get("channel"):
+                warnings.append("Slack notification relies on the webhook default channel because no explicit channel override is set.")
+        if workflow_data.trigger.type.startswith("task.") and "task_id" not in test_context:
+            warnings.append("Test context is missing task_id, so task-linked actions may be blocked in the dry run.")
+        return warnings
+
+    def _build_action_previews(self, workflow_data: WorkflowCreateRequest, test_context: Dict[str, Any], conditions_met: bool) -> List[WorkflowSimulationActionPreview]:
+        previews: List[WorkflowSimulationActionPreview] = []
+        for action in workflow_data.actions:
+            if not conditions_met:
+                previews.append(WorkflowSimulationActionPreview(
+                    action_type=action.type,
+                    status="blocked",
+                    summary="Conditions did not match, so this action would not run.",
+                ))
+                continue
+            if action.type == "slack.notify":
+                previews.append(self._preview_slack_action(action.params, test_context))
+            elif action.type == "task.retry":
+                previews.append(self._preview_retry_action(action.params, test_context))
+            else:
+                previews.append(WorkflowSimulationActionPreview(
+                    action_type=action.type,
+                    status="blocked",
+                    summary="Unsupported action type for dry-run preview.",
+                ))
+        return previews
+
+    def _preview_slack_action(self, params: Dict[str, Any], test_context: Dict[str, Any]) -> WorkflowSimulationActionPreview:
+        handler = SlackActionHandler(self.session, self.db_manager, self.monitor_instance)
+        is_valid, error = handler.validate_params(params)
+        if not is_valid:
+            return WorkflowSimulationActionPreview(
+                action_type="slack.notify",
+                status="blocked",
+                summary=error,
+            )
+
+        config = self.action_config_service.get_config(params["config_id"])
+        if not config:
+            return WorkflowSimulationActionPreview(
+                action_type="slack.notify",
+                status="blocked",
+                summary=f"Action config not found: {params['config_id']}",
+            )
+
+        rendered = handler.render_template(params.get("template", ""), test_context)
+        warnings: List[str] = []
+        if len(rendered) > 280:
+            warnings.append("Rendered Slack message is fairly long and may be noisy in production.")
+
+        return WorkflowSimulationActionPreview(
+            action_type="slack.notify",
+            status="would_execute",
+            summary="Would send a Slack notification.",
+            details={
+                "config_name": config.name,
+                "channel": params.get("channel") or "(webhook default)",
+                "message": rendered,
+            },
+            warnings=warnings,
+        )
+
+    def _preview_retry_action(self, params: Dict[str, Any], test_context: Dict[str, Any]) -> WorkflowSimulationActionPreview:
+        handler = RetryActionHandler(self.session, self.db_manager, self.monitor_instance)
+        is_valid, error = handler.validate_params(params)
+        if not is_valid:
+            return WorkflowSimulationActionPreview(
+                action_type="task.retry",
+                status="blocked",
+                summary=error,
+            )
+
+        task_id = test_context.get("task_id")
+        if not task_id:
+            return WorkflowSimulationActionPreview(
+                action_type="task.retry",
+                status="blocked",
+                summary="No task_id in test context, so retry safety could not be evaluated.",
+            )
+
+        task_events = self.task_service.get_task_events(task_id)
+        warnings: List[str] = []
+        details: Dict[str, Any] = {
+            "task_id": task_id,
+            "delay_seconds": params.get("delay_seconds", 0),
+            "max_retries": params.get("max_retries", 10),
+        }
+        if task_events:
+            original_task = task_events[-1]
+            current_retry_count = handler._count_workflow_retries(task_id, original_task.root_id)
+            details.update({
+                "task_name": original_task.task_name,
+                "queue": original_task.queue or "default",
+                "current_retry_depth": current_retry_count,
+            })
+            if current_retry_count + 1 >= details["max_retries"]:
+                warnings.append("This dry run is near the retry cap; later real executions may be blocked soon.")
+        else:
+            warnings.append("Task history was not found in the database; retry preview is based only on the provided context.")
+            details["task_name"] = test_context.get("task_name")
+            details["queue"] = test_context.get("queue") or "default"
+
+        return WorkflowSimulationActionPreview(
+            action_type="task.retry",
+            status="would_execute",
+            summary="Would enqueue a retry for the matching task.",
+            details=details,
+            warnings=warnings,
+        )
+
+    def _history_key(self, workflow_name: str, trigger_type: str) -> str:
+        slug = f"{workflow_name}:{trigger_type}".lower().replace(" ", "-")
+        return f"workflow_simulations.{slug}"
+
+    def _store_history(self, workflow_name: str, trigger_type: str, record: WorkflowSimulationRecord) -> List[WorkflowSimulationRecord]:
+        key = self._history_key(workflow_name, trigger_type)
+        current = self.app_config_service.get_setting_value(key, default=[])
+        items = current if isinstance(current, list) else []
+        items.insert(0, record.model_dump(mode="json"))
+        items = items[: self.HISTORY_LIMIT]
+        self.app_config_service.upsert_setting(
+            key,
+            AppSettingUpdate(
+                value=items,
+                value_type="json",
+                label="Workflow simulation history",
+                description="Recent dry-run workflow simulations.",
+                category="workflow_simulations",
+            ),
+        )
+        return [WorkflowSimulationRecord(**item) for item in items]

--- a/agent/tests/unit/test_workflow_simulation.py
+++ b/agent/tests/unit/test_workflow_simulation.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from services.action_config_service import ActionConfigService
 from services.workflow_simulation_service import WorkflowSimulationService
 from models import WorkflowCreateRequest, TriggerConfig, ActionConfig, ConditionGroup, Condition, ActionConfigCreateRequest
-from database import TaskEventDB
+from database import TaskEventDB, RetryRelationshipDB
 from tests.base import ServiceTestCase
 
 
@@ -99,6 +99,37 @@ class TestWorkflowSimulationService(ServiceTestCase):
         self.assertEqual(result.action_previews[0].status, "would_execute")
         self.assertEqual(result.action_previews[0].details["queue"], "priority")
         self.assertEqual(result.action_previews[0].details["current_retry_depth"], 0)
+
+    def test_retry_preview_blocks_when_retry_cap_is_already_reached(self):
+        now = datetime.now(timezone.utc)
+        self.session.add(TaskEventDB(
+            task_id="task-3",
+            task_name="reports.generate",
+            event_type="task.failed",
+            timestamp=now,
+            queue="priority",
+            root_id="root-3",
+        ))
+        self.session.add(RetryRelationshipDB(task_id="task-3", original_id="retry-2"))
+        self.session.add(RetryRelationshipDB(task_id="retry-2", original_id="retry-1"))
+        self.session.add(RetryRelationshipDB(task_id="retry-1", original_id="root-3"))
+        self.session.commit()
+
+        workflow = WorkflowCreateRequest(
+            name="Retry capped report",
+            trigger=TriggerConfig(type="task.failed", config={}),
+            conditions=ConditionGroup(operator="AND", conditions=[]),
+            actions=[ActionConfig(type="task.retry", params={"delay_seconds": 30, "max_retries": 3})],
+        )
+
+        result = self.service.simulate(
+            workflow,
+            {"task_id": "task-3", "task_name": "reports.generate", "event_type": "task.failed"},
+        )
+
+        self.assertEqual(result.action_previews[0].status, "blocked")
+        self.assertIn("Retry cap already reached", result.action_previews[0].summary)
+        self.assertEqual(result.action_previews[0].details["current_retry_depth"], 3)
 
 
 if __name__ == "__main__":

--- a/agent/tests/unit/test_workflow_simulation.py
+++ b/agent/tests/unit/test_workflow_simulation.py
@@ -131,6 +131,29 @@ class TestWorkflowSimulationService(ServiceTestCase):
         self.assertIn("Retry cap already reached", result.action_previews[0].summary)
         self.assertEqual(result.action_previews[0].details["current_retry_depth"], 3)
 
+    def test_retry_preview_blocks_from_context_when_history_is_missing(self):
+        workflow = WorkflowCreateRequest(
+            name="Retry capped by context",
+            trigger=TriggerConfig(type="task.failed", config={}),
+            conditions=ConditionGroup(operator="AND", conditions=[]),
+            actions=[ActionConfig(type="task.retry", params={"delay_seconds": 30, "max_retries": 3})],
+        )
+
+        result = self.service.simulate(
+            workflow,
+            {
+                "task_id": "task-missing",
+                "task_name": "reports.generate",
+                "event_type": "task.failed",
+                "retry_count": 3,
+            },
+        )
+
+        self.assertEqual(result.action_previews[0].status, "blocked")
+        self.assertIn("Would NOT enqueue a retry", result.action_previews[0].summary)
+        self.assertEqual(result.action_previews[0].details["current_retry_depth"], 3)
+        self.assertTrue(any("would be rejected" in warning for warning in result.action_previews[0].warnings))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/agent/tests/unit/test_workflow_simulation.py
+++ b/agent/tests/unit/test_workflow_simulation.py
@@ -1,0 +1,105 @@
+"""Tests for workflow dry-run simulation."""
+
+import unittest
+from datetime import datetime, timezone
+
+from services.action_config_service import ActionConfigService
+from services.workflow_simulation_service import WorkflowSimulationService
+from models import WorkflowCreateRequest, TriggerConfig, ActionConfig, ConditionGroup, Condition, ActionConfigCreateRequest
+from database import TaskEventDB
+from tests.base import ServiceTestCase
+
+
+class TestWorkflowSimulationService(ServiceTestCase):
+    def setUp(self):
+        super().setUp()
+        self.config_service = ActionConfigService(self.session)
+        self.config = self.config_service.create_config(
+            ActionConfigCreateRequest(
+                name="Ops Slack",
+                description="",
+                action_type="slack.notify",
+                config={"webhook_url": "https://hooks.slack.test/services/demo"},
+            )
+        )
+        self.service = WorkflowSimulationService(self.session)
+
+    def test_simulation_previews_actions_and_persists_history(self):
+        workflow = WorkflowCreateRequest(
+            name="Alert on failed payments",
+            trigger=TriggerConfig(type="task.failed", config={}),
+            conditions=ConditionGroup(
+                operator="AND",
+                conditions=[Condition(field="task_name", operator="equals", value="payments.charge")],
+            ),
+            actions=[
+                ActionConfig(
+                    type="slack.notify",
+                    params={
+                        "config_id": self.config.id,
+                        "template": "Task {{task_name}} failed for {{task_id}}",
+                    },
+                )
+            ],
+        )
+
+        result = self.service.simulate(
+            workflow,
+            {"task_id": "task-1", "task_name": "payments.charge", "event_type": "task.failed"},
+        )
+
+        self.assertTrue(result.conditions_met)
+        self.assertTrue(result.would_execute)
+        self.assertEqual(result.action_previews[0].status, "would_execute")
+        self.assertIn("payments.charge", result.action_previews[0].details["message"])
+        self.assertEqual(len(result.simulation_history), 1)
+        self.assertEqual(result.simulation_history[0].workflow_name, workflow.name)
+
+    def test_simulation_warns_for_broad_rule_and_blocks_invalid_action(self):
+        workflow = WorkflowCreateRequest(
+            name="Immediate retry all failures",
+            trigger=TriggerConfig(type="task.failed", config={}),
+            actions=[ActionConfig(type="task.retry", params={"delay_seconds": 0})],
+        )
+
+        result = self.service.simulate(
+            workflow,
+            {"task_name": "payments.charge", "event_type": "task.failed"},
+        )
+
+        self.assertTrue(any("No conditions configured" in warning for warning in result.warnings))
+        self.assertTrue(any("missing task_id" in warning for warning in result.warnings))
+        self.assertEqual(result.action_previews[0].status, "blocked")
+        self.assertIn("No task_id", result.action_previews[0].summary)
+
+    def test_retry_preview_uses_task_history_when_present(self):
+        now = datetime.now(timezone.utc)
+        self.session.add(TaskEventDB(
+            task_id="task-2",
+            task_name="reports.generate",
+            event_type="task-failed",
+            timestamp=now,
+            queue="priority",
+            root_id="root-2",
+        ))
+        self.session.commit()
+
+        workflow = WorkflowCreateRequest(
+            name="Retry stuck report",
+            trigger=TriggerConfig(type="task.failed", config={}),
+            conditions=ConditionGroup(operator="AND", conditions=[]),
+            actions=[ActionConfig(type="task.retry", params={"delay_seconds": 30, "max_retries": 3})],
+        )
+
+        result = self.service.simulate(
+            workflow,
+            {"task_id": "task-2", "task_name": "reports.generate", "event_type": "task.failed"},
+        )
+
+        self.assertEqual(result.action_previews[0].status, "would_execute")
+        self.assertEqual(result.action_previews[0].details["queue"], "priority")
+        self.assertEqual(result.action_previews[0].details["current_retry_depth"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent/tests/unit/test_workflow_simulation.py
+++ b/agent/tests/unit/test_workflow_simulation.py
@@ -77,7 +77,7 @@ class TestWorkflowSimulationService(ServiceTestCase):
         self.session.add(TaskEventDB(
             task_id="task-2",
             task_name="reports.generate",
-            event_type="task-failed",
+            event_type="task.failed",
             timestamp=now,
             queue="priority",
             root_id="root-2",

--- a/frontend/app/components/workflows/WorkflowSimulationDialog.vue
+++ b/frontend/app/components/workflows/WorkflowSimulationDialog.vue
@@ -116,7 +116,10 @@ async function runSimulation() {
     simulationError.value = null
     result.value = null
     running.value = true
-    const context = localContext.value ? JSON.parse(localContext.value) : {}
+    const parsedContext = localContext.value ? JSON.parse(localContext.value) : {}
+    const context = parsedContext && typeof parsedContext === 'object' && !Array.isArray(parsedContext)
+      ? parsedContext
+      : {}
     result.value = await workflowStore.simulateWorkflow(props.workflow, context)
   } catch (err) {
     if (err instanceof SyntaxError) {

--- a/frontend/app/components/workflows/WorkflowSimulationDialog.vue
+++ b/frontend/app/components/workflows/WorkflowSimulationDialog.vue
@@ -1,0 +1,140 @@
+<template>
+  <Dialog :open="open" @update:open="$emit('close')">
+    <DialogContent class="max-w-3xl max-h-[85vh] overflow-hidden flex flex-col">
+      <DialogHeader>
+        <DialogTitle>Simulate Workflow</DialogTitle>
+        <DialogDescription>Dry-run this workflow against a sample event without firing real actions.</DialogDescription>
+      </DialogHeader>
+
+      <div class="space-y-4 overflow-y-auto pr-1">
+        <div>
+          <label class="text-xs font-medium text-text-secondary mb-1.5 block">Sample event context (JSON)</label>
+          <Textarea v-model="localContext" rows="10" class="font-mono text-xs w-full" />
+        </div>
+
+        <div v-if="simulationError" class="text-sm text-status-error bg-status-error-bg border border-status-error-border rounded px-3 py-2">
+          {{ simulationError }}
+        </div>
+
+        <div v-if="result" class="space-y-4">
+          <div class="rounded-lg border border-border-subtle p-4 bg-background-raised">
+            <div class="flex flex-wrap items-center gap-2 mb-3">
+              <Badge :variant="result.conditions_met ? 'default' : 'secondary'">
+                {{ result.conditions_met ? 'Conditions match' : 'Conditions do not match' }}
+              </Badge>
+              <Badge :variant="result.would_execute ? 'default' : 'secondary'">
+                {{ result.would_execute ? 'Would execute' : 'Would not execute' }}
+              </Badge>
+            </div>
+            <div v-if="result.warnings.length" class="space-y-2">
+              <div v-for="warning in result.warnings" :key="warning" class="text-xs rounded border border-amber-300/40 bg-amber-500/10 px-3 py-2 text-amber-200">
+                {{ warning }}
+              </div>
+            </div>
+          </div>
+
+          <div class="rounded-lg border border-border-subtle p-4 space-y-3">
+            <h3 class="text-sm font-medium text-text-primary">Action preview</h3>
+            <div v-for="(action, index) in result.action_previews" :key="`${action.action_type}-${index}`" class="rounded border border-border-subtle bg-background-base p-3 space-y-2">
+              <div class="flex items-center gap-2">
+                <Badge :variant="action.status === 'would_execute' ? 'default' : 'destructive'">{{ action.status === 'would_execute' ? 'Would run' : 'Blocked' }}</Badge>
+                <span class="text-sm text-text-primary font-medium">{{ action.action_type }}</span>
+              </div>
+              <p class="text-sm text-text-secondary">{{ action.summary }}</p>
+              <div v-if="Object.keys(action.details || {}).length" class="text-xs text-text-muted font-mono whitespace-pre-wrap break-all">{{ formatDetails(action.details) }}</div>
+              <div v-for="warning in action.warnings || []" :key="warning" class="text-xs rounded border border-amber-300/40 bg-amber-500/10 px-3 py-2 text-amber-200">
+                {{ warning }}
+              </div>
+            </div>
+          </div>
+
+          <div v-if="result.simulation_history.length" class="rounded-lg border border-border-subtle p-4 space-y-3">
+            <h3 class="text-sm font-medium text-text-primary">Recent simulations</h3>
+            <div v-for="(entry, index) in result.simulation_history.slice(0, 5)" :key="`${entry.simulated_at}-${index}`" class="text-xs text-text-muted border-b border-border-subtle last:border-b-0 pb-2 last:pb-0">
+              <div class="flex items-center gap-2 mb-1">
+                <Badge variant="outline">{{ entry.would_execute ? 'Would execute' : 'No execution' }}</Badge>
+                <span>{{ formatTime(entry.simulated_at) }}</span>
+              </div>
+              <div>{{ entry.warnings[0] || 'No major warnings.' }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button variant="ghost" @click="$emit('close')">Close</Button>
+        <Button @click="runSimulation" :disabled="running">
+          {{ running ? 'Simulating...' : 'Run Simulation' }}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { Button } from '~/components/ui/button'
+import { Textarea } from '~/components/ui/textarea'
+import { Badge } from '~/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '~/components/ui/dialog'
+import type { WorkflowCreateRequest, WorkflowSimulationResponse } from '~/types/workflow'
+
+const props = defineProps<{
+  open: boolean
+  workflow: WorkflowCreateRequest
+  defaultContext: string
+}>()
+
+const emit = defineEmits<{ close: [] }>()
+
+const workflowStore = useWorkflowsStore()
+const localContext = ref(props.defaultContext)
+const running = ref(false)
+const simulationError = ref<string | null>(null)
+const result = ref<WorkflowSimulationResponse | null>(null)
+
+watch(() => props.defaultContext, (value) => {
+  localContext.value = value
+})
+
+watch(() => props.open, (open) => {
+  if (open) {
+    simulationError.value = null
+  }
+})
+
+async function runSimulation() {
+  try {
+    simulationError.value = null
+    result.value = null
+    running.value = true
+    const context = localContext.value ? JSON.parse(localContext.value) : {}
+    result.value = await workflowStore.simulateWorkflow(props.workflow, context)
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      simulationError.value = 'Context must be valid JSON.'
+    } else if (err instanceof Error) {
+      simulationError.value = err.message
+    } else {
+      simulationError.value = 'Unable to run workflow simulation.'
+    }
+  } finally {
+    running.value = false
+  }
+}
+
+function formatDetails(details: Record<string, any>) {
+  return JSON.stringify(details, null, 2)
+}
+
+function formatTime(value: string) {
+  return new Date(value).toLocaleString()
+}
+</script>

--- a/frontend/app/components/workflows/WorkflowSimulationDialog.vue
+++ b/frontend/app/components/workflows/WorkflowSimulationDialog.vue
@@ -84,7 +84,8 @@ import {
   DialogHeader,
   DialogTitle
 } from '~/components/ui/dialog'
-import type { WorkflowCreateRequest, WorkflowSimulationResponse } from '~/types/workflow'
+import type { WorkflowCreateRequest } from '~/src/types/api'
+import type { WorkflowSimulationResponse } from '~/types/workflow'
 
 const props = defineProps<{
   open: boolean

--- a/frontend/app/components/workflows/WorkflowSimulationDialog.vue
+++ b/frontend/app/components/workflows/WorkflowSimulationDialog.vue
@@ -107,6 +107,7 @@ watch(() => props.defaultContext, (value) => {
 watch(() => props.open, (open) => {
   if (open) {
     simulationError.value = null
+    result.value = null
   }
 })
 

--- a/frontend/app/components/workflows/WorkflowSimulationDialog.vue
+++ b/frontend/app/components/workflows/WorkflowSimulationDialog.vue
@@ -84,8 +84,7 @@ import {
   DialogHeader,
   DialogTitle
 } from '~/components/ui/dialog'
-import type { WorkflowCreateRequest } from '~/src/types/api'
-import type { WorkflowSimulationResponse } from '~/types/workflow'
+import type { WorkflowCreateRequest, WorkflowSimulationResponse } from '~/services/apiClient'
 
 const props = defineProps<{
   open: boolean

--- a/frontend/app/pages/workflows/[id]/edit.vue
+++ b/frontend/app/pages/workflows/[id]/edit.vue
@@ -19,7 +19,7 @@
         <NuxtLink :to="`/workflows/${route.params.id}`">
           <Button variant="ghost" size="sm">Cancel</Button>
         </NuxtLink>
-        <Button variant="outline" size="sm" @click="showSimulationDialog = true">
+        <Button variant="outline" size="sm" :disabled="!simulationWorkflow" @click="showSimulationDialog = true">
           <FlaskConical class="h-3.5 w-3.5 mr-1.5" />
           Simulate
         </Button>

--- a/frontend/app/pages/workflows/[id]/edit.vue
+++ b/frontend/app/pages/workflows/[id]/edit.vue
@@ -106,9 +106,9 @@
       </Dialog>
 
       <WorkflowSimulationDialog
-        v-if="workflow"
+        v-if="simulationWorkflow"
         :open="showSimulationDialog"
-        :workflow="workflow as any"
+        :workflow="simulationWorkflow"
         :default-context="testContext"
         @close="showSimulationDialog = false"
       />
@@ -291,10 +291,12 @@ import WorkflowConditionBuilder from '~/components/workflows/WorkflowConditionBu
 import WorkflowActionsList from '~/components/workflows/WorkflowActionsList.vue'
 import WorkflowCircuitBreakerConfig from '~/components/workflows/WorkflowCircuitBreakerConfig.vue'
 import WorkflowSimulationDialog from '~/components/workflows/WorkflowSimulationDialog.vue'
-import type { WorkflowUpdateRequest } from '~/types/workflow'
+import type { WorkflowCreateRequest, WorkflowUpdateRequest } from '~/types/workflow'
+import { useLogger } from '~/services/logger'
 
 const route = useRoute()
 const workflowStore = useWorkflowsStore()
+const logger = useLogger()
 const saving = ref(false)
 const showTestDialog = ref(false)
 const showSimulationDialog = ref(false)
@@ -317,6 +319,25 @@ const canSave = computed(() => {
          workflow.value.actions.length > 0
 })
 
+const simulationWorkflow = computed<WorkflowCreateRequest | null>(() => {
+  if (!workflow.value?.name || !workflow.value.trigger || !workflow.value.actions) {
+    return null
+  }
+
+  return {
+    name: workflow.value.name,
+    description: workflow.value.description,
+    enabled: workflow.value.enabled ?? true,
+    trigger: workflow.value.trigger,
+    conditions: workflow.value.conditions,
+    actions: workflow.value.actions,
+    priority: workflow.value.priority ?? 100,
+    max_executions_per_hour: workflow.value.max_executions_per_hour,
+    cooldown_seconds: workflow.value.cooldown_seconds ?? 0,
+    circuit_breaker: workflow.value.circuit_breaker ?? null,
+  }
+})
+
 async function saveWorkflow() {
   if (!canSave.value || !workflow.value) return
 
@@ -332,7 +353,9 @@ async function saveWorkflow() {
     await workflowStore.fetchWorkflow(route.params.id as string)
     await navigateTo(`/workflows/${route.params.id}`)
   } catch (err) {
-    console.error('Failed to save workflow:', err)
+    logger.error('Failed to save workflow', {
+      error: err instanceof Error ? err.message : String(err)
+    })
   } finally {
     saving.value = false
   }
@@ -382,7 +405,9 @@ onMounted(async () => {
   try {
     await workflowStore.fetchWorkflowMetadata()
   } catch (err) {
-    console.error('Failed to load workflow metadata:', err)
+    logger.error('Failed to load workflow metadata', {
+      error: err instanceof Error ? err.message : String(err)
+    })
   }
 
   const loaded = await workflowStore.fetchWorkflow(route.params.id as string)
@@ -401,7 +426,7 @@ onMounted(async () => {
       circuit_breaker: loaded.circuit_breaker
     }
   } else {
-    console.error('Failed to load workflow data')
+    logger.error('Failed to load workflow data')
   }
 
   isLoading.value = false

--- a/frontend/app/pages/workflows/[id]/edit.vue
+++ b/frontend/app/pages/workflows/[id]/edit.vue
@@ -19,9 +19,9 @@
         <NuxtLink :to="`/workflows/${route.params.id}`">
           <Button variant="ghost" size="sm">Cancel</Button>
         </NuxtLink>
-        <Button variant="outline" size="sm" @click="showTestDialog = true">
+        <Button variant="outline" size="sm" @click="showSimulationDialog = true">
           <FlaskConical class="h-3.5 w-3.5 mr-1.5" />
-          Test
+          Simulate
         </Button>
         <Button @click="saveWorkflow" :disabled="!canSave || saving" size="sm">
           <Save class="h-3.5 w-3.5 mr-1.5" />
@@ -104,6 +104,14 @@
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <WorkflowSimulationDialog
+        v-if="workflow"
+        :open="showSimulationDialog"
+        :workflow="workflow as any"
+        :default-context="testContext"
+        @close="showSimulationDialog = false"
+      />
 
       <!-- Workflow Builder -->
       <div class="border border-border-subtle rounded-md p-5">
@@ -282,12 +290,14 @@ import WorkflowTriggerSelector from '~/components/workflows/WorkflowTriggerSelec
 import WorkflowConditionBuilder from '~/components/workflows/WorkflowConditionBuilder.vue'
 import WorkflowActionsList from '~/components/workflows/WorkflowActionsList.vue'
 import WorkflowCircuitBreakerConfig from '~/components/workflows/WorkflowCircuitBreakerConfig.vue'
+import WorkflowSimulationDialog from '~/components/workflows/WorkflowSimulationDialog.vue'
 import type { WorkflowUpdateRequest } from '~/types/workflow'
 
 const route = useRoute()
 const workflowStore = useWorkflowsStore()
 const saving = ref(false)
 const showTestDialog = ref(false)
+const showSimulationDialog = ref(false)
 const testing = ref(false)
 const testContext = ref('{\n  "task_id": "example-task",\n  "task_name": "process_payment",\n  "event_type": "task.failed",\n  "retry_count": 0,\n  "queue": "default"\n}')
 const testResult = ref<any | null>(null)

--- a/frontend/app/pages/workflows/[id]/edit.vue
+++ b/frontend/app/pages/workflows/[id]/edit.vue
@@ -109,7 +109,7 @@
         v-if="simulationWorkflow"
         :open="showSimulationDialog"
         :workflow="simulationWorkflow"
-        :default-context="testContext"
+        :default-context="simulationDefaultContext"
         @close="showSimulationDialog = false"
       />
 
@@ -291,7 +291,8 @@ import WorkflowConditionBuilder from '~/components/workflows/WorkflowConditionBu
 import WorkflowActionsList from '~/components/workflows/WorkflowActionsList.vue'
 import WorkflowCircuitBreakerConfig from '~/components/workflows/WorkflowCircuitBreakerConfig.vue'
 import WorkflowSimulationDialog from '~/components/workflows/WorkflowSimulationDialog.vue'
-import type { WorkflowCreateRequest, WorkflowUpdateRequest } from '~/types/workflow'
+import type { WorkflowCreateRequest } from '~/src/types/api'
+import type { WorkflowUpdateRequest } from '~/types/workflow'
 import { useLogger } from '~/services/logger'
 
 const route = useRoute()
@@ -335,6 +336,18 @@ const simulationWorkflow = computed<WorkflowCreateRequest | null>(() => {
     max_executions_per_hour: workflow.value.max_executions_per_hour,
     cooldown_seconds: workflow.value.cooldown_seconds ?? 0,
     circuit_breaker: workflow.value.circuit_breaker ?? null,
+  }
+})
+
+const simulationDefaultContext = computed(() => {
+  try {
+    const parsed = testContext.value ? JSON.parse(testContext.value) : {}
+    return JSON.stringify({
+      ...parsed,
+      event_type: workflow.value?.trigger?.type || parsed.event_type || 'task.failed'
+    }, null, 2)
+  } catch {
+    return testContext.value
   }
 })
 

--- a/frontend/app/pages/workflows/[id]/edit.vue
+++ b/frontend/app/pages/workflows/[id]/edit.vue
@@ -291,8 +291,7 @@ import WorkflowConditionBuilder from '~/components/workflows/WorkflowConditionBu
 import WorkflowActionsList from '~/components/workflows/WorkflowActionsList.vue'
 import WorkflowCircuitBreakerConfig from '~/components/workflows/WorkflowCircuitBreakerConfig.vue'
 import WorkflowSimulationDialog from '~/components/workflows/WorkflowSimulationDialog.vue'
-import type { WorkflowCreateRequest } from '~/src/types/api'
-import type { WorkflowUpdateRequest } from '~/types/workflow'
+import type { WorkflowCreateRequest, WorkflowUpdateRequest } from '~/services/apiClient'
 import { useLogger } from '~/services/logger'
 
 const route = useRoute()

--- a/frontend/app/pages/workflows/new.vue
+++ b/frontend/app/pages/workflows/new.vue
@@ -15,9 +15,9 @@
         <h1 class="text-xl font-semibold text-text-primary">New Workflow</h1>
       </div>
       <div class="flex items-center gap-2">
-        <Button variant="outline" size="sm" disabled title="Save the workflow to run a test">
+        <Button variant="outline" size="sm" @click="showSimulationDialog = true" :disabled="!canSave">
           <FlaskConical class="h-3.5 w-3.5 mr-1.5" />
-          Test
+          Simulate
         </Button>
         <Button @click="saveWorkflow" :disabled="!canSave || saving" size="sm">
           <Save class="h-3.5 w-3.5 mr-1.5" />
@@ -202,6 +202,13 @@
     <div v-if="workflowStore.error" class="mt-4 p-4 bg-status-error-bg border border-status-error-border rounded-lg">
       <p class="text-sm text-status-error">{{ workflowStore.error }}</p>
     </div>
+
+    <WorkflowSimulationDialog
+      :open="showSimulationDialog"
+      :workflow="workflow"
+      :default-context="simulationContext"
+      @close="showSimulationDialog = false"
+    />
   </div>
 </template>
 
@@ -216,10 +223,12 @@ import WorkflowTriggerSelector from '~/components/workflows/WorkflowTriggerSelec
 import WorkflowConditionBuilder from '~/components/workflows/WorkflowConditionBuilder.vue'
 import WorkflowActionsList from '~/components/workflows/WorkflowActionsList.vue'
 import WorkflowCircuitBreakerConfig from '~/components/workflows/WorkflowCircuitBreakerConfig.vue'
+import WorkflowSimulationDialog from '~/components/workflows/WorkflowSimulationDialog.vue'
 import type { WorkflowCreateRequest } from '~/types/workflow'
 
 const workflowStore = useWorkflowsStore()
 const saving = ref(false)
+const showSimulationDialog = ref(false)
 
 // Form State
 const workflow = ref<WorkflowCreateRequest>({
@@ -242,6 +251,15 @@ const canSave = computed(() => {
          workflow.value.trigger?.type.length > 0 &&
          workflow.value.actions.length > 0
 })
+
+const simulationContext = computed(() => JSON.stringify({
+  task_id: 'example-task',
+  task_name: 'process_payment',
+  event_type: workflow.value.trigger?.type || 'task.failed',
+  queue: 'default',
+  retry_count: 0,
+  exception: 'ExampleError'
+}, null, 2))
 
 function updateCircuitBreaker(config: any) {
   console.log('[New] updateCircuitBreaker called with:', config)

--- a/frontend/app/pages/workflows/new.vue
+++ b/frontend/app/pages/workflows/new.vue
@@ -225,8 +225,10 @@ import WorkflowActionsList from '~/components/workflows/WorkflowActionsList.vue'
 import WorkflowCircuitBreakerConfig from '~/components/workflows/WorkflowCircuitBreakerConfig.vue'
 import WorkflowSimulationDialog from '~/components/workflows/WorkflowSimulationDialog.vue'
 import type { WorkflowCreateRequest } from '~/types/workflow'
+import { useLogger } from '~/services/logger'
 
 const workflowStore = useWorkflowsStore()
+const logger = useLogger()
 const saving = ref(false)
 const showSimulationDialog = ref(false)
 
@@ -262,31 +264,27 @@ const simulationContext = computed(() => JSON.stringify({
 }, null, 2))
 
 function updateCircuitBreaker(config: any) {
-  console.log('[New] updateCircuitBreaker called with:', config)
   workflow.value.circuit_breaker = config
-  console.log('[New] workflow.value after update:', JSON.stringify(workflow.value, null, 2))
+  logger.debug('Updated workflow circuit breaker', { config })
 }
 
 async function saveWorkflow() {
   if (!canSave.value) return
 
-  console.log('[New] saveWorkflow called, workflow.value:', JSON.stringify(workflow.value, null, 2))
-
   saving.value = true
   try {
     const cleanedWorkflow = { ...workflow.value }
-    console.log('[New] cleanedWorkflow before cleanup:', JSON.stringify(cleanedWorkflow, null, 2))
 
     if (cleanedWorkflow.circuit_breaker === null) {
-      console.log('[New] Deleting null circuit_breaker')
       delete cleanedWorkflow.circuit_breaker
     }
 
-    console.log('[New] Final payload being sent:', JSON.stringify(cleanedWorkflow, null, 2))
     const created = await workflowStore.createWorkflow(cleanedWorkflow)
     navigateTo(`/workflows/${created.id}`)
   } catch (err) {
-    console.error('Failed to save workflow:', err)
+    logger.error('Failed to save workflow', {
+      error: err instanceof Error ? err.message : String(err)
+    })
   } finally {
     saving.value = false
   }
@@ -296,7 +294,9 @@ onMounted(async () => {
   try {
     await workflowStore.fetchWorkflowMetadata()
   } catch (err) {
-    console.error('Failed to load workflow metadata:', err)
+    logger.error('Failed to load workflow metadata', {
+      error: err instanceof Error ? err.message : String(err)
+    })
   }
 })
 </script>

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -7,6 +7,7 @@ import type {
   TaskEventResponse,
   WorkerInfo
 } from '../src/types/api'
+import type { WorkflowCreateRequest, WorkflowSimulationResponse } from '../types/workflow'
 
 export type AuthProvider = 'google' | 'github'
 
@@ -700,7 +701,7 @@ class ApiService {
     return response.data
   }
 
-  async simulateWorkflow(workflow: any, testContext: any): Promise<any> {
+  async simulateWorkflow(workflow: WorkflowCreateRequest, testContext: Record<string, unknown>): Promise<WorkflowSimulationResponse> {
     const response = await this.api.request({
       path: '/api/workflows/simulate',
       method: 'POST',

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -7,8 +7,8 @@ import type {
   TaskEventResponse,
   WorkerInfo
 } from '../src/types/api'
-import type { WorkflowCreateRequest } from '../src/types/api'
-import type { WorkflowSimulationResponse, WorkflowUpdateRequest } from '../types/workflow'
+import type { WorkflowCreateRequest, WorkflowUpdateRequest } from '../src/types/api'
+import type { WorkflowSimulationResponse } from '../types/workflow'
 
 export type AuthProvider = 'google' | 'github'
 

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -700,6 +700,18 @@ class ApiService {
     return response.data
   }
 
+  async simulateWorkflow(workflow: any, testContext: any): Promise<any> {
+    const response = await this.api.request({
+      path: '/api/workflows/simulate',
+      method: 'POST',
+      body: {
+        workflow,
+        test_context: testContext
+      }
+    })
+    return response.data
+  }
+
   async getActionConfigs(params?: {
     action_type?: string
     limit?: number

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -8,7 +8,7 @@ import type {
   WorkerInfo
 } from '../src/types/api'
 import type { WorkflowCreateRequest } from '../src/types/api'
-import type { WorkflowSimulationResponse } from '../types/workflow'
+import type { WorkflowSimulationResponse, WorkflowUpdateRequest } from '../types/workflow'
 
 export type AuthProvider = 'google' | 'github'
 
@@ -779,7 +779,10 @@ export type {
   AppConfigSnapshotDTO,
   AppSettingDTO,
   AppSettingInput,
-  TaskIssueConfigDTO
+  TaskIssueConfigDTO,
+  WorkflowCreateRequest,
+  WorkflowSimulationResponse,
+  WorkflowUpdateRequest
 }
 
 // Re-export session types from auto-generated API

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -7,7 +7,8 @@ import type {
   TaskEventResponse,
   WorkerInfo
 } from '../src/types/api'
-import type { WorkflowCreateRequest, WorkflowSimulationResponse } from '../types/workflow'
+import type { WorkflowCreateRequest } from '../src/types/api'
+import type { WorkflowSimulationResponse } from '../types/workflow'
 
 export type AuthProvider = 'google' | 'github'
 

--- a/frontend/app/stores/workflows.ts
+++ b/frontend/app/stores/workflows.ts
@@ -6,6 +6,7 @@ import type {
   WorkflowCreateRequest,
   WorkflowUpdateRequest,
   WorkflowExecutionRecord,
+  WorkflowSimulationResponse,
   ActionConfigDefinition,
   ActionConfigCreateRequest,
   ActionConfigUpdateRequest
@@ -20,6 +21,7 @@ export const useWorkflowsStore = defineStore('workflows', () => {
   const actionConfigs = ref<ActionConfigDefinition[]>([])
   const triggerCatalog = ref<{ type: string; label: string; description: string; category: string }[]>([])
   const actionCatalog = ref<{ type: string; label: string; description: string; category: string }[]>([])
+  const latestSimulation = ref<WorkflowSimulationResponse | null>(null)
   const metadataLoaded = ref(false)
 
   const isLoading = ref(false)
@@ -195,6 +197,17 @@ export const useWorkflowsStore = defineStore('workflows', () => {
     }
   }
 
+  async function simulateWorkflow(workflow: WorkflowCreateRequest, testContext: any) {
+    try {
+      error.value = null
+      latestSimulation.value = await apiService.simulateWorkflow(workflow, testContext)
+      return latestSimulation.value
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to simulate workflow'
+      throw err
+    }
+  }
+
   async function fetchActionConfigs(params?: { action_type?: string }) {
     try {
       isLoading.value = true
@@ -270,6 +283,7 @@ export const useWorkflowsStore = defineStore('workflows', () => {
     currentWorkflow,
     executions,
     actionConfigs,
+    latestSimulation,
     isLoading,
     error,
 
@@ -288,6 +302,7 @@ export const useWorkflowsStore = defineStore('workflows', () => {
     fetchWorkflowExecutions,
     fetchRecentExecutions,
     testWorkflow,
+    simulateWorkflow,
     fetchActionConfigs,
     createActionConfig,
     updateActionConfig,

--- a/frontend/app/types/workflow.ts
+++ b/frontend/app/types/workflow.ts
@@ -200,3 +200,32 @@ export interface WorkflowTestResponse {
   would_execute: boolean
   actions: string[]
 }
+
+export interface WorkflowSimulationActionPreview {
+  action_type: string
+  status: 'would_execute' | 'blocked'
+  summary: string
+  details: Record<string, any>
+  warnings: string[]
+}
+
+export interface WorkflowSimulationRecord {
+  simulated_at: string
+  workflow_name: string
+  trigger_type: string
+  conditions_met: boolean
+  would_execute: boolean
+  warnings: string[]
+  action_previews: WorkflowSimulationActionPreview[]
+}
+
+export interface WorkflowSimulationResponse {
+  workflow_name: string
+  trigger_type: string
+  test_context: Record<string, any>
+  conditions_met: boolean
+  would_execute: boolean
+  warnings: string[]
+  action_previews: WorkflowSimulationActionPreview[]
+  simulation_history: WorkflowSimulationRecord[]
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,18 @@
 /** @type {import('tailwindcss').Config} */
+const withOpacity = (cssVariable: string) => ({ opacityValue }: { opacityValue?: string }) => {
+  if (opacityValue === undefined) {
+    return `var(${cssVariable})`
+  }
+
+  const opacity = Number.parseFloat(opacityValue)
+
+  if (Number.isNaN(opacity)) {
+    return `var(${cssVariable})`
+  }
+
+  return `color-mix(in srgb, var(${cssVariable}) ${opacity * 100}%, transparent)`
+}
+
 export default {
   content: [
     "./app/**/*.{js,vue,ts}",
@@ -19,90 +33,90 @@ export default {
       colors: {
         // Backgrounds using CSS variables
         background: {
-          base: 'var(--bg-base)',
-          surface: 'var(--bg-surface)',
-          raised: 'var(--bg-raised)',
+          base: withOpacity('--bg-base'),
+          surface: withOpacity('--bg-surface'),
+          raised: withOpacity('--bg-raised'),
           overlay: 'hsl(0, 0%, 18%, 0.8)',
           // Interactive states
-          hover: 'var(--bg-hover)',
-          'hover-subtle': 'var(--bg-hover-subtle)',
-          active: 'var(--bg-active)',
-          selected: 'var(--bg-selected)'
+          hover: withOpacity('--bg-hover'),
+          'hover-subtle': withOpacity('--bg-hover-subtle'),
+          active: withOpacity('--bg-active'),
+          selected: withOpacity('--bg-selected')
         },
         // Text colors using CSS variables
         text: {
-          primary: 'var(--text-primary)',
-          secondary: 'var(--text-secondary)',
-          muted: 'var(--text-muted)',
-          disabled: 'var(--text-disabled)'
+          primary: withOpacity('--text-primary'),
+          secondary: withOpacity('--text-secondary'),
+          muted: withOpacity('--text-muted'),
+          disabled: withOpacity('--text-disabled')
         },
         // Card and borders
         card: {
-          base: 'var(--bg-surface)',
-          border: 'var(--border)',
+          base: withOpacity('--bg-surface'),
+          border: withOpacity('--border'),
         },
         // Border colors
         border: {
-          DEFAULT: 'var(--border)',
-          highlight: 'var(--highlight)',
-          subtle: 'var(--border-subtle)'
+          DEFAULT: withOpacity('--border'),
+          highlight: withOpacity('--highlight'),
+          subtle: withOpacity('--border-subtle')
         },
         // Primary/Brand colors
         primary: {
-          DEFAULT: 'var(--primary)',
-          hover: 'var(--primary-hover)',
-          bg: 'var(--primary-bg)',
-          border: 'var(--primary-border)'
+          DEFAULT: withOpacity('--primary'),
+          hover: withOpacity('--primary-hover'),
+          bg: withOpacity('--primary-bg'),
+          border: withOpacity('--primary-border')
         },
         // Semantic status colors using CSS variables
         status: {
           // Success states
           success: {
-            DEFAULT: 'var(--status-success)',
-            bg: 'var(--status-success-bg)',
-            border: 'var(--status-success-border)',
+            DEFAULT: withOpacity('--status-success'),
+            bg: withOpacity('--status-success-bg'),
+            border: withOpacity('--status-success-border'),
             hover: 'hsl(158,100%,13%)'
           },
           // Error states
           error: {
-            DEFAULT: 'var(--status-error)',
-            bg: 'var(--status-error-bg)',
-            border: 'var(--status-error-border)',
+            DEFAULT: withOpacity('--status-error'),
+            bg: withOpacity('--status-error-bg'),
+            border: withOpacity('--status-error-border'),
             hover: 'hsl(347, 77%, 18%)'
           },
           // Warning states
           warning: {
-            DEFAULT: 'var(--status-warning)',
-            bg: 'var(--status-warning-bg)',
-            border: 'var(--status-warning-border)',
+            DEFAULT: withOpacity('--status-warning'),
+            bg: withOpacity('--status-warning-bg'),
+            border: withOpacity('--status-warning-border'),
             hover: 'hsl(45, 85%, 18%)'
           },
           // Info states
           info: {
-            DEFAULT: 'var(--status-info)',
-            bg: 'var(--status-info-bg)',
-            border: 'var(--status-info-border)',
+            DEFAULT: withOpacity('--status-info'),
+            bg: withOpacity('--status-info-bg'),
+            border: withOpacity('--status-info-border'),
             hover: 'hsl(199, 89%, 18%)'
           },
           // Retry states
           retry: {
-            DEFAULT: 'var(--status-retry)',
-            bg: 'var(--status-retry-bg)',
-            border: 'var(--status-retry-border)',
+            DEFAULT: withOpacity('--status-retry'),
+            bg: withOpacity('--status-retry-bg'),
+            border: withOpacity('--status-retry-border'),
             hover: 'hsl(24, 95%, 18%)'
           },
           // Neutral states
           neutral: {
-            DEFAULT: 'var(--status-neutral)',
-            bg: 'var(--status-neutral-bg)',
-            border: 'var(--status-neutral-border)',
+            DEFAULT: withOpacity('--status-neutral'),
+            bg: withOpacity('--status-neutral-bg'),
+            border: withOpacity('--status-neutral-border'),
             hover: 'hsl(215, 20%, 18%)'
           },
           // Special states
           special: {
-            DEFAULT: 'var(--status-special)',
-            bg: 'var(--status-special-bg)',
-            border: 'var(--status-special-border)',
+            DEFAULT: withOpacity('--status-special'),
+            bg: withOpacity('--status-special-bg'),
+            border: withOpacity('--status-special-border'),
             hover: 'hsl(263, 70%, 18%)'
           }
         }


### PR DESCRIPTION
## Summary
- add dry-run workflow simulation evaluation with action previews, warnings, and recent history
- expose simulation from the workflow create/edit flows through a reusable dialog
- cover the backend service with focused unit tests

## Testing
- python3 -m unittest tests.unit.test_workflow_simulation -v
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow simulation (dry-run) endpoint and UI to run simulations with sample event context; persists recent simulation history.
  * Per-action previews showing "Would run" vs "Blocked", top-level warnings, rendered message previews, and retry diagnostics.
* **Frontend**
  * Simulation button/dialog, API call, store state, and UI for results, warnings, and recent runs.
* **Tests**
  * Unit tests covering simulation outcomes, warnings, retry behavior, and history persistence.
* **Chores**
  * Color helper for theme opacity and improved logging usage in workflow pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->