### PR TITLE
Add automatic retention cleanup scheduling

### DIFF
--- a/agent/api/config_routes.py
+++ b/agent/api/config_routes.py
@@ -98,7 +98,8 @@ def create_router(app_state) -> APIRouter:
         """Get automatic retention cleanup schedule status."""
         scheduler = app_state.retention_scheduler
         if scheduler is None:
-            return RetentionScheduleStatus(enabled=False, interval_hours=24)
+            interval_hours = getattr(app_state.config, 'retention_interval_hours', 24)
+            return RetentionScheduleStatus(enabled=False, interval_hours=interval_hours)
         return scheduler.get_status()
 
     @router.post("/retention/cleanup", response_model=RetentionCleanupResponse)

--- a/agent/api/config_routes.py
+++ b/agent/api/config_routes.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from config import Config
-from models import AppSetting, AppSettingUpdate, AppConfigSnapshot, DataRetentionConfig, RetentionCleanupResponse
+from models import AppSetting, AppSettingUpdate, AppConfigSnapshot, DataRetentionConfig, RetentionCleanupResponse, RetentionScheduleStatus
 from services import AppConfigService, RetentionService
 from security.dependencies import get_auth_dependency
 
@@ -92,6 +92,14 @@ def create_router(app_state) -> APIRouter:
     ):
         """Get normalized data retention policy values."""
         return retention_service.get_policy()
+
+    @router.get("/retention/schedule", response_model=RetentionScheduleStatus)
+    async def get_retention_schedule_status():
+        """Get automatic retention cleanup schedule status."""
+        scheduler = app_state.retention_scheduler
+        if scheduler is None:
+            return RetentionScheduleStatus(enabled=False, interval_hours=24)
+        return scheduler.get_status()
 
     @router.post("/retention/cleanup", response_model=RetentionCleanupResponse)
     async def run_retention_cleanup(

--- a/agent/app.py
+++ b/agent/app.py
@@ -43,6 +43,7 @@ class ApplicationState:
         self.config: Optional[Config] = None
         self.auth_manager = None
         self.auth_dependencies = None
+        self.retention_scheduler = None
 
 
 app_state = ApplicationState()
@@ -57,6 +58,8 @@ async def lifespan(app: FastAPI):
     # Shutdown
     if app_state.health_monitor:
         app_state.health_monitor.stop()
+    if app_state.retention_scheduler:
+        app_state.retention_scheduler.stop()
     if app_state.connection_manager:
         await app_state.connection_manager.stop_background_broadcaster()
     if app_state.monitor_instance:
@@ -287,6 +290,24 @@ async def initialize_application():
     app_state.workflow_engine.monitor_instance = app_state.monitor_instance
 
     start_health_monitor()
+    start_retention_scheduler(config)
+
+
+def start_retention_scheduler(config: Config):
+    """Start the automatic retention cleanup scheduler."""
+    if app_state.retention_scheduler and app_state.retention_scheduler.is_alive():
+        logger.warning("Retention cleanup scheduler already running")
+        return
+
+    from services.retention_scheduler import RetentionScheduler
+
+    app_state.retention_scheduler = RetentionScheduler(
+        app_state.db_manager,
+        enabled=config.retention_cleanup_enabled,
+        interval_hours=config.retention_cleanup_interval_hours,
+        interval_seconds=config.retention_cleanup_interval_seconds,
+    )
+    app_state.retention_scheduler.start()
 
 
 def start_monitor(config: Config):

--- a/agent/config.py
+++ b/agent/config.py
@@ -75,6 +75,15 @@ class Config:
     max_clients: int = int(os.getenv('MAX_WS_CLIENTS', 100))
     event_buffer_size: int = int(os.getenv('EVENT_BUFFER_SIZE', 1000))
 
+    # Retention cleanup scheduler
+    retention_cleanup_enabled: bool = _as_bool(os.getenv('RETENTION_CLEANUP_ENABLED', 'true'), default=True)
+    retention_cleanup_interval_hours: int = int(os.getenv('RETENTION_CLEANUP_INTERVAL_HOURS', 24))
+    retention_cleanup_interval_seconds: Optional[int] = (
+        int(os.getenv('RETENTION_CLEANUP_INTERVAL_SECONDS'))
+        if os.getenv('RETENTION_CLEANUP_INTERVAL_SECONDS')
+        else None
+    )
+
     # CORS / Hosts
     allowed_origins: List[str] = field(default_factory=lambda: _split_csv(os.getenv('ALLOWED_ORIGINS')))
     allowed_hosts: List[str] = field(default_factory=lambda: _split_csv(os.getenv('ALLOWED_HOSTS')))

--- a/agent/models.py
+++ b/agent/models.py
@@ -484,6 +484,18 @@ class RetentionCleanupResponse(BaseModel):
     results: List[RetentionCleanupResult] = Field(default_factory=list)
 
 
+class RetentionScheduleStatus(BaseModel):
+    """Status of automatic retention cleanup scheduling."""
+    enabled: bool = True
+    interval_hours: int = Field(default=24, ge=1, le=168)
+    next_run_at: Optional[datetime] = None
+    last_run_at: Optional[datetime] = None
+    last_completed_at: Optional[datetime] = None
+    last_duration_seconds: Optional[float] = Field(default=None, ge=0)
+    last_deleted_rows: Optional[int] = Field(default=None, ge=0)
+    last_error: Optional[str] = None
+
+
 class AppConfigSnapshot(BaseModel):
     """Grouped configuration snapshot returned to clients."""
     task_issue_summary: TaskIssueConfig

--- a/agent/services/__init__.py
+++ b/agent/services/__init__.py
@@ -11,6 +11,7 @@ from .session_service import SessionService
 from .auth_service import AuthService
 from .app_config_service import AppConfigService
 from .retention_service import RetentionService
+from .retention_scheduler import RetentionScheduler
 
 __all__ = [
     'TaskService',
@@ -23,5 +24,6 @@ __all__ = [
     'SessionService',
     'AuthService',
     'AppConfigService',
-    'RetentionService'
+    'RetentionService',
+    'RetentionScheduler'
 ]

--- a/agent/services/retention_scheduler.py
+++ b/agent/services/retention_scheduler.py
@@ -67,6 +67,10 @@ class RetentionScheduler:
 
     def stop(self) -> None:
         self._stop_event.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5)
+            if self._thread.is_alive():
+                logger.warning("Retention cleanup scheduler thread did not stop within timeout")
 
     def is_alive(self) -> bool:
         return bool(self._thread and self._thread.is_alive())

--- a/agent/services/retention_scheduler.py
+++ b/agent/services/retention_scheduler.py
@@ -60,6 +60,7 @@ class RetentionScheduler:
             logger.warning("Retention cleanup scheduler already running")
             return
 
+        self._stop_event.clear()
         self._thread = threading.Thread(target=self._run_loop, name="retention-cleanup-scheduler", daemon=True)
         self._thread.start()
         logger.info("Automatic retention cleanup scheduler started (interval=%ss)", int(self.interval.total_seconds()))

--- a/agent/services/retention_scheduler.py
+++ b/agent/services/retention_scheduler.py
@@ -1,0 +1,107 @@
+"""Background scheduler for automatic retention cleanup."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from database import DatabaseManager
+from models import RetentionCleanupResponse
+from .retention_service import RetentionService
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RetentionScheduleStatus:
+    enabled: bool
+    interval_hours: int
+    next_run_at: Optional[datetime] = None
+    last_run_at: Optional[datetime] = None
+    last_completed_at: Optional[datetime] = None
+    last_duration_seconds: Optional[float] = None
+    last_deleted_rows: Optional[int] = None
+    last_error: Optional[str] = None
+
+
+class RetentionScheduler:
+    """Run retention cleanup on a fixed interval in the background."""
+
+    def __init__(
+        self,
+        db_manager: DatabaseManager,
+        *,
+        enabled: bool = True,
+        interval_hours: int = 24,
+        interval_seconds: Optional[int] = None,
+    ):
+        self.db_manager = db_manager
+        self.enabled = enabled
+        self.interval_hours = max(1, interval_hours)
+        self.interval = timedelta(seconds=max(1, interval_seconds)) if interval_seconds else timedelta(hours=self.interval_hours)
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+        now = datetime.now(timezone.utc)
+        self._status = RetentionScheduleStatus(
+            enabled=enabled,
+            interval_hours=self.interval_hours,
+            next_run_at=now + self.interval if enabled else None,
+        )
+
+    def start(self) -> None:
+        if not self.enabled:
+            logger.info("Automatic retention cleanup scheduler disabled")
+            return
+        if self._thread and self._thread.is_alive():
+            logger.warning("Retention cleanup scheduler already running")
+            return
+
+        self._thread = threading.Thread(target=self._run_loop, name="retention-cleanup-scheduler", daemon=True)
+        self._thread.start()
+        logger.info("Automatic retention cleanup scheduler started (interval=%ss)", int(self.interval.total_seconds()))
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def is_alive(self) -> bool:
+        return bool(self._thread and self._thread.is_alive())
+
+    def get_status(self) -> RetentionScheduleStatus:
+        with self._lock:
+            return RetentionScheduleStatus(**self._status.__dict__)
+
+    def _run_loop(self) -> None:
+        while not self._stop_event.is_set():
+            with self._lock:
+                next_run_at = self._status.next_run_at or (datetime.now(timezone.utc) + self.interval)
+                self._status.next_run_at = next_run_at
+
+            wait_seconds = max(0.0, (next_run_at - datetime.now(timezone.utc)).total_seconds())
+            if self._stop_event.wait(wait_seconds):
+                return
+
+            started_at = datetime.now(timezone.utc)
+            deleted_rows: Optional[int] = None
+            error: Optional[str] = None
+
+            try:
+                with self.db_manager.get_session() as session:
+                    result: RetentionCleanupResponse = RetentionService(session).cleanup(dry_run=False)
+                    deleted_rows = result.total_deleted
+                logger.info("Automatic retention cleanup completed, deleted %s rows", deleted_rows)
+            except Exception as exc:  # pylint: disable=broad-except
+                error = str(exc)
+                logger.error("Automatic retention cleanup failed: %s", exc, exc_info=True)
+
+            finished_at = datetime.now(timezone.utc)
+            with self._lock:
+                self._status.last_run_at = started_at
+                self._status.last_completed_at = finished_at
+                self._status.last_duration_seconds = round((finished_at - started_at).total_seconds(), 3)
+                self._status.last_deleted_rows = deleted_rows
+                self._status.last_error = error
+                self._status.next_run_at = finished_at + self.interval

--- a/agent/tests/unit/test_retention_scheduler.py
+++ b/agent/tests/unit/test_retention_scheduler.py
@@ -1,0 +1,57 @@
+import unittest
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from services.retention_scheduler import RetentionScheduler
+
+
+class _FakeSessionContext:
+    def __enter__(self):
+        return object()
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeDBManager:
+    def get_session(self):
+        return _FakeSessionContext()
+
+
+class TestRetentionScheduler(unittest.TestCase):
+    def test_disabled_scheduler_reports_no_next_run(self):
+        scheduler = RetentionScheduler(_FakeDBManager(), enabled=False, interval_hours=24)
+
+        status = scheduler.get_status()
+
+        self.assertFalse(status.enabled)
+        self.assertIsNone(status.next_run_at)
+        self.assertFalse(scheduler.is_alive())
+
+    def test_scheduler_runs_cleanup_and_updates_status(self):
+        scheduler = RetentionScheduler(_FakeDBManager(), enabled=True, interval_hours=1, interval_seconds=1)
+
+        with patch('services.retention_scheduler.RetentionService') as retention_service_cls:
+            retention_service_cls.return_value.cleanup.return_value = SimpleNamespace(total_deleted=7)
+
+            scheduler.start()
+            thread = scheduler._thread
+            self.assertIsNotNone(thread)
+            thread.join(timeout=2.5)
+            scheduler.stop()
+            thread.join(timeout=1)
+
+        status = scheduler.get_status()
+
+        self.assertIsNotNone(status.last_run_at)
+        self.assertIsNotNone(status.last_completed_at)
+        self.assertEqual(status.last_deleted_rows, 7)
+        self.assertIsNone(status.last_error)
+        self.assertIsInstance(status.next_run_at, datetime)
+        self.assertGreater(status.next_run_at, status.last_completed_at)
+        self.assertFalse(scheduler.is_alive())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/frontend/app/components/ConfirmationDialog.vue
+++ b/frontend/app/components/ConfirmationDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { getCurrentInstance, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import { AlertTriangle, Loader2 } from 'lucide-vue-next'
 import { Button } from '@/components/ui/button'
 
@@ -28,6 +28,10 @@ const emit = defineEmits<{
 
 const isOpen = ref(false)
 const dialogRef = ref<HTMLElement | null>(null)
+const instance = getCurrentInstance()
+const uniqueId = instance?.uid ?? Math.random().toString(36).slice(2)
+const titleId = `confirmation-dialog-title-${uniqueId}`
+const descriptionId = `confirmation-dialog-description-${uniqueId}`
 let previousFocusedElement: HTMLElement | null = null
 
 function getFocusableElements() {
@@ -122,15 +126,15 @@ defineExpose({
       class="grid w-full max-w-md gap-4 rounded-lg border border-border-subtle bg-background-surface p-6 shadow-lg"
       role="dialog"
       aria-modal="true"
-      :aria-labelledby="'confirmation-dialog-title'"
-      :aria-describedby="'confirmation-dialog-description'"
+      :aria-labelledby="titleId"
+      :aria-describedby="description ? descriptionId : undefined"
     >
       <div class="space-y-2">
-        <h2 id="confirmation-dialog-title" class="flex items-center gap-2 text-lg font-semibold text-text-primary">
+        <h2 :id="titleId" class="flex items-center gap-2 text-lg font-semibold text-text-primary">
           <AlertTriangle v-if="variant === 'destructive'" class="h-5 w-5 text-red-500" />
           {{ title }}
         </h2>
-        <p id="confirmation-dialog-description" v-if="description" class="text-sm text-text-secondary">
+        <p :id="descriptionId" v-if="description" class="text-sm text-text-secondary">
           {{ description }}
         </p>
       </div>

--- a/frontend/app/components/ConfirmationDialog.vue
+++ b/frontend/app/components/ConfirmationDialog.vue
@@ -1,15 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { AlertTriangle, Loader2 } from 'lucide-vue-next'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 
 interface Props {
@@ -49,14 +40,6 @@ const handleCancel = () => {
   isOpen.value = false
 }
 
-const handleOpenChange = (open: boolean) => {
-  // Don't allow closing when loading
-  if (!props.isLoading) {
-    isOpen.value = open
-  }
-}
-
-// Expose method to open dialog programmatically
 defineExpose({
   open: () => { isOpen.value = true },
   close: () => { isOpen.value = false }
@@ -64,42 +47,44 @@ defineExpose({
 </script>
 
 <template>
-  <Dialog v-model:open="isOpen" @update:open="handleOpenChange">
-    <DialogTrigger as-child>
-      <slot name="trigger">
-        <Button>Open Dialog</Button>
-      </slot>
-    </DialogTrigger>
-    
-    <DialogContent class="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle class="flex items-center gap-2">
-          <AlertTriangle 
-            v-if="variant === 'destructive'" 
-            class="h-5 w-5 text-red-500" 
-          />
+  <div class="contents" @click="isOpen = true">
+    <slot name="trigger">
+      <Button>Open Dialog</Button>
+    </slot>
+  </div>
+
+  <div v-if="isOpen" class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
+    <div
+      class="grid w-full max-w-md gap-4 rounded-lg border border-border-subtle bg-background-surface p-6 shadow-lg"
+      role="dialog"
+      aria-modal="true"
+      :aria-labelledby="'confirmation-dialog-title'"
+      :aria-describedby="'confirmation-dialog-description'"
+    >
+      <div class="space-y-2">
+        <h2 id="confirmation-dialog-title" class="flex items-center gap-2 text-lg font-semibold text-text-primary">
+          <AlertTriangle v-if="variant === 'destructive'" class="h-5 w-5 text-red-500" />
           {{ title }}
-        </DialogTitle>
-        <DialogDescription v-if="description" class="text-left">
+        </h2>
+        <p id="confirmation-dialog-description" v-if="description" class="text-sm text-text-secondary">
           {{ description }}
-        </DialogDescription>
-      </DialogHeader>
-      
-      <!-- Custom content slot -->
+        </p>
+      </div>
+
       <div v-if="$slots.content" class="py-2">
         <slot name="content" />
       </div>
-      
-      <DialogFooter class="flex-col-reverse sm:flex-row sm:justify-end sm:gap-2">
-        <Button 
-          variant="outline" 
+
+      <div class="flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-2">
+        <Button
+          variant="outline"
           @click="handleCancel"
           :disabled="isLoading"
           class="mt-2 sm:mt-0"
         >
           {{ cancelText }}
         </Button>
-        <Button 
+        <Button
           :variant="variant === 'destructive' ? 'destructive' : 'default'"
           @click="handleConfirm"
           :disabled="isLoading"
@@ -108,7 +93,7 @@ defineExpose({
           <Loader2 v-if="isLoading" class="h-4 w-4 animate-spin" />
           {{ confirmText }}
         </Button>
-      </DialogFooter>
-    </DialogContent>
-  </Dialog>
+      </div>
+    </div>
+  </div>
 </template>

--- a/frontend/app/components/ConfirmationDialog.vue
+++ b/frontend/app/components/ConfirmationDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import { AlertTriangle, Loader2 } from 'lucide-vue-next'
 import { Button } from '@/components/ui/button'
 
@@ -27,22 +27,84 @@ const emit = defineEmits<{
 }>()
 
 const isOpen = ref(false)
+const dialogRef = ref<HTMLElement | null>(null)
+let previousFocusedElement: HTMLElement | null = null
+
+function getFocusableElements() {
+  return Array.from(
+    dialogRef.value?.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    ) ?? []
+  )
+}
+
+function closeDialog() {
+  isOpen.value = false
+}
+
+function handleKeydown(event: KeyboardEvent) {
+  if (!isOpen.value) return
+
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    if (!props.isLoading) handleCancel()
+    return
+  }
+
+  if (event.key !== 'Tab') return
+
+  const focusable = getFocusableElements()
+  if (focusable.length === 0) {
+    event.preventDefault()
+    dialogRef.value?.focus()
+    return
+  }
+
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  const active = document.activeElement as HTMLElement | null
+
+  if (event.shiftKey && active === first) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+
+watch(isOpen, async (open) => {
+  if (open) {
+    previousFocusedElement = document.activeElement as HTMLElement | null
+    document.addEventListener('keydown', handleKeydown)
+    await nextTick()
+    getFocusableElements()[0]?.focus() ?? dialogRef.value?.focus()
+    return
+  }
+
+  document.removeEventListener('keydown', handleKeydown)
+  previousFocusedElement?.focus()
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', handleKeydown)
+})
 
 const handleConfirm = () => {
   emit('confirm')
   if (!props.isLoading) {
-    isOpen.value = false
+    closeDialog()
   }
 }
 
 const handleCancel = () => {
   emit('cancel')
-  isOpen.value = false
+  closeDialog()
 }
 
 defineExpose({
   open: () => { isOpen.value = true },
-  close: () => { isOpen.value = false }
+  close: closeDialog
 })
 </script>
 
@@ -53,8 +115,10 @@ defineExpose({
     </slot>
   </div>
 
-  <div v-if="isOpen" class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
+  <div v-if="isOpen" class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4" @click.self="!isLoading && handleCancel()">
     <div
+      ref="dialogRef"
+      tabindex="-1"
       class="grid w-full max-w-md gap-4 rounded-lg border border-border-subtle bg-background-surface p-6 shadow-lg"
       role="dialog"
       aria-modal="true"

--- a/frontend/app/components/ui/button/Button.vue
+++ b/frontend/app/components/ui/button/Button.vue
@@ -1,44 +1,58 @@
 <script setup lang="ts">
-import type { HTMLAttributes } from "vue"
-import { Primitive, type PrimitiveProps } from "reka-ui"
-import { cn } from "@/lib/utils"
-import { buttonVariants, type ButtonVariants } from "./index"
-import { computed } from "vue"
+import type { HTMLAttributes } from 'vue'
+import { computed, useAttrs } from 'vue'
+import { cn } from '@/lib/utils'
+import { buttonVariants, type ButtonVariants } from './index'
 
 interface Props {
-  variant?: ButtonVariants["variant"]
-  size?: ButtonVariants["size"]
-  class?: HTMLAttributes["class"]
-  as?: PrimitiveProps["as"]
-  asChild?: PrimitiveProps["asChild"]
+  variant?: ButtonVariants['variant']
+  size?: ButtonVariants['size']
+  class?: HTMLAttributes['class']
+  as?: string
   disabled?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  as: "button",
-  variant: "default",
-  size: "default",
-  asChild: false,
+  as: 'button',
+  variant: 'default',
+  size: 'default',
   disabled: false,
 })
 
+const attrs = useAttrs()
+
+const emit = defineEmits<{
+  (e: 'click', event: MouseEvent): void
+}>()
+
 const buttonClass = computed(() => {
-  const variantClasses = buttonVariants({ 
-    variant: props.variant || "default", 
-    size: props.size || "default" 
+  const variantClasses = buttonVariants({
+    variant: props.variant || 'default',
+    size: props.size || 'default',
   })
-  const finalClasses = cn(variantClasses, props.class)
-  return finalClasses
+  return cn(variantClasses, props.class)
 })
+
+function handleClick(event: MouseEvent) {
+  if (props.disabled) {
+    event.preventDefault()
+    event.stopPropagation()
+    return
+  }
+
+  emit('click', event)
+}
 </script>
 
 <template>
-  <Primitive
-    :as="props.as"
-    :as-child="props.asChild"
+  <component
+    :is="props.as"
+    v-bind="attrs"
     :class="buttonClass"
-    :disabled="props.disabled"
+    :disabled="props.as === 'button' ? props.disabled : undefined"
+    :aria-disabled="props.as !== 'button' && props.disabled ? 'true' : undefined"
+    @click="handleClick"
   >
     <slot />
-  </Primitive>
+  </component>
 </template>

--- a/frontend/app/components/ui/button/Button.vue
+++ b/frontend/app/components/ui/button/Button.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+defineOptions({ inheritAttrs: false })
+
 import type { HTMLAttributes } from 'vue'
 import { computed, useAttrs } from 'vue'
 import { cn } from '@/lib/utils'

--- a/frontend/app/components/ui/input/Input.vue
+++ b/frontend/app/components/ui/input/Input.vue
@@ -4,7 +4,9 @@
       'flex h-9 w-full rounded-md border border-border-subtle bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30 disabled:cursor-not-allowed disabled:opacity-50',
       props.class
     )"
+    :value="props.modelValue"
     v-bind="$attrs"
+    @input="onInput"
   />
 </template>
 
@@ -13,9 +15,19 @@ import { cn } from '@/lib/utils'
 
 interface Props {
   class?: string
+  modelValue?: string | number | null
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  class: ''
+  class: '',
+  modelValue: '',
 })
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void
+}>()
+
+function onInput(event: Event) {
+  emit('update:modelValue', (event.target as HTMLInputElement).value)
+}
 </script>

--- a/frontend/app/components/ui/input/Input.vue
+++ b/frontend/app/components/ui/input/Input.vue
@@ -4,7 +4,7 @@
       'flex h-9 w-full rounded-md border border-border-subtle bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30 disabled:cursor-not-allowed disabled:opacity-50',
       props.class
     )"
-    :value="props.modelValue"
+    :value="props.modelValue ?? ''"
     v-bind="$attrs"
     @input="onInput"
   />

--- a/frontend/app/pages/settings/workspace.vue
+++ b/frontend/app/pages/settings/workspace.vue
@@ -9,7 +9,7 @@
       </p>
     </section>
 
-    <div class="space-y-6">
+    <div class="space-y-6" :inert="showCleanupConfirm || undefined" :aria-hidden="showCleanupConfirm ? 'true' : undefined">
       <section class="rounded-2xl border border-border-subtle bg-background-surface p-6 shadow-sm">
         <div class="flex flex-wrap items-center justify-between gap-4">
           <div>
@@ -164,8 +164,10 @@
         </div>
       </section>
 
-      <div v-if="showCleanupConfirm" class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
+      <div v-if="showCleanupConfirm" class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4" @click.self="!cleanupRunning && closeCleanupConfirm()">
         <div
+          ref="cleanupDialogRef"
+          tabindex="-1"
           class="grid w-full max-w-md gap-4 rounded-lg border border-border-subtle bg-background-surface p-6 shadow-lg"
           role="dialog"
           aria-modal="true"
@@ -183,7 +185,7 @@
               type="button"
               class="mt-2 inline-flex items-center justify-center gap-2 rounded-md border border-border-subtle bg-background-surface px-4 py-2 text-sm font-medium text-text-primary shadow-sm transition-colors hover:bg-background-subtle disabled:cursor-not-allowed disabled:opacity-50 sm:mt-0"
               :disabled="cleanupRunning"
-              @click="showCleanupConfirm = false"
+              @click="closeCleanupConfirm()"
             >
               Cancel
             </button>
@@ -249,7 +251,7 @@
 
 <script setup lang="ts">
 import { ArrowUpRight, Github, Sparkles } from 'lucide-vue-next'
-import { computed, onMounted, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import Alert from '~/components/alert/Alert.vue'
 import ThemeToggle from '~/components/ThemeToggle.vue'
 import TimeDisplay from '~/components/TimeDisplay.vue'
@@ -311,6 +313,8 @@ const cleanupResult = ref<RetentionCleanupResponseDTO | null>(null)
 const cleanupError = ref('')
 const showCleanupConfirm = ref(false)
 const retentionSchedule = ref<RetentionScheduleStatusDTO | null>(null)
+const cleanupDialogRef = ref<HTMLElement | null>(null)
+let cleanupTriggerElement: HTMLElement | null = null
 
 const isLoading = computed(() => configStore.isLoading)
 const loadError = computed(() => configStore.error)
@@ -320,7 +324,11 @@ function syncFormFromStore() {
 }
 
 async function refreshRetentionSchedule() {
-  retentionSchedule.value = await configStore.getRetentionSchedule()
+  try {
+    retentionSchedule.value = await configStore.getRetentionSchedule()
+  } catch (error) {
+    console.error('Failed to refresh retention schedule', error)
+  }
 }
 
 function resetRetentionForm() {
@@ -363,8 +371,68 @@ async function runCleanup() {
   await executeCleanup(false)
 }
 
-async function confirmCleanupRun() {
+function closeCleanupConfirm() {
   showCleanupConfirm.value = false
+}
+
+function getCleanupFocusableElements() {
+  return Array.from(
+    cleanupDialogRef.value?.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    ) ?? []
+  )
+}
+
+function handleCleanupConfirmKeydown(event: KeyboardEvent) {
+  if (!showCleanupConfirm.value) return
+
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    if (!cleanupRunning.value) closeCleanupConfirm()
+    return
+  }
+
+  if (event.key !== 'Tab') return
+
+  const focusable = getCleanupFocusableElements()
+  if (focusable.length === 0) {
+    event.preventDefault()
+    cleanupDialogRef.value?.focus()
+    return
+  }
+
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  const active = document.activeElement as HTMLElement | null
+
+  if (event.shiftKey && active === first) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+
+watch(showCleanupConfirm, async (open) => {
+  if (open) {
+    cleanupTriggerElement = document.activeElement as HTMLElement | null
+    document.addEventListener('keydown', handleCleanupConfirmKeydown)
+    await nextTick()
+    getCleanupFocusableElements()[1]?.focus() ?? getCleanupFocusableElements()[0]?.focus() ?? cleanupDialogRef.value?.focus()
+    return
+  }
+
+  document.removeEventListener('keydown', handleCleanupConfirmKeydown)
+  cleanupTriggerElement?.focus()
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', handleCleanupConfirmKeydown)
+})
+
+async function confirmCleanupRun() {
+  closeCleanupConfirm()
   await runCleanup()
 }
 

--- a/frontend/app/pages/settings/workspace.vue
+++ b/frontend/app/pages/settings/workspace.vue
@@ -35,7 +35,7 @@
             <span>{{ loadError }}</span>
           </Alert>
 
-          <form class="grid gap-4 md:grid-cols-2" @submit.prevent="saveRetention">
+          <div class="grid gap-4 md:grid-cols-2">
             <div v-for="field in retentionFields" :key="field.key" class="space-y-2">
               <Label :for="field.key">{{ field.label }}</Label>
               <Input
@@ -50,15 +50,25 @@
             </div>
 
             <div class="md:col-span-2 flex flex-wrap items-center gap-3 pt-2">
-              <Button type="submit" :disabled="isSaving || isLoading">
+              <button
+                type="button"
+                class="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                :disabled="isSaving || isLoading"
+                @click="saveRetention"
+              >
                 {{ isSaving ? 'Saving…' : 'Save retention settings' }}
-              </Button>
-              <Button type="button" variant="outline" :disabled="isSaving || isLoading" @click="resetRetentionForm">
+              </button>
+              <button
+                type="button"
+                class="inline-flex items-center justify-center gap-2 rounded-md border border-border-subtle bg-background-surface px-4 py-2 text-sm font-medium text-text-primary shadow-sm transition-colors hover:bg-background-subtle disabled:cursor-not-allowed disabled:opacity-50"
+                :disabled="isSaving || isLoading"
+                @click="resetRetentionForm"
+              >
                 Reset
-              </Button>
+              </button>
               <span v-if="saveMessage" class="text-sm text-text-secondary">{{ saveMessage }}</span>
             </div>
-          </form>
+          </div>
 
           <div class="rounded-2xl border border-border-subtle/80 bg-background-subtle p-4 space-y-4">
             <div>
@@ -66,27 +76,60 @@
               <p class="mt-1 text-sm text-text-secondary">
                 Preview what would be removed, then run cleanup when you are ready.
               </p>
+              <div class="mt-3 rounded-xl border border-border-subtle bg-background-surface px-4 py-3 text-sm">
+                <p class="text-text-primary">
+                  <span class="font-medium">Automatic cleanup:</span>
+                  {{ retentionSchedule?.enabled ? `every ${retentionSchedule.interval_hours}h` : 'disabled' }}
+                </p>
+                <div class="mt-2 space-y-2">
+                  <div class="flex items-start justify-between gap-4 rounded-lg bg-background-subtle/60 px-3 py-2">
+                    <span class="pt-1 text-xs font-medium uppercase tracking-[0.2em] text-text-secondary">Next run</span>
+                    <TimeDisplay
+                      v-if="retentionSchedule?.next_run_at"
+                      :timestamp="retentionSchedule.next_run_at"
+                      :refresh-interval="1000"
+                    />
+                    <span v-else class="text-sm text-text-secondary">Not scheduled yet</span>
+                  </div>
+                  <div v-if="retentionSchedule?.last_completed_at" class="flex items-start justify-between gap-4 rounded-lg bg-background-subtle/60 px-3 py-2">
+                    <span class="pt-1 text-xs font-medium uppercase tracking-[0.2em] text-text-secondary">Last completed</span>
+                    <div class="flex flex-col items-end gap-1">
+                      <TimeDisplay
+                        :timestamp="retentionSchedule.last_completed_at"
+                        :refresh-interval="1000"
+                      />
+                      <span
+                        v-if="retentionSchedule.last_deleted_rows !== null && retentionSchedule.last_deleted_rows !== undefined"
+                        class="text-xs text-text-secondary"
+                      >
+                        Deleted {{ retentionSchedule.last_deleted_rows }} rows
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <p v-if="retentionSchedule?.last_error" class="mt-1 text-red-400">
+                  Last scheduler error: {{ retentionSchedule.last_error }}
+                </p>
+              </div>
             </div>
 
             <div class="flex flex-wrap items-center gap-3">
-              <Button variant="outline" :disabled="cleanupRunning" @click="previewCleanup">
-                {{ cleanupRunning && cleanupMode === 'dry' ? 'Running preview…' : 'Preview cleanup' }}
-              </Button>
-              <ConfirmationDialog
-                title="Run retention cleanup?"
-                description="This will permanently delete data that falls outside the configured retention windows. Preview cleanup first if you want to inspect the impact before deleting anything."
-                confirm-text="Run cleanup"
-                cancel-text="Cancel"
-                variant="destructive"
-                :is-loading="cleanupRunning && cleanupMode === 'live'"
-                @confirm="runCleanup"
+              <button
+                type="button"
+                class="inline-flex items-center justify-center gap-2 rounded-md border border-border-subtle bg-background-surface px-4 py-2 text-sm font-medium text-text-primary shadow-sm transition-colors hover:bg-background-subtle disabled:cursor-not-allowed disabled:opacity-50"
+                :disabled="cleanupRunning"
+                @click="previewCleanup"
               >
-                <template #trigger>
-                  <Button :disabled="cleanupRunning">
-                    {{ cleanupRunning && cleanupMode === 'live' ? 'Running cleanup…' : 'Run cleanup now' }}
-                  </Button>
-                </template>
-              </ConfirmationDialog>
+                {{ cleanupRunning && cleanupMode === 'dry' ? 'Running preview…' : 'Preview cleanup' }}
+              </button>
+              <button
+                type="button"
+                class="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                :disabled="cleanupRunning"
+                @click="showCleanupConfirm = true"
+              >
+                {{ cleanupRunning && cleanupMode === 'live' ? 'Running cleanup…' : 'Run cleanup now' }}
+              </button>
             </div>
 
             <Alert v-if="cleanupError" variant="destructive">
@@ -120,6 +163,41 @@
           </div>
         </div>
       </section>
+
+      <div v-if="showCleanupConfirm" class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
+        <div
+          class="grid w-full max-w-md gap-4 rounded-lg border border-border-subtle bg-background-surface p-6 shadow-lg"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="retention-cleanup-title"
+          aria-describedby="retention-cleanup-description"
+        >
+          <div class="space-y-2">
+            <h2 id="retention-cleanup-title" class="text-lg font-semibold text-text-primary">Run retention cleanup?</h2>
+            <p id="retention-cleanup-description" class="text-sm text-text-secondary">
+              This will permanently delete data that falls outside the configured retention windows. Preview cleanup first if you want to inspect the impact before deleting anything.
+            </p>
+          </div>
+          <div class="flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-2">
+            <button
+              type="button"
+              class="mt-2 inline-flex items-center justify-center gap-2 rounded-md border border-border-subtle bg-background-surface px-4 py-2 text-sm font-medium text-text-primary shadow-sm transition-colors hover:bg-background-subtle disabled:cursor-not-allowed disabled:opacity-50 sm:mt-0"
+              :disabled="cleanupRunning"
+              @click="showCleanupConfirm = false"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="inline-flex items-center justify-center gap-2 rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+              :disabled="cleanupRunning"
+              @click="confirmCleanupRun"
+            >
+              {{ cleanupRunning && cleanupMode === 'live' ? 'Running cleanup…' : 'Run cleanup' }}
+            </button>
+          </div>
+        </div>
+      </div>
 
       <section class="rounded-2xl border border-border-subtle bg-background-surface p-6 shadow-sm">
         <div class="space-y-4">
@@ -173,14 +251,14 @@
 import { ArrowUpRight, Github, Sparkles } from 'lucide-vue-next'
 import { computed, onMounted, ref } from 'vue'
 import Alert from '~/components/alert/Alert.vue'
-import ConfirmationDialog from '~/components/ConfirmationDialog.vue'
 import ThemeToggle from '~/components/ThemeToggle.vue'
+import TimeDisplay from '~/components/TimeDisplay.vue'
 import WorkflowSlackConfigPanel from '~/components/workflows/WorkflowSlackConfigPanel.vue'
 import { Button } from '~/components/ui/button'
 import { Input } from '~/components/ui/input'
 import { Label } from '~/components/ui/label'
 import { useConfigStore } from '~/stores/config'
-import type { DataRetentionConfigDTO, RetentionCleanupResponseDTO } from '~/services/apiClient'
+import type { DataRetentionConfigDTO, RetentionCleanupResponseDTO, RetentionScheduleStatusDTO } from '~/services/apiClient'
 
 const configStore = useConfigStore()
 
@@ -231,12 +309,18 @@ const cleanupRunning = ref(false)
 const cleanupMode = ref<'dry' | 'live' | null>(null)
 const cleanupResult = ref<RetentionCleanupResponseDTO | null>(null)
 const cleanupError = ref('')
+const showCleanupConfirm = ref(false)
+const retentionSchedule = ref<RetentionScheduleStatusDTO | null>(null)
 
 const isLoading = computed(() => configStore.isLoading)
 const loadError = computed(() => configStore.error)
 
 function syncFormFromStore() {
   retentionForm.value = { ...configStore.dataRetention }
+}
+
+async function refreshRetentionSchedule() {
+  retentionSchedule.value = await configStore.getRetentionSchedule()
 }
 
 function resetRetentionForm() {
@@ -263,6 +347,7 @@ async function executeCleanup(dryRun: boolean) {
     cleanupMode.value = dryRun ? 'dry' : 'live'
     cleanupError.value = ''
     cleanupResult.value = await configStore.runRetentionCleanup(dryRun)
+    await refreshRetentionSchedule()
   } catch (err) {
     cleanupError.value = err instanceof Error ? err.message : 'Cleanup request failed.'
   } finally {
@@ -278,11 +363,17 @@ async function runCleanup() {
   await executeCleanup(false)
 }
 
+async function confirmCleanupRun() {
+  showCleanupConfirm.value = false
+  await runCleanup()
+}
+
 onMounted(async () => {
   if (!configStore.config) {
     await configStore.fetchConfig()
   }
   syncFormFromStore()
+  await refreshRetentionSchedule()
 })
 
 definePageMeta({

--- a/frontend/app/pages/settings/workspace.vue
+++ b/frontend/app/pages/settings/workspace.vue
@@ -9,7 +9,7 @@
       </p>
     </section>
 
-    <div class="space-y-6" :inert="showCleanupConfirm || undefined" :aria-hidden="showCleanupConfirm ? 'true' : undefined">
+    <div class="space-y-6">
       <section class="rounded-2xl border border-border-subtle bg-background-surface p-6 shadow-sm">
         <div class="flex flex-wrap items-center justify-between gap-4">
           <div>
@@ -164,43 +164,6 @@
         </div>
       </section>
 
-      <div v-if="showCleanupConfirm" class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4" @click.self="!cleanupRunning && closeCleanupConfirm()">
-        <div
-          ref="cleanupDialogRef"
-          tabindex="-1"
-          class="grid w-full max-w-md gap-4 rounded-lg border border-border-subtle bg-background-surface p-6 shadow-lg"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="retention-cleanup-title"
-          aria-describedby="retention-cleanup-description"
-        >
-          <div class="space-y-2">
-            <h2 id="retention-cleanup-title" class="text-lg font-semibold text-text-primary">Run retention cleanup?</h2>
-            <p id="retention-cleanup-description" class="text-sm text-text-secondary">
-              This will permanently delete data that falls outside the configured retention windows. Preview cleanup first if you want to inspect the impact before deleting anything.
-            </p>
-          </div>
-          <div class="flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-2">
-            <button
-              type="button"
-              class="mt-2 inline-flex items-center justify-center gap-2 rounded-md border border-border-subtle bg-background-surface px-4 py-2 text-sm font-medium text-text-primary shadow-sm transition-colors hover:bg-background-subtle disabled:cursor-not-allowed disabled:opacity-50 sm:mt-0"
-              :disabled="cleanupRunning"
-              @click="closeCleanupConfirm()"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              class="inline-flex items-center justify-center gap-2 rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-50"
-              :disabled="cleanupRunning"
-              @click="confirmCleanupRun"
-            >
-              {{ cleanupRunning && cleanupMode === 'live' ? 'Running cleanup…' : 'Run cleanup' }}
-            </button>
-          </div>
-        </div>
-      </div>
-
       <section class="rounded-2xl border border-border-subtle bg-background-surface p-6 shadow-sm">
         <div class="space-y-4">
           <div>
@@ -246,6 +209,43 @@
         <WorkflowSlackConfigPanel :active="true" :enable-selection="false" />
       </section>
     </div>
+
+    <div v-if="showCleanupConfirm" class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4" @click.self="!cleanupRunning && closeCleanupConfirm()">
+      <div
+        ref="cleanupDialogRef"
+        tabindex="-1"
+        class="grid w-full max-w-md gap-4 rounded-lg border border-border-subtle bg-background-surface p-6 shadow-lg"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="retention-cleanup-title"
+        aria-describedby="retention-cleanup-description"
+      >
+        <div class="space-y-2">
+          <h2 id="retention-cleanup-title" class="text-lg font-semibold text-text-primary">Run retention cleanup?</h2>
+          <p id="retention-cleanup-description" class="text-sm text-text-secondary">
+            This will permanently delete data that falls outside the configured retention windows. Preview cleanup first if you want to inspect the impact before deleting anything.
+          </p>
+        </div>
+        <div class="flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-2">
+          <button
+            type="button"
+            class="mt-2 inline-flex items-center justify-center gap-2 rounded-md border border-border-subtle bg-background-surface px-4 py-2 text-sm font-medium text-text-primary shadow-sm transition-colors hover:bg-background-subtle disabled:cursor-not-allowed disabled:opacity-50 sm:mt-0"
+            :disabled="cleanupRunning"
+            @click="closeCleanupConfirm()"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="inline-flex items-center justify-center gap-2 rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+            :disabled="cleanupRunning"
+            @click="confirmCleanupRun"
+          >
+            {{ cleanupRunning && cleanupMode === 'live' ? 'Running cleanup…' : 'Run cleanup' }}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -259,10 +259,12 @@ import WorkflowSlackConfigPanel from '~/components/workflows/WorkflowSlackConfig
 import { Button } from '~/components/ui/button'
 import { Input } from '~/components/ui/input'
 import { Label } from '~/components/ui/label'
-import { useConfigStore } from '~/stores/config'
 import type { DataRetentionConfigDTO, RetentionCleanupResponseDTO, RetentionScheduleStatusDTO } from '~/services/apiClient'
+import { useLogger } from '~/services/logger'
+import { useConfigStore } from '~/stores/config'
 
 const configStore = useConfigStore()
+const logger = useLogger()
 
 const retentionFields: Array<{ key: keyof DataRetentionConfigDTO; label: string; description: string }> = [
   {
@@ -327,7 +329,7 @@ async function refreshRetentionSchedule() {
   try {
     retentionSchedule.value = await configStore.getRetentionSchedule()
   } catch (error) {
-    console.error('Failed to refresh retention schedule', error)
+    logger.error('Failed to refresh retention schedule', error)
   }
 }
 

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -87,6 +87,17 @@ export interface RetentionCleanupResponseDTO {
   results: RetentionCleanupResultDTO[]
 }
 
+export interface RetentionScheduleStatusDTO {
+  enabled: boolean
+  interval_hours: number
+  next_run_at?: string | null
+  last_run_at?: string | null
+  last_completed_at?: string | null
+  last_duration_seconds?: number | null
+  last_deleted_rows?: number | null
+  last_error?: string | null
+}
+
 export interface AppConfigSnapshotDTO {
   task_issue_summary: TaskIssueConfigDTO
   data_retention: DataRetentionConfigDTO
@@ -231,6 +242,14 @@ class ApiService {
   async getRetentionConfig(): Promise<DataRetentionConfigDTO> {
     const response = await this.api.request({
       path: '/api/config/retention',
+      method: 'GET'
+    })
+    return response.data
+  }
+
+  async getRetentionSchedule(): Promise<RetentionScheduleStatusDTO> {
+    const response = await this.api.request({
+      path: '/api/config/retention/schedule',
       method: 'GET'
     })
     return response.data

--- a/frontend/app/stores/config.ts
+++ b/frontend/app/stores/config.ts
@@ -7,6 +7,7 @@ import {
   type AppSettingInput,
   type DataRetentionConfigDTO,
   type RetentionCleanupResponseDTO,
+  type RetentionScheduleStatusDTO,
 } from '~/services/apiClient'
 
 const TASK_ISSUE_LOOKBACK_DEFAULT = 24
@@ -172,6 +173,10 @@ export const useConfigStore = defineStore('config', () => {
     }
   }
 
+  async function getRetentionSchedule(): Promise<RetentionScheduleStatusDTO> {
+    return apiService.getRetentionSchedule()
+  }
+
   async function runRetentionCleanup(dryRun = true): Promise<RetentionCleanupResponseDTO> {
     return apiService.runRetentionCleanup(dryRun)
   }
@@ -189,6 +194,7 @@ export const useConfigStore = defineStore('config', () => {
     deleteSetting,
     updateTaskIssueLookback,
     updateDataRetention,
+    getRetentionSchedule,
     runRetentionCleanup,
   }
 })


### PR DESCRIPTION
## Summary
- add backend scheduling for automatic retention cleanup runs and expose scheduler status in the config API
- extend workspace retention settings UI with automatic cleanup status, next run, and last run visibility
- cover the new scheduler path with targeted backend tests

## Verification
- `cd agent && python3 -m pytest tests/unit/test_retention_scheduler.py tests/unit/test_retention_service.py tests/unit/test_app_config_service.py -q`
- `cd frontend && npm ci && npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retention cleanup scheduler with configurable interval (default 24h) and UI to run/preview cleanup from Workspace settings
  * Workspace now shows scheduler status: enabled state, next run, last completion, and recent errors
  * API and client/store support to fetch retention schedule

* **Refactor**
  * Dialog, button, and input components updated for improved keyboard/focus behavior and controlled input handling

* **Tests**
  * Unit tests added for the retention scheduler
<!-- end of auto-generated comment: release notes by coderabbit.ai -->