### PR TITLE
feat: add workflow historical replay

### DIFF
--- a/agent/api/workflow_routes.py
+++ b/agent/api/workflow_routes.py
@@ -8,11 +8,16 @@ from models import (
     WorkflowDefinition,
     WorkflowCreateRequest,
     WorkflowUpdateRequest,
-    WorkflowExecutionRecord
+    WorkflowExecutionRecord,
+    WorkflowReplayRequest,
+    WorkflowReplayResponse,
+    TaskEvent,
+    WorkerEvent,
 )
 from services.workflow_service import WorkflowService
 from services.action_executor import ActionExecutor
 from services.workflow_catalog import TRIGGER_METADATA
+from services.workflow_executor import WorkflowExecutor
 from config import Config
 from security.dependencies import get_auth_dependency
 
@@ -199,5 +204,46 @@ def create_router(app_state) -> APIRouter:
             "would_execute": conditions_met,
             "actions": [action.type for action in workflow.actions]
         }
+
+    @router.post("/{workflow_id}/replay", response_model=WorkflowReplayResponse)
+    async def replay_workflow(
+        workflow_id: str,
+        replay_request: WorkflowReplayRequest,
+        session: Session = Depends(get_db)
+    ):
+        """Replay historical events against a workflow, optionally executing matching actions."""
+        workflow_service = WorkflowService(session)
+        workflow = workflow_service.get_workflow(workflow_id)
+
+        if not workflow:
+            raise HTTPException(status_code=404, detail="Workflow not found")
+
+        try:
+            replay_result = workflow_service.replay_workflow(workflow, replay_request)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+        if replay_request.dry_run or not replay_result.matches:
+            return replay_result
+
+        executor = WorkflowExecutor(
+            session=session,
+            db_manager=app_state.db_manager,
+            monitor_instance=app_state.monitor_instance
+        )
+
+        executed_count = 0
+        for match in replay_result.matches:
+            context = match.context
+            if workflow.trigger.type.startswith("task."):
+                event = TaskEvent(**context)
+            else:
+                event = WorkerEvent(**context)
+            await executor.execute_workflow(workflow, context, event)
+            executed_count += 1
+
+        replay_result.executed_count = executed_count
+        replay_result.dry_run = False
+        return replay_result
 
     return router

--- a/agent/models.py
+++ b/agent/models.py
@@ -772,6 +772,37 @@ class WorkflowExecutionRecord(BaseModel):
         from_attributes = True
 
 
+class WorkflowReplayRequest(BaseModel):
+    """Request model for replaying historical events against a workflow."""
+    start_time: Optional[datetime] = None
+    end_time: Optional[datetime] = None
+    limit: int = Field(default=25, ge=1, le=200)
+    dry_run: bool = True
+
+
+class WorkflowReplayMatch(BaseModel):
+    """Single historical event that matched a workflow during replay."""
+    event_type: str
+    timestamp: datetime
+    task_id: Optional[str] = None
+    task_name: Optional[str] = None
+    hostname: Optional[str] = None
+    summary: str
+    context: Dict[str, Any]
+
+
+class WorkflowReplayResponse(BaseModel):
+    """Summary of a workflow historical replay run."""
+    workflow_id: str
+    workflow_name: str
+    dry_run: bool
+    scanned_count: int
+    matched_count: int
+    executed_count: int = 0
+    truncated: bool = False
+    matches: List[WorkflowReplayMatch] = Field(default_factory=list)
+
+
 class ActionConfigDefinition(BaseModel):
     """Reusable action configuration."""
     id: Optional[str] = None

--- a/agent/services/workflow_service.py
+++ b/agent/services/workflow_service.py
@@ -6,10 +6,10 @@ from datetime import date, datetime, timezone, timedelta
 from typing import Any, Dict, List, Optional, Set
 from enum import Enum
 
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, or_, func
 from sqlalchemy.orm import Session
 
-from database import WorkflowDB, WorkflowExecutionDB, ensure_utc_isoformat, utc_now
+from database import WorkflowDB, WorkflowExecutionDB, TaskEventDB, WorkerEventDB, ensure_utc_isoformat, utc_now
 from models import (
     WorkflowDefinition,
     WorkflowCreateRequest,
@@ -19,13 +19,34 @@ from models import (
     ConditionGroup,
     ActionConfig,
     CircuitBreakerConfig,
-    CircuitBreakerState
+    CircuitBreakerState,
+    WorkflowReplayRequest,
+    WorkflowReplayMatch,
+    WorkflowReplayResponse,
+    TaskEvent,
+    WorkerEvent,
 )
 from services.action_executor import ActionExecutor
 from services.action_config_service import ActionConfigService
 from services.workflow_catalog import TRIGGER_METADATA
 
 logger = logging.getLogger(__name__)
+
+TRIGGER_TO_EVENT_TYPE = {
+    trigger: event_type for event_type, trigger in {
+        "task-sent": "task.sent",
+        "task-received": "task.received",
+        "task-started": "task.started",
+        "task-succeeded": "task.succeeded",
+        "task-failed": "task.failed",
+        "task-retried": "task.retried",
+        "task-revoked": "task.revoked",
+        "task-orphaned": "task.orphaned",
+        "worker-online": "worker.online",
+        "worker-offline": "worker.offline",
+        "worker-heartbeat": "worker.heartbeat",
+    }.items()
+}
 
 
 class WorkflowService:
@@ -506,6 +527,54 @@ class WorkflowService:
         executions_db = query.all()
         return [self._db_to_execution(e) for e in executions_db]
 
+    def replay_workflow(
+        self,
+        workflow: WorkflowDefinition,
+        replay_request: WorkflowReplayRequest,
+    ) -> WorkflowReplayResponse:
+        """Evaluate a workflow against historical events and return matching candidates."""
+        from services.workflow_engine import WorkflowEngine
+
+        trigger_event_type = TRIGGER_TO_EVENT_TYPE.get(workflow.trigger.type)
+        if not trigger_event_type:
+            raise ValueError(f"Unsupported workflow trigger for replay: {workflow.trigger.type}")
+
+        end_time = self._ensure_aware_utc(replay_request.end_time) or datetime.now(timezone.utc)
+        start_time = self._ensure_aware_utc(replay_request.start_time) or (end_time - timedelta(hours=24))
+        if start_time > end_time:
+            raise ValueError("start_time must be before end_time")
+
+        if workflow.trigger.type.startswith("task."):
+            model = TaskEventDB
+            query = self.session.query(TaskEventDB).filter(TaskEventDB.event_type == trigger_event_type)
+        else:
+            model = WorkerEventDB
+            query = self.session.query(WorkerEventDB).filter(WorkerEventDB.event_type == trigger_event_type)
+
+        query = query.filter(model.timestamp >= start_time, model.timestamp <= end_time)
+        scanned_count = query.with_entities(func.count()).scalar() or 0
+        events_db = query.order_by(model.timestamp.desc()).limit(replay_request.limit).all()
+
+        engine = WorkflowEngine(db_manager=None)
+        matches: List[WorkflowReplayMatch] = []
+        for event_db in events_db:
+            event = self._db_to_replay_event(event_db)
+            context = event.model_dump()
+            if not engine._evaluate_conditions(workflow, context):
+                continue
+            matches.append(self._event_to_replay_match(event, context))
+
+        return WorkflowReplayResponse(
+            workflow_id=workflow.id or "",
+            workflow_name=workflow.name,
+            dry_run=replay_request.dry_run,
+            scanned_count=scanned_count,
+            matched_count=len(matches),
+            executed_count=0,
+            truncated=scanned_count > replay_request.limit,
+            matches=matches,
+        )
+
     # ==================== Helper Methods ====================
 
     def _db_to_workflow(self, workflow_db: WorkflowDB) -> WorkflowDefinition:
@@ -563,4 +632,61 @@ class WorkflowService:
             duration_ms=execution_db.duration_ms,
             workflow_snapshot=execution_db.workflow_snapshot,
             circuit_breaker_key=execution_db.circuit_breaker_key
+        )
+
+    def _db_to_replay_event(self, event_db: TaskEventDB | WorkerEventDB) -> TaskEvent | WorkerEvent:
+        if isinstance(event_db, TaskEventDB):
+            return TaskEvent(
+                task_id=event_db.task_id,
+                task_name=event_db.task_name,
+                event_type=event_db.event_type,
+                timestamp=self._ensure_aware_utc(event_db.timestamp) or datetime.now(timezone.utc),
+                args=event_db.args or [],
+                kwargs=event_db.kwargs or {},
+                retries=event_db.retries or 0,
+                eta=event_db.eta,
+                expires=event_db.expires,
+                hostname=event_db.hostname,
+                worker_name=event_db.worker_name,
+                queue=event_db.queue,
+                exchange=event_db.exchange or "",
+                routing_key=event_db.routing_key or "default",
+                root_id=event_db.root_id,
+                parent_id=event_db.parent_id,
+                result=event_db.result,
+                runtime=event_db.runtime,
+                exception=event_db.exception,
+                traceback=event_db.traceback,
+                is_orphan=bool(event_db.is_orphan),
+                orphaned_at=self._ensure_aware_utc(event_db.orphaned_at),
+            )
+
+        return WorkerEvent(
+            hostname=event_db.hostname,
+            event_type=event_db.event_type,
+            timestamp=self._ensure_aware_utc(event_db.timestamp) or datetime.now(timezone.utc),
+            active=event_db.active_tasks if isinstance(event_db.active_tasks, int) else None,
+            processed=event_db.processed,
+        )
+
+    def _event_to_replay_match(self, event: TaskEvent | WorkerEvent, context: Dict[str, Any]) -> WorkflowReplayMatch:
+        if isinstance(event, TaskEvent):
+            summary = f"{event.task_name} on {event.hostname or 'unknown worker'}"
+            return WorkflowReplayMatch(
+                event_type=event.event_type,
+                timestamp=event.timestamp,
+                task_id=event.task_id,
+                task_name=event.task_name,
+                hostname=event.hostname,
+                summary=summary,
+                context=self._json_safe(context),
+            )
+
+        summary = f"{event.event_type} on {event.hostname}"
+        return WorkflowReplayMatch(
+            event_type=event.event_type,
+            timestamp=event.timestamp,
+            hostname=event.hostname,
+            summary=summary,
+            context=self._json_safe(context),
         )

--- a/agent/tests/unit/test_workflow_replay.py
+++ b/agent/tests/unit/test_workflow_replay.py
@@ -1,0 +1,115 @@
+"""Tests for workflow historical replay preview."""
+
+import os
+import sys
+import uuid
+import unittest
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from tests.base import DatabaseTestCase
+from database import WorkflowDB
+from models import WorkflowReplayRequest
+from services.workflow_service import WorkflowService
+
+
+class TestWorkflowReplay(DatabaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.workflow_service = WorkflowService(self.session)
+
+    def _create_workflow(self, trigger_type="task.failed", conditions=None):
+        workflow = WorkflowDB(
+            id=str(uuid.uuid4()),
+            name="Replay test workflow",
+            enabled=True,
+            trigger_type=trigger_type,
+            trigger_config={},
+            conditions=conditions,
+            actions=[{"type": "task.retry", "params": {}}],
+        )
+        self.session.add(workflow)
+        self.session.commit()
+        return self.workflow_service.get_workflow(workflow.id)
+
+    def test_replay_matches_condition_filtered_task_events(self):
+        now = datetime.now(timezone.utc)
+        self.create_task_event_db(
+            task_id="task-1",
+            task_name="tasks.alpha",
+            event_type="task-failed",
+            timestamp=now - timedelta(minutes=10),
+            hostname="worker-a",
+            exception="Boom",
+        )
+        self.create_task_event_db(
+            task_id="task-2",
+            task_name="tasks.beta",
+            event_type="task-failed",
+            timestamp=now - timedelta(minutes=5),
+            hostname="worker-b",
+            exception="Ignore",
+        )
+
+        workflow = self._create_workflow(conditions={
+            "operator": "AND",
+            "conditions": [
+                {"field": "task_name", "operator": "equals", "value": "tasks.alpha"}
+            ]
+        })
+
+        result = self.workflow_service.replay_workflow(workflow, WorkflowReplayRequest(
+            start_time=now - timedelta(hours=1),
+            end_time=now,
+            limit=10,
+            dry_run=True,
+        ))
+
+        self.assertEqual(result.scanned_count, 2)
+        self.assertEqual(result.matched_count, 1)
+        self.assertEqual(result.matches[0].task_id, "task-1")
+        self.assertEqual(result.matches[0].task_name, "tasks.alpha")
+
+    def test_replay_matches_worker_events(self):
+        now = datetime.now(timezone.utc)
+        self.create_worker_event_db(
+            hostname="worker-critical",
+            event_type="worker-offline",
+            timestamp=now - timedelta(minutes=3),
+            status="offline",
+        )
+        self.create_worker_event_db(
+            hostname="worker-ok",
+            event_type="worker-online",
+            timestamp=now - timedelta(minutes=1),
+            status="online",
+        )
+
+        workflow = self._create_workflow(trigger_type="worker.offline")
+        result = self.workflow_service.replay_workflow(workflow, WorkflowReplayRequest(
+            start_time=now - timedelta(hours=1),
+            end_time=now,
+            limit=10,
+            dry_run=True,
+        ))
+
+        self.assertEqual(result.scanned_count, 1)
+        self.assertEqual(result.matched_count, 1)
+        self.assertEqual(result.matches[0].hostname, "worker-critical")
+
+    def test_replay_rejects_invalid_time_range(self):
+        workflow = self._create_workflow()
+        now = datetime.now(timezone.utc)
+
+        with self.assertRaises(ValueError):
+            self.workflow_service.replay_workflow(workflow, WorkflowReplayRequest(
+                start_time=now,
+                end_time=now - timedelta(hours=1),
+                limit=10,
+                dry_run=True,
+            ))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/frontend/app/pages/workflows/[id]/index.vue
+++ b/frontend/app/pages/workflows/[id]/index.vue
@@ -33,6 +33,13 @@
           <Button
             variant="outline"
             size="sm"
+            @click="showReplayDialog = true"
+          >
+            Replay History
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
             @click="toggleEnabled"
             :disabled="toggling"
           >
@@ -236,6 +243,68 @@
       </Button>
     </NuxtLink>
   </div>
+
+  <Dialog :open="showReplayDialog" @update:open="(open) => { showReplayDialog = open; replayError = null }">
+    <DialogContent class="max-w-2xl">
+      <DialogHeader>
+        <DialogTitle>Replay historical events</DialogTitle>
+        <DialogDescription>
+          Check which past events would have matched this workflow, then optionally replay those actions.
+        </DialogDescription>
+      </DialogHeader>
+      <div class="space-y-4">
+        <div class="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label class="text-xs font-medium text-text-secondary mb-1.5 block">Look back (hours)</label>
+            <Input v-model="replayHours" type="number" min="1" max="168" />
+          </div>
+          <div>
+            <label class="text-xs font-medium text-text-secondary mb-1.5 block">Max events to scan</label>
+            <Input v-model="replayLimit" type="number" min="1" max="200" />
+          </div>
+        </div>
+        <div v-if="replayError" class="text-sm text-status-error bg-status-error-bg border border-status-error-border rounded px-3 py-2">
+          {{ replayError }}
+        </div>
+        <div v-if="workflowStore.replayResult" class="rounded border border-border-subtle bg-background-base p-3 space-y-3">
+          <div class="flex flex-wrap items-center gap-2 text-xs text-text-muted">
+            <Badge variant="outline">Scanned {{ workflowStore.replayResult.scanned_count }}</Badge>
+            <Badge :variant="workflowStore.replayResult.matched_count ? 'default' : 'outline'">
+              Matched {{ workflowStore.replayResult.matched_count }}
+            </Badge>
+            <Badge v-if="!workflowStore.replayResult.dry_run" variant="outline">
+              Replayed {{ workflowStore.replayResult.executed_count }}
+            </Badge>
+          </div>
+          <div class="max-h-72 overflow-y-auto space-y-2">
+            <div
+              v-for="(match, idx) in workflowStore.replayResult.matches"
+              :key="idx"
+              class="rounded border border-border-subtle px-3 py-2"
+            >
+              <div class="flex items-center justify-between gap-3 text-xs">
+                <span class="font-medium text-text-primary">{{ match.summary }}</span>
+                <span class="text-text-muted">{{ formatDateTime(match.timestamp) }}</span>
+              </div>
+              <div class="mt-1 text-[11px] text-text-muted font-mono">{{ match.event_type }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <DialogFooter>
+        <Button variant="ghost" @click="showReplayDialog = false">Close</Button>
+        <Button variant="outline" @click="runReplay(true)" :disabled="replaying">
+          {{ replaying ? 'Running...' : 'Preview Matches' }}
+        </Button>
+        <Button
+          @click="runReplay(false)"
+          :disabled="replaying || !workflowStore.replayResult?.matched_count"
+        >
+          Replay Matching Events
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
 </template>
 
 <script setup lang="ts">
@@ -244,12 +313,19 @@ import { ChevronLeft, Power, Pencil, AlertCircle, ShieldCheck } from 'lucide-vue
 import { Button } from '~/components/ui/button'
 import { Badge } from '~/components/ui/badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
+import { Input } from '~/components/ui/input'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '~/components/ui/dialog'
 import StatusDot from '~/components/StatusDot.vue'
 import WorkflowExecutionHistory from '~/components/workflows/WorkflowExecutionHistory.vue'
 
 const route = useRoute()
 const workflowStore = useWorkflowsStore()
 const toggling = ref(false)
+const showReplayDialog = ref(false)
+const replaying = ref(false)
+const replayError = ref<string | null>(null)
+const replayHours = ref('24')
+const replayLimit = ref('25')
 
 const successRate = computed(() => {
   const workflow = workflowStore.currentWorkflow
@@ -265,6 +341,28 @@ async function toggleEnabled() {
     await workflowStore.toggleWorkflow(workflowStore.currentWorkflow.id)
   } finally {
     toggling.value = false
+  }
+}
+
+async function runReplay(dryRun: boolean) {
+  if (!workflowStore.currentWorkflow?.id) return
+
+  replaying.value = true
+  replayError.value = null
+  try {
+    const hours = Math.max(1, Math.min(168, Number(replayHours.value || '24')))
+    const end = new Date()
+    const start = new Date(end.getTime() - hours * 60 * 60 * 1000)
+    await workflowStore.replayWorkflow(workflowStore.currentWorkflow.id, {
+      dry_run: dryRun,
+      limit: Math.max(1, Math.min(200, Number(replayLimit.value || '25'))),
+      start_time: start.toISOString(),
+      end_time: end.toISOString(),
+    })
+  } catch (err) {
+    replayError.value = err instanceof Error ? err.message : 'Replay failed'
+  } finally {
+    replaying.value = false
   }
 }
 

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -700,6 +700,15 @@ class ApiService {
     return response.data
   }
 
+  async replayWorkflow(workflowId: string, data: any): Promise<any> {
+    const response = await this.api.request({
+      path: `/api/workflows/${workflowId}/replay`,
+      method: 'POST',
+      body: data
+    })
+    return response.data
+  }
+
   async getActionConfigs(params?: {
     action_type?: string
     limit?: number

--- a/frontend/app/stores/workflows.ts
+++ b/frontend/app/stores/workflows.ts
@@ -6,6 +6,8 @@ import type {
   WorkflowCreateRequest,
   WorkflowUpdateRequest,
   WorkflowExecutionRecord,
+  WorkflowReplayRequest,
+  WorkflowReplayResponse,
   ActionConfigDefinition,
   ActionConfigCreateRequest,
   ActionConfigUpdateRequest
@@ -17,6 +19,7 @@ export const useWorkflowsStore = defineStore('workflows', () => {
   const workflows = ref<WorkflowDefinition[]>([])
   const currentWorkflow = ref<WorkflowDefinition | null>(null)
   const executions = ref<WorkflowExecutionRecord[]>([])
+  const replayResult = ref<WorkflowReplayResponse | null>(null)
   const actionConfigs = ref<ActionConfigDefinition[]>([])
   const triggerCatalog = ref<{ type: string; label: string; description: string; category: string }[]>([])
   const actionCatalog = ref<{ type: string; label: string; description: string; category: string }[]>([])
@@ -195,6 +198,20 @@ export const useWorkflowsStore = defineStore('workflows', () => {
     }
   }
 
+  async function replayWorkflow(workflowId: string, payload: WorkflowReplayRequest) {
+    try {
+      isLoading.value = true
+      error.value = null
+      replayResult.value = await apiService.replayWorkflow(workflowId, payload)
+      return replayResult.value
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to replay workflow'
+      throw err
+    } finally {
+      isLoading.value = false
+    }
+  }
+
   async function fetchActionConfigs(params?: { action_type?: string }) {
     try {
       isLoading.value = true
@@ -269,6 +286,7 @@ export const useWorkflowsStore = defineStore('workflows', () => {
     workflows,
     currentWorkflow,
     executions,
+    replayResult,
     actionConfigs,
     isLoading,
     error,
@@ -288,6 +306,7 @@ export const useWorkflowsStore = defineStore('workflows', () => {
     fetchWorkflowExecutions,
     fetchRecentExecutions,
     testWorkflow,
+    replayWorkflow,
     fetchActionConfigs,
     createActionConfig,
     updateActionConfig,

--- a/frontend/app/types/workflow.ts
+++ b/frontend/app/types/workflow.ts
@@ -138,6 +138,34 @@ export interface WorkflowExecutionRecord {
   workflow_snapshot?: Record<string, any>
 }
 
+export interface WorkflowReplayRequest {
+  start_time?: string
+  end_time?: string
+  limit: number
+  dry_run: boolean
+}
+
+export interface WorkflowReplayMatch {
+  event_type: string
+  timestamp: string
+  task_id?: string
+  task_name?: string
+  hostname?: string
+  summary: string
+  context: Record<string, any>
+}
+
+export interface WorkflowReplayResponse {
+  workflow_id: string
+  workflow_name: string
+  dry_run: boolean
+  scanned_count: number
+  matched_count: number
+  executed_count: number
+  truncated: boolean
+  matches: WorkflowReplayMatch[]
+}
+
 // ==================== Action Config Types ====================
 
 export interface ActionConfigDefinition {

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,18 @@
 /** @type {import('tailwindcss').Config} */
+const withOpacity = (cssVariable: string) => ({ opacityValue }: { opacityValue?: string }) => {
+  if (opacityValue === undefined) {
+    return `var(${cssVariable})`
+  }
+
+  const opacity = Number.parseFloat(opacityValue)
+
+  if (Number.isNaN(opacity)) {
+    return `var(${cssVariable})`
+  }
+
+  return `color-mix(in srgb, var(${cssVariable}) ${opacity * 100}%, transparent)`
+}
+
 export default {
   content: [
     "./app/**/*.{js,vue,ts}",
@@ -19,90 +33,90 @@ export default {
       colors: {
         // Backgrounds using CSS variables
         background: {
-          base: 'var(--bg-base)',
-          surface: 'var(--bg-surface)',
-          raised: 'var(--bg-raised)',
+          base: withOpacity('--bg-base'),
+          surface: withOpacity('--bg-surface'),
+          raised: withOpacity('--bg-raised'),
           overlay: 'hsl(0, 0%, 18%, 0.8)',
           // Interactive states
-          hover: 'var(--bg-hover)',
-          'hover-subtle': 'var(--bg-hover-subtle)',
-          active: 'var(--bg-active)',
-          selected: 'var(--bg-selected)'
+          hover: withOpacity('--bg-hover'),
+          'hover-subtle': withOpacity('--bg-hover-subtle'),
+          active: withOpacity('--bg-active'),
+          selected: withOpacity('--bg-selected')
         },
         // Text colors using CSS variables
         text: {
-          primary: 'var(--text-primary)',
-          secondary: 'var(--text-secondary)',
-          muted: 'var(--text-muted)',
-          disabled: 'var(--text-disabled)'
+          primary: withOpacity('--text-primary'),
+          secondary: withOpacity('--text-secondary'),
+          muted: withOpacity('--text-muted'),
+          disabled: withOpacity('--text-disabled')
         },
         // Card and borders
         card: {
-          base: 'var(--bg-surface)',
-          border: 'var(--border)',
+          base: withOpacity('--bg-surface'),
+          border: withOpacity('--border'),
         },
         // Border colors
         border: {
-          DEFAULT: 'var(--border)',
-          highlight: 'var(--highlight)',
-          subtle: 'var(--border-subtle)'
+          DEFAULT: withOpacity('--border'),
+          highlight: withOpacity('--highlight'),
+          subtle: withOpacity('--border-subtle')
         },
         // Primary/Brand colors
         primary: {
-          DEFAULT: 'var(--primary)',
-          hover: 'var(--primary-hover)',
-          bg: 'var(--primary-bg)',
-          border: 'var(--primary-border)'
+          DEFAULT: withOpacity('--primary'),
+          hover: withOpacity('--primary-hover'),
+          bg: withOpacity('--primary-bg'),
+          border: withOpacity('--primary-border')
         },
         // Semantic status colors using CSS variables
         status: {
           // Success states
           success: {
-            DEFAULT: 'var(--status-success)',
-            bg: 'var(--status-success-bg)',
-            border: 'var(--status-success-border)',
+            DEFAULT: withOpacity('--status-success'),
+            bg: withOpacity('--status-success-bg'),
+            border: withOpacity('--status-success-border'),
             hover: 'hsl(158,100%,13%)'
           },
           // Error states
           error: {
-            DEFAULT: 'var(--status-error)',
-            bg: 'var(--status-error-bg)',
-            border: 'var(--status-error-border)',
+            DEFAULT: withOpacity('--status-error'),
+            bg: withOpacity('--status-error-bg'),
+            border: withOpacity('--status-error-border'),
             hover: 'hsl(347, 77%, 18%)'
           },
           // Warning states
           warning: {
-            DEFAULT: 'var(--status-warning)',
-            bg: 'var(--status-warning-bg)',
-            border: 'var(--status-warning-border)',
+            DEFAULT: withOpacity('--status-warning'),
+            bg: withOpacity('--status-warning-bg'),
+            border: withOpacity('--status-warning-border'),
             hover: 'hsl(45, 85%, 18%)'
           },
           // Info states
           info: {
-            DEFAULT: 'var(--status-info)',
-            bg: 'var(--status-info-bg)',
-            border: 'var(--status-info-border)',
+            DEFAULT: withOpacity('--status-info'),
+            bg: withOpacity('--status-info-bg'),
+            border: withOpacity('--status-info-border'),
             hover: 'hsl(199, 89%, 18%)'
           },
           // Retry states
           retry: {
-            DEFAULT: 'var(--status-retry)',
-            bg: 'var(--status-retry-bg)',
-            border: 'var(--status-retry-border)',
+            DEFAULT: withOpacity('--status-retry'),
+            bg: withOpacity('--status-retry-bg'),
+            border: withOpacity('--status-retry-border'),
             hover: 'hsl(24, 95%, 18%)'
           },
           // Neutral states
           neutral: {
-            DEFAULT: 'var(--status-neutral)',
-            bg: 'var(--status-neutral-bg)',
-            border: 'var(--status-neutral-border)',
+            DEFAULT: withOpacity('--status-neutral'),
+            bg: withOpacity('--status-neutral-bg'),
+            border: withOpacity('--status-neutral-border'),
             hover: 'hsl(215, 20%, 18%)'
           },
           // Special states
           special: {
-            DEFAULT: 'var(--status-special)',
-            bg: 'var(--status-special-bg)',
-            border: 'var(--status-special-border)',
+            DEFAULT: withOpacity('--status-special'),
+            bg: withOpacity('--status-special-bg'),
+            border: withOpacity('--status-special-border'),
             hover: 'hsl(263, 70%, 18%)'
           }
         }


### PR DESCRIPTION
## Summary
- add workflow replay API support for previewing and replaying historical task/worker events
- add workflow detail UI for lookback/limit-based replay previews and execution
- cover replay matching and invalid range handling with backend tests

## Testing
- python3 -m unittest tests.unit.test_workflow_replay -v
- npm run build
- local replay preview/execution against built frontend + seeded sqlite DB
