### PR TITLE
feat: refine retention cleanup controls

### DIFF
--- a/agent/api/config_routes.py
+++ b/agent/api/config_routes.py
@@ -99,6 +99,9 @@ def create_router(app_state) -> APIRouter:
         retention_service: RetentionService = Depends(get_retention_service)
     ):
         """Run retention cleanup, optionally as a dry-run preview."""
-        return retention_service.cleanup(dry_run=dry_run)
+        try:
+            return retention_service.cleanup(dry_run=dry_run)
+        except RuntimeError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     return router

--- a/agent/app.py
+++ b/agent/app.py
@@ -43,6 +43,7 @@ class ApplicationState:
         self.config: Optional[Config] = None
         self.auth_manager = None
         self.auth_dependencies = None
+        self.retention_scheduler = None
 
 
 app_state = ApplicationState()
@@ -57,6 +58,8 @@ async def lifespan(app: FastAPI):
     # Shutdown
     if app_state.health_monitor:
         app_state.health_monitor.stop()
+    if app_state.retention_scheduler:
+        app_state.retention_scheduler.stop()
     if app_state.connection_manager:
         await app_state.connection_manager.stop_background_broadcaster()
     if app_state.monitor_instance:
@@ -287,6 +290,7 @@ async def initialize_application():
     app_state.workflow_engine.monitor_instance = app_state.monitor_instance
 
     start_health_monitor()
+    start_retention_scheduler()
 
 
 def start_monitor(config: Config):
@@ -323,6 +327,18 @@ def start_health_monitor():
         app_state.event_handler
     )
     app_state.health_monitor.start()
+
+
+def start_retention_scheduler():
+    """Start the automatic retention cleanup scheduler."""
+    if app_state.retention_scheduler:
+        logger.warning("Retention scheduler already running")
+        return
+
+    from services.retention_scheduler_service import RetentionSchedulerService
+
+    app_state.retention_scheduler = RetentionSchedulerService(app_state.db_manager)
+    app_state.retention_scheduler.start()
 
 
 def start_server():

--- a/agent/models.py
+++ b/agent/models.py
@@ -472,8 +472,12 @@ class DataRetentionConfig(BaseModel):
 class RetentionScheduleConfig(BaseModel):
     """Automatic retention cleanup schedule."""
     enabled: bool = False
-    frequency: Literal["daily", "weekly"] = "daily"
-    run_at: str = Field(default="03:00", pattern=r"^([01]\d|2[0-3]):[0-5]\d$")
+    preset: Literal["hourly", "daily", "weekly", "monthly"] = "daily"
+    hour: int = Field(default=3, ge=0, le=23)
+    minute: int = Field(default=0, ge=0, le=59)
+    weekday: int = Field(default=0, ge=0, le=6)
+    month_day: int = Field(default=1, ge=1, le=31)
+    timezone: Literal["UTC"] = "UTC"
 
 
 class RetentionCleanupResult(BaseModel):

--- a/agent/models.py
+++ b/agent/models.py
@@ -469,6 +469,13 @@ class DataRetentionConfig(BaseModel):
     inactive_sessions_days: int = Field(default=30, ge=1, le=3650)
 
 
+class RetentionScheduleConfig(BaseModel):
+    """Automatic retention cleanup schedule."""
+    enabled: bool = False
+    frequency: Literal["daily", "weekly"] = "daily"
+    run_at: str = Field(default="03:00", pattern=r"^([01]\d|2[0-3]):[0-5]\d$")
+
+
 class RetentionCleanupResult(BaseModel):
     """Result for a single retention target cleanup."""
     key: str
@@ -481,6 +488,18 @@ class RetentionCleanupResponse(BaseModel):
     """Summary of a retention cleanup run."""
     dry_run: bool = False
     total_deleted: int = Field(ge=0)
+    policy: DataRetentionConfig
+    results: List[RetentionCleanupResult] = Field(default_factory=list)
+
+
+class RetentionLastRun(BaseModel):
+    """Last automatic retention cleanup run status."""
+    status: Literal["never", "success", "error", "running"] = "never"
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    total_deleted: int = Field(default=0, ge=0)
+    dry_run: bool = False
+    error: Optional[str] = None
     results: List[RetentionCleanupResult] = Field(default_factory=list)
 
 
@@ -488,6 +507,8 @@ class AppConfigSnapshot(BaseModel):
     """Grouped configuration snapshot returned to clients."""
     task_issue_summary: TaskIssueConfig
     data_retention: DataRetentionConfig
+    retention_schedule: RetentionScheduleConfig = Field(default_factory=RetentionScheduleConfig)
+    retention_last_run: RetentionLastRun = Field(default_factory=RetentionLastRun)
 
 
 class UserInfo(BaseModel):

--- a/agent/services/__init__.py
+++ b/agent/services/__init__.py
@@ -11,6 +11,7 @@ from .session_service import SessionService
 from .auth_service import AuthService
 from .app_config_service import AppConfigService
 from .retention_service import RetentionService
+from .retention_scheduler_service import RetentionSchedulerService
 
 __all__ = [
     'TaskService',
@@ -23,5 +24,6 @@ __all__ = [
     'SessionService',
     'AuthService',
     'AppConfigService',
-    'RetentionService'
+    'RetentionService',
+    'RetentionSchedulerService'
 ]

--- a/agent/services/app_config_service.py
+++ b/agent/services/app_config_service.py
@@ -27,8 +27,12 @@ RETENTION_WORKFLOW_EXECUTIONS_DAYS_KEY = "data_retention.workflow_executions_day
 RETENTION_TASK_DAILY_STATS_DAYS_KEY = "data_retention.task_daily_stats_days"
 RETENTION_INACTIVE_SESSIONS_DAYS_KEY = "data_retention.inactive_sessions_days"
 RETENTION_SCHEDULE_ENABLED_KEY = "data_retention.schedule.enabled"
-RETENTION_SCHEDULE_FREQUENCY_KEY = "data_retention.schedule.frequency"
-RETENTION_SCHEDULE_RUN_AT_KEY = "data_retention.schedule.run_at"
+RETENTION_SCHEDULE_PRESET_KEY = "data_retention.schedule.preset"
+RETENTION_SCHEDULE_HOUR_KEY = "data_retention.schedule.hour"
+RETENTION_SCHEDULE_MINUTE_KEY = "data_retention.schedule.minute"
+RETENTION_SCHEDULE_WEEKDAY_KEY = "data_retention.schedule.weekday"
+RETENTION_SCHEDULE_MONTH_DAY_KEY = "data_retention.schedule.month_day"
+RETENTION_SCHEDULE_TIMEZONE_KEY = "data_retention.schedule.timezone"
 RETENTION_LAST_RUN_KEY = "data_retention.last_run"
 
 DEFAULT_SETTING_DEFINITIONS: Dict[str, Dict[str, Any]] = {
@@ -102,21 +106,57 @@ DEFAULT_SETTING_DEFINITIONS: Dict[str, Dict[str, Any]] = {
         "description": "Whether retention cleanup should run automatically.",
         "category": "data_retention",
     },
-    RETENTION_SCHEDULE_FREQUENCY_KEY: {
+    RETENTION_SCHEDULE_PRESET_KEY: {
         "default": "daily",
         "value_type": "string",
-        "label": "Automatic cleanup frequency",
+        "label": "Automatic cleanup schedule",
         "description": "How often automatic cleanup should run.",
         "category": "data_retention",
-        "allowed": {"daily", "weekly"},
+        "allowed": {"hourly", "daily", "weekly", "monthly"},
     },
-    RETENTION_SCHEDULE_RUN_AT_KEY: {
-        "default": "03:00",
-        "value_type": "string",
-        "label": "Automatic cleanup time",
-        "description": "UTC time when automatic cleanup should run.",
+    RETENTION_SCHEDULE_HOUR_KEY: {
+        "default": 3,
+        "value_type": "number",
+        "label": "Automatic cleanup hour",
+        "description": "UTC hour when automatic cleanup should run.",
         "category": "data_retention",
-        "pattern": r"^([01]\d|2[0-3]):[0-5]\d$",
+        "min": 0,
+        "max": 23,
+    },
+    RETENTION_SCHEDULE_MINUTE_KEY: {
+        "default": 0,
+        "value_type": "number",
+        "label": "Automatic cleanup minute",
+        "description": "UTC minute when automatic cleanup should run.",
+        "category": "data_retention",
+        "min": 0,
+        "max": 59,
+    },
+    RETENTION_SCHEDULE_WEEKDAY_KEY: {
+        "default": 0,
+        "value_type": "number",
+        "label": "Automatic cleanup weekday",
+        "description": "UTC weekday for weekly automatic cleanup. Monday is 0.",
+        "category": "data_retention",
+        "min": 0,
+        "max": 6,
+    },
+    RETENTION_SCHEDULE_MONTH_DAY_KEY: {
+        "default": 1,
+        "value_type": "number",
+        "label": "Automatic cleanup day of month",
+        "description": "UTC day of month for monthly automatic cleanup.",
+        "category": "data_retention",
+        "min": 1,
+        "max": 31,
+    },
+    RETENTION_SCHEDULE_TIMEZONE_KEY: {
+        "default": "UTC",
+        "value_type": "string",
+        "label": "Automatic cleanup timezone",
+        "description": "Timezone used for automatic cleanup schedules.",
+        "category": "data_retention",
+        "allowed": {"UTC"},
     },
     RETENTION_LAST_RUN_KEY: {
         "default": {"status": "never", "total_deleted": 0, "dry_run": False, "results": []},
@@ -341,7 +381,7 @@ class AppConfigService:
     def get_data_retention_config(self) -> DataRetentionConfig:
         """Return normalized data retention configuration."""
         self.ensure_defaults()
-        return DataRetentionConfig(
+        policy = DataRetentionConfig(
             task_successful_days=self._get_bounded_number_setting(RETENTION_TASK_SUCCESSFUL_DAYS_KEY),
             task_unsuccessful_days=self._get_bounded_number_setting(RETENTION_TASK_UNSUCCESSFUL_DAYS_KEY),
             worker_events_days=self._get_bounded_number_setting(RETENTION_WORKER_EVENTS_DAYS_KEY),
@@ -349,6 +389,18 @@ class AppConfigService:
             task_daily_stats_days=self._get_bounded_number_setting(RETENTION_TASK_DAILY_STATS_DAYS_KEY),
             inactive_sessions_days=self._get_bounded_number_setting(RETENTION_INACTIVE_SESSIONS_DAYS_KEY),
         )
+        logger.info(
+            "Data retention policy loaded: task_successful_days=%s "
+            "task_unsuccessful_days=%s worker_events_days=%s workflow_executions_days=%s "
+            "task_daily_stats_days=%s inactive_sessions_days=%s",
+            policy.task_successful_days,
+            policy.task_unsuccessful_days,
+            policy.worker_events_days,
+            policy.workflow_executions_days,
+            policy.task_daily_stats_days,
+            policy.inactive_sessions_days,
+        )
+        return policy
 
     def get_retention_schedule_config(self) -> RetentionScheduleConfig:
         """Return normalized automatic retention cleanup schedule."""
@@ -359,15 +411,35 @@ class AppConfigService:
         except ValueError:
             enabled = False
 
-        frequency = str(self.get_setting_value(RETENTION_SCHEDULE_FREQUENCY_KEY, "daily"))
-        if frequency not in {"daily", "weekly"}:
-            frequency = "daily"
+        preset = str(self.get_setting_value(RETENTION_SCHEDULE_PRESET_KEY, "daily"))
+        if preset not in {"hourly", "daily", "weekly", "monthly"}:
+            preset = "daily"
 
-        run_at = str(self.get_setting_value(RETENTION_SCHEDULE_RUN_AT_KEY, "03:00"))
-        if not re.match(r"^([01]\d|2[0-3]):[0-5]\d$", run_at):
-            run_at = "03:00"
+        timezone_value = str(self.get_setting_value(RETENTION_SCHEDULE_TIMEZONE_KEY, "UTC"))
+        if timezone_value != "UTC":
+            timezone_value = "UTC"
 
-        return RetentionScheduleConfig(enabled=enabled, frequency=frequency, run_at=run_at)
+        schedule = RetentionScheduleConfig(
+            enabled=enabled,
+            preset=preset,
+            hour=self._get_bounded_number_setting(RETENTION_SCHEDULE_HOUR_KEY),
+            minute=self._get_bounded_number_setting(RETENTION_SCHEDULE_MINUTE_KEY),
+            weekday=self._get_bounded_number_setting(RETENTION_SCHEDULE_WEEKDAY_KEY),
+            month_day=self._get_bounded_number_setting(RETENTION_SCHEDULE_MONTH_DAY_KEY),
+            timezone=timezone_value,
+        )
+        logger.info(
+            "Retention schedule loaded: enabled=%s preset=%s hour=%s minute=%s "
+            "weekday=%s month_day=%s timezone=%s",
+            schedule.enabled,
+            schedule.preset,
+            schedule.hour,
+            schedule.minute,
+            schedule.weekday,
+            schedule.month_day,
+            schedule.timezone,
+        )
+        return schedule
 
     def get_retention_last_run(self) -> RetentionLastRun:
         """Return the last automatic retention cleanup status."""
@@ -382,6 +454,16 @@ class AppConfigService:
 
     def set_retention_last_run(self, last_run: RetentionLastRun) -> AppSetting:
         """Persist the last automatic retention cleanup status."""
+        logger.info(
+            "Persisting retention last run: status=%s started_at=%s finished_at=%s "
+            "total_deleted=%s dry_run=%s error=%s",
+            last_run.status,
+            last_run.started_at.isoformat() if last_run.started_at else None,
+            last_run.finished_at.isoformat() if last_run.finished_at else None,
+            last_run.total_deleted,
+            last_run.dry_run,
+            last_run.error,
+        )
         return self.upsert_setting(
             RETENTION_LAST_RUN_KEY,
             AppSettingUpdate(

--- a/agent/services/app_config_service.py
+++ b/agent/services/app_config_service.py
@@ -1,12 +1,21 @@
 """Service for managing application configuration stored in the database."""
 
 import logging
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy.orm import Session
 
 from database import AppSettingDB
-from models import AppSetting, AppSettingUpdate, AppConfigSnapshot, TaskIssueConfig, DataRetentionConfig
+from models import (
+    AppSetting,
+    AppSettingUpdate,
+    AppConfigSnapshot,
+    TaskIssueConfig,
+    DataRetentionConfig,
+    RetentionLastRun,
+    RetentionScheduleConfig,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +26,10 @@ RETENTION_WORKER_EVENTS_DAYS_KEY = "data_retention.worker_events_days"
 RETENTION_WORKFLOW_EXECUTIONS_DAYS_KEY = "data_retention.workflow_executions_days"
 RETENTION_TASK_DAILY_STATS_DAYS_KEY = "data_retention.task_daily_stats_days"
 RETENTION_INACTIVE_SESSIONS_DAYS_KEY = "data_retention.inactive_sessions_days"
+RETENTION_SCHEDULE_ENABLED_KEY = "data_retention.schedule.enabled"
+RETENTION_SCHEDULE_FREQUENCY_KEY = "data_retention.schedule.frequency"
+RETENTION_SCHEDULE_RUN_AT_KEY = "data_retention.schedule.run_at"
+RETENTION_LAST_RUN_KEY = "data_retention.last_run"
 
 DEFAULT_SETTING_DEFINITIONS: Dict[str, Dict[str, Any]] = {
     TASK_ISSUE_LOOKBACK_KEY: {
@@ -81,6 +94,36 @@ DEFAULT_SETTING_DEFINITIONS: Dict[str, Dict[str, Any]] = {
         "category": "data_retention",
         "min": 1,
         "max": 3650,
+    },
+    RETENTION_SCHEDULE_ENABLED_KEY: {
+        "default": False,
+        "value_type": "boolean",
+        "label": "Automatic cleanup",
+        "description": "Whether retention cleanup should run automatically.",
+        "category": "data_retention",
+    },
+    RETENTION_SCHEDULE_FREQUENCY_KEY: {
+        "default": "daily",
+        "value_type": "string",
+        "label": "Automatic cleanup frequency",
+        "description": "How often automatic cleanup should run.",
+        "category": "data_retention",
+        "allowed": {"daily", "weekly"},
+    },
+    RETENTION_SCHEDULE_RUN_AT_KEY: {
+        "default": "03:00",
+        "value_type": "string",
+        "label": "Automatic cleanup time",
+        "description": "UTC time when automatic cleanup should run.",
+        "category": "data_retention",
+        "pattern": r"^([01]\d|2[0-3]):[0-5]\d$",
+    },
+    RETENTION_LAST_RUN_KEY: {
+        "default": {"status": "never", "total_deleted": 0, "dry_run": False, "results": []},
+        "value_type": "json",
+        "label": "Last retention cleanup run",
+        "description": "Last automatic cleanup status and result.",
+        "category": "data_retention",
     },
 }
 
@@ -170,6 +213,15 @@ class AppConfigService:
             value = self._normalize_boolean(value)
         elif target_type == "string":
             value = str(value) if value is not None else ""
+            allowed_values = definition.get("allowed")
+            if allowed_values and value not in allowed_values:
+                allowed_display = ", ".join(sorted(allowed_values))
+                raise ValueError(f"Value for {key} must be one of: {allowed_display}")
+            pattern = definition.get("pattern")
+            if pattern and not re.match(pattern, value):
+                raise ValueError(f"Value for {key} must match {pattern}")
+        elif target_type == "json":
+            value = value if value is not None else {}
 
         return value, target_type
 
@@ -298,6 +350,47 @@ class AppConfigService:
             inactive_sessions_days=self._get_bounded_number_setting(RETENTION_INACTIVE_SESSIONS_DAYS_KEY),
         )
 
+    def get_retention_schedule_config(self) -> RetentionScheduleConfig:
+        """Return normalized automatic retention cleanup schedule."""
+        self.ensure_defaults()
+        enabled_value = self.get_setting_value(RETENTION_SCHEDULE_ENABLED_KEY, False)
+        try:
+            enabled = self._normalize_boolean(enabled_value)
+        except ValueError:
+            enabled = False
+
+        frequency = str(self.get_setting_value(RETENTION_SCHEDULE_FREQUENCY_KEY, "daily"))
+        if frequency not in {"daily", "weekly"}:
+            frequency = "daily"
+
+        run_at = str(self.get_setting_value(RETENTION_SCHEDULE_RUN_AT_KEY, "03:00"))
+        if not re.match(r"^([01]\d|2[0-3]):[0-5]\d$", run_at):
+            run_at = "03:00"
+
+        return RetentionScheduleConfig(enabled=enabled, frequency=frequency, run_at=run_at)
+
+    def get_retention_last_run(self) -> RetentionLastRun:
+        """Return the last automatic retention cleanup status."""
+        self.ensure_defaults()
+        value = self.get_setting_value(RETENTION_LAST_RUN_KEY, {})
+        if not isinstance(value, dict):
+            value = {}
+        try:
+            return RetentionLastRun(**value)
+        except Exception:  # pylint: disable=broad-except
+            return RetentionLastRun()
+
+    def set_retention_last_run(self, last_run: RetentionLastRun) -> AppSetting:
+        """Persist the last automatic retention cleanup status."""
+        return self.upsert_setting(
+            RETENTION_LAST_RUN_KEY,
+            AppSettingUpdate(
+                value=last_run.model_dump(mode="json"),
+                value_type="json",
+                category="data_retention",
+            ),
+        )
+
     def get_config_snapshot(self) -> AppConfigSnapshot:
         """Return grouped configuration for clients."""
         self.ensure_defaults()
@@ -305,4 +398,6 @@ class AppConfigService:
         return AppConfigSnapshot(
             task_issue_summary=TaskIssueConfig(lookback_hours=lookback_hours),
             data_retention=self.get_data_retention_config(),
+            retention_schedule=self.get_retention_schedule_config(),
+            retention_last_run=self.get_retention_last_run(),
         )

--- a/agent/services/retention_scheduler_service.py
+++ b/agent/services/retention_scheduler_service.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import logging
 import threading
-from datetime import datetime, time, timedelta, timezone
+from calendar import monthrange
+from datetime import datetime, time, timezone
 from typing import Optional
 
 from database import DatabaseManager
-from models import RetentionLastRun
+from models import RetentionLastRun, RetentionScheduleConfig
 from services.app_config_service import AppConfigService
 from services.retention_service import RetentionService
 
@@ -47,15 +48,38 @@ class RetentionSchedulerService:
             schedule = config_service.get_retention_schedule_config()
             last_run = config_service.get_retention_last_run()
 
-        if not schedule.enabled or not self.is_due(schedule.frequency, schedule.run_at, last_run, now):
+        logger.info(
+            "Retention scheduler poll: now=%s enabled=%s preset=%s hour=%s minute=%s "
+            "weekday=%s month_day=%s timezone=%s "
+            "last_status=%s last_started_at=%s last_finished_at=%s",
+            now.isoformat(),
+            schedule.enabled,
+            schedule.preset,
+            schedule.hour,
+            schedule.minute,
+            schedule.weekday,
+            schedule.month_day,
+            schedule.timezone,
+            last_run.status,
+            last_run.started_at.isoformat() if last_run.started_at else None,
+            last_run.finished_at.isoformat() if last_run.finished_at else None,
+        )
+
+        if not schedule.enabled:
+            logger.info("Retention scheduler skipped: automatic cleanup is disabled")
             return False
 
+        if not self.is_due(schedule, last_run, now):
+            return False
+
+        logger.info("Retention scheduler due: starting automatic cleanup")
         self.run_cleanup()
         return True
 
     def run_cleanup(self):
         """Run one live retention cleanup."""
         started_at = datetime.now(timezone.utc)
+        logger.info("Automatic retention cleanup starting: started_at=%s", started_at.isoformat())
         try:
             with self.db_manager.get_session() as session:
                 config_service = AppConfigService(session)
@@ -76,7 +100,13 @@ class RetentionSchedulerService:
                         results=result.results,
                     )
                 )
-                logger.info("Automatic retention cleanup deleted %s rows", result.total_deleted)
+                logger.info(
+                    "Automatic retention cleanup finished: started_at=%s finished_at=%s "
+                    "total_deleted=%s",
+                    started_at.isoformat(),
+                    finished_at.isoformat(),
+                    result.total_deleted,
+                )
                 return result
         except Exception as exc:  # pylint: disable=broad-except
             logger.error("Automatic retention cleanup failed: %s", exc, exc_info=True)
@@ -100,22 +130,105 @@ class RetentionSchedulerService:
             self._stop_event.wait(self.poll_interval_seconds)
 
     @staticmethod
-    def is_due(frequency: str, run_at: str, last_run: RetentionLastRun, now: datetime) -> bool:
+    def is_due(schedule: RetentionScheduleConfig, last_run: RetentionLastRun, now: datetime) -> bool:
         """Return whether a schedule is due at the given UTC time."""
         if now.tzinfo is None:
             now = now.replace(tzinfo=timezone.utc)
 
-        hour, minute = [int(part) for part in run_at.split(":", 1)]
-        scheduled_today = datetime.combine(now.date(), time(hour=hour, minute=minute), tzinfo=timezone.utc)
-        if now < scheduled_today:
+        finished_at = RetentionSchedulerService._finished_at(last_run)
+        if schedule.preset == "hourly":
+            scheduled_at = now.replace(minute=schedule.minute, second=0, microsecond=0)
+            if now < scheduled_at:
+                logger.info(
+                    "Retention scheduler skipped: current time is before scheduled minute "
+                    "now=%s scheduled_this_hour=%s",
+                    now.isoformat(),
+                    scheduled_at.isoformat(),
+                )
+                return False
+            return RetentionSchedulerService._is_after_last_run(scheduled_at, finished_at)
+
+        scheduled_today = datetime.combine(
+            now.date(),
+            time(hour=schedule.hour, minute=schedule.minute),
+            tzinfo=timezone.utc,
+        )
+        if schedule.preset == "daily":
+            if now < scheduled_today:
+                logger.info(
+                    "Retention scheduler skipped: current time is before scheduled time "
+                    "now=%s scheduled_today=%s",
+                    now.isoformat(),
+                    scheduled_today.isoformat(),
+                )
+                return False
+            return RetentionSchedulerService._is_after_last_run(scheduled_today, finished_at)
+
+        if schedule.preset == "weekly":
+            if now.weekday() != schedule.weekday:
+                logger.info(
+                    "Retention scheduler skipped: current weekday does not match schedule "
+                    "now=%s current_weekday=%s scheduled_weekday=%s",
+                    now.isoformat(),
+                    now.weekday(),
+                    schedule.weekday,
+                )
+                return False
+            if now < scheduled_today:
+                logger.info(
+                    "Retention scheduler skipped: current time is before scheduled weekly time "
+                    "now=%s scheduled_today=%s",
+                    now.isoformat(),
+                    scheduled_today.isoformat(),
+                )
+                return False
+            return RetentionSchedulerService._is_after_last_run(scheduled_today, finished_at)
+
+        scheduled_day = min(schedule.month_day, monthrange(now.year, now.month)[1])
+        if now.day != scheduled_day:
+            logger.info(
+                "Retention scheduler skipped: current month day does not match schedule "
+                "now=%s current_day=%s scheduled_day=%s configured_month_day=%s",
+                now.isoformat(),
+                now.day,
+                scheduled_day,
+                schedule.month_day,
+            )
             return False
+        if now < scheduled_today:
+            logger.info(
+                "Retention scheduler skipped: current time is before scheduled monthly time "
+                "now=%s scheduled_today=%s",
+                now.isoformat(),
+                scheduled_today.isoformat(),
+            )
+            return False
+        return RetentionSchedulerService._is_after_last_run(scheduled_today, finished_at)
 
+    @staticmethod
+    def _finished_at(last_run: RetentionLastRun) -> Optional[datetime]:
         finished_at = last_run.finished_at or last_run.started_at
-        if finished_at is None:
-            return True
-        if finished_at.tzinfo is None:
-            finished_at = finished_at.replace(tzinfo=timezone.utc)
+        if finished_at and finished_at.tzinfo is None:
+            return finished_at.replace(tzinfo=timezone.utc)
+        return finished_at
 
-        if frequency == "weekly":
-            return finished_at <= now - timedelta(days=7)
-        return finished_at.date() < now.date()
+    @staticmethod
+    def _is_after_last_run(scheduled_at: datetime, finished_at: Optional[datetime]) -> bool:
+        if finished_at is None:
+            logger.info("Retention scheduler due: no previous automatic cleanup run recorded")
+            return True
+        if finished_at < scheduled_at:
+            logger.info(
+                "Retention scheduler due: scheduled run has not completed "
+                "scheduled_at=%s last_finished_at=%s",
+                scheduled_at.isoformat(),
+                finished_at.isoformat(),
+            )
+            return True
+        logger.info(
+            "Retention scheduler skipped: scheduled run already completed "
+            "scheduled_at=%s last_finished_at=%s",
+            scheduled_at.isoformat(),
+            finished_at.isoformat(),
+        )
+        return False

--- a/agent/services/retention_scheduler_service.py
+++ b/agent/services/retention_scheduler_service.py
@@ -1,0 +1,121 @@
+"""Automatic retention cleanup scheduler."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from datetime import datetime, time, timedelta, timezone
+from typing import Optional
+
+from database import DatabaseManager
+from models import RetentionLastRun
+from services.app_config_service import AppConfigService
+from services.retention_service import RetentionService
+
+logger = logging.getLogger(__name__)
+
+
+class RetentionSchedulerService:
+    """Run retention cleanup automatically when the persisted schedule is due."""
+
+    def __init__(self, db_manager: DatabaseManager, poll_interval_seconds: int = 60):
+        self.db_manager = db_manager
+        self.poll_interval_seconds = poll_interval_seconds
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            logger.warning("Retention scheduler already running")
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run_loop, name="retention-scheduler", daemon=True)
+        self._thread.start()
+        logger.info("Retention scheduler started")
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5)
+        logger.info("Retention scheduler stopped")
+
+    def run_once_if_due(self, now: Optional[datetime] = None) -> bool:
+        """Run cleanup once when enabled and due. Returns True when cleanup ran."""
+        now = now or datetime.now(timezone.utc)
+        with self.db_manager.get_session() as session:
+            config_service = AppConfigService(session)
+            schedule = config_service.get_retention_schedule_config()
+            last_run = config_service.get_retention_last_run()
+
+        if not schedule.enabled or not self.is_due(schedule.frequency, schedule.run_at, last_run, now):
+            return False
+
+        self.run_cleanup()
+        return True
+
+    def run_cleanup(self):
+        """Run one live retention cleanup."""
+        started_at = datetime.now(timezone.utc)
+        try:
+            with self.db_manager.get_session() as session:
+                config_service = AppConfigService(session)
+                config_service.set_retention_last_run(
+                    RetentionLastRun(status="running", started_at=started_at, total_deleted=0)
+                )
+
+            with self.db_manager.get_session() as session:
+                result = RetentionService(session).cleanup(dry_run=False)
+                finished_at = datetime.now(timezone.utc)
+                AppConfigService(session).set_retention_last_run(
+                    RetentionLastRun(
+                        status="success",
+                        started_at=started_at,
+                        finished_at=finished_at,
+                        total_deleted=result.total_deleted,
+                        dry_run=False,
+                        results=result.results,
+                    )
+                )
+                logger.info("Automatic retention cleanup deleted %s rows", result.total_deleted)
+                return result
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error("Automatic retention cleanup failed: %s", exc, exc_info=True)
+            with self.db_manager.get_session() as session:
+                AppConfigService(session).set_retention_last_run(
+                    RetentionLastRun(
+                        status="error",
+                        started_at=started_at,
+                        finished_at=datetime.now(timezone.utc),
+                        error=str(exc),
+                    )
+            )
+            return None
+
+    def _run_loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self.run_once_if_due()
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.error("Retention scheduler check failed: %s", exc, exc_info=True)
+            self._stop_event.wait(self.poll_interval_seconds)
+
+    @staticmethod
+    def is_due(frequency: str, run_at: str, last_run: RetentionLastRun, now: datetime) -> bool:
+        """Return whether a schedule is due at the given UTC time."""
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+
+        hour, minute = [int(part) for part in run_at.split(":", 1)]
+        scheduled_today = datetime.combine(now.date(), time(hour=hour, minute=minute), tzinfo=timezone.utc)
+        if now < scheduled_today:
+            return False
+
+        finished_at = last_run.finished_at or last_run.started_at
+        if finished_at is None:
+            return True
+        if finished_at.tzinfo is None:
+            finished_at = finished_at.replace(tzinfo=timezone.utc)
+
+        if frequency == "weekly":
+            return finished_at <= now - timedelta(days=7)
+        return finished_at.date() < now.date()

--- a/agent/services/retention_service.py
+++ b/agent/services/retention_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+import threading
 from typing import Callable, List
 
 from sqlalchemy import and_, not_, select
@@ -23,6 +24,8 @@ from database import (
 )
 from models import DataRetentionConfig, RetentionCleanupResponse, RetentionCleanupResult
 from services.app_config_service import AppConfigService
+
+_cleanup_lock = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -44,33 +47,40 @@ class RetentionService:
         return self.config_service.get_data_retention_config()
 
     def cleanup(self, *, dry_run: bool = False) -> RetentionCleanupResponse:
-        policy = self.get_policy()
-        now = datetime.now(timezone.utc)
-        results: List[RetentionCleanupResult] = []
+        if not _cleanup_lock.acquire(blocking=False):
+            raise RuntimeError("Retention cleanup is already running")
 
-        for target in RETENTION_TARGETS:
-            retention_days = target.retention_days(policy)
-            cutoff = now - timedelta(days=retention_days)
-            deleted = target.apply(self.session, cutoff, dry_run)
-            results.append(
-                RetentionCleanupResult(
-                    key=target.key,
-                    label=target.label,
-                    retention_days=retention_days,
-                    deleted=deleted,
+        try:
+            policy = self.get_policy()
+            now = datetime.now(timezone.utc)
+            results: List[RetentionCleanupResult] = []
+
+            for target in RETENTION_TARGETS:
+                retention_days = target.retention_days(policy)
+                cutoff = now - timedelta(days=retention_days)
+                deleted = target.apply(self.session, cutoff, dry_run)
+                results.append(
+                    RetentionCleanupResult(
+                        key=target.key,
+                        label=target.label,
+                        retention_days=retention_days,
+                        deleted=deleted,
+                    )
                 )
+
+            if dry_run:
+                self.session.rollback()
+            else:
+                self.session.commit()
+
+            return RetentionCleanupResponse(
+                dry_run=dry_run,
+                total_deleted=sum(item.deleted for item in results),
+                policy=policy,
+                results=results,
             )
-
-        if dry_run:
-            self.session.rollback()
-        else:
-            self.session.commit()
-
-        return RetentionCleanupResponse(
-            dry_run=dry_run,
-            total_deleted=sum(item.deleted for item in results),
-            results=results,
-        )
+        finally:
+            _cleanup_lock.release()
 
 
 def _delete_by_datetime(model, column_name: str):

--- a/agent/services/retention_service.py
+++ b/agent/services/retention_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+import logging
 import threading
 from typing import Callable, List
 
@@ -25,6 +26,7 @@ from database import (
 from models import DataRetentionConfig, RetentionCleanupResponse, RetentionCleanupResult
 from services.app_config_service import AppConfigService
 
+logger = logging.getLogger(__name__)
 _cleanup_lock = threading.Lock()
 
 
@@ -54,11 +56,34 @@ class RetentionService:
             policy = self.get_policy()
             now = datetime.now(timezone.utc)
             results: List[RetentionCleanupResult] = []
+            logger.info(
+                "Retention cleanup started: dry_run=%s now=%s "
+                "task_successful_days=%s task_unsuccessful_days=%s worker_events_days=%s "
+                "workflow_executions_days=%s task_daily_stats_days=%s inactive_sessions_days=%s",
+                dry_run,
+                now.isoformat(),
+                policy.task_successful_days,
+                policy.task_unsuccessful_days,
+                policy.worker_events_days,
+                policy.workflow_executions_days,
+                policy.task_daily_stats_days,
+                policy.inactive_sessions_days,
+            )
 
             for target in RETENTION_TARGETS:
                 retention_days = target.retention_days(policy)
                 cutoff = now - timedelta(days=retention_days)
                 deleted = target.apply(self.session, cutoff, dry_run)
+                logger.info(
+                    "Retention cleanup target processed: key=%s label=%s dry_run=%s "
+                    "retention_days=%s cutoff=%s rows=%s",
+                    target.key,
+                    target.label,
+                    dry_run,
+                    retention_days,
+                    cutoff.isoformat(),
+                    deleted,
+                )
                 results.append(
                     RetentionCleanupResult(
                         key=target.key,
@@ -73,12 +98,18 @@ class RetentionService:
             else:
                 self.session.commit()
 
-            return RetentionCleanupResponse(
+            response = RetentionCleanupResponse(
                 dry_run=dry_run,
                 total_deleted=sum(item.deleted for item in results),
                 policy=policy,
                 results=results,
             )
+            logger.info(
+                "Retention cleanup completed: dry_run=%s total_deleted=%s",
+                response.dry_run,
+                response.total_deleted,
+            )
+            return response
         finally:
             _cleanup_lock.release()
 

--- a/agent/tests/unit/test_app_config_service.py
+++ b/agent/tests/unit/test_app_config_service.py
@@ -5,8 +5,11 @@ from services.app_config_service import (
     TASK_ISSUE_LOOKBACK_KEY,
     RETENTION_TASK_SUCCESSFUL_DAYS_KEY,
     RETENTION_TASK_UNSUCCESSFUL_DAYS_KEY,
+    RETENTION_SCHEDULE_ENABLED_KEY,
+    RETENTION_SCHEDULE_FREQUENCY_KEY,
+    RETENTION_SCHEDULE_RUN_AT_KEY,
 )
-from models import AppSettingUpdate
+from models import AppSettingUpdate, RetentionLastRun
 from tests.base import DatabaseTestCase
 from database import AppSettingDB
 
@@ -60,6 +63,47 @@ class TestAppConfigService(DatabaseTestCase):
         self.assertEqual(updated.task_successful_days, 7)
         self.assertEqual(updated.task_unsuccessful_days, 45)
 
+    def test_get_retention_schedule_uses_defaults_and_overrides(self):
+        defaults = self.service.get_retention_schedule_config()
+        self.assertFalse(defaults.enabled)
+        self.assertEqual(defaults.frequency, "daily")
+        self.assertEqual(defaults.run_at, "03:00")
+
+        self.service.upsert_setting(
+            RETENTION_SCHEDULE_ENABLED_KEY,
+            AppSettingUpdate(value=True, value_type="boolean"),
+        )
+        self.service.upsert_setting(
+            RETENTION_SCHEDULE_FREQUENCY_KEY,
+            AppSettingUpdate(value="weekly", value_type="string"),
+        )
+        self.service.upsert_setting(
+            RETENTION_SCHEDULE_RUN_AT_KEY,
+            AppSettingUpdate(value="04:30", value_type="string"),
+        )
+
+        updated = self.service.get_retention_schedule_config()
+        self.assertTrue(updated.enabled)
+        self.assertEqual(updated.frequency, "weekly")
+        self.assertEqual(updated.run_at, "04:30")
+
+    def test_retention_schedule_rejects_invalid_values(self):
+        with self.assertRaises(ValueError):
+            self.service.upsert_setting(
+                RETENTION_SCHEDULE_FREQUENCY_KEY,
+                AppSettingUpdate(value="hourly", value_type="string"),
+            )
+        with self.assertRaises(ValueError):
+            self.service.upsert_setting(
+                RETENTION_SCHEDULE_RUN_AT_KEY,
+                AppSettingUpdate(value="25:00", value_type="string"),
+            )
+
+    def test_retention_last_run_round_trips(self):
+        self.service.set_retention_last_run(RetentionLastRun(status="success", total_deleted=3))
+        last_run = self.service.get_retention_last_run()
+        self.assertEqual(last_run.status, "success")
+        self.assertEqual(last_run.total_deleted, 3)
 
 if __name__ == "__main__":
     unittest.main()

--- a/agent/tests/unit/test_app_config_service.py
+++ b/agent/tests/unit/test_app_config_service.py
@@ -6,8 +6,11 @@ from services.app_config_service import (
     RETENTION_TASK_SUCCESSFUL_DAYS_KEY,
     RETENTION_TASK_UNSUCCESSFUL_DAYS_KEY,
     RETENTION_SCHEDULE_ENABLED_KEY,
-    RETENTION_SCHEDULE_FREQUENCY_KEY,
-    RETENTION_SCHEDULE_RUN_AT_KEY,
+    RETENTION_SCHEDULE_HOUR_KEY,
+    RETENTION_SCHEDULE_MINUTE_KEY,
+    RETENTION_SCHEDULE_MONTH_DAY_KEY,
+    RETENTION_SCHEDULE_PRESET_KEY,
+    RETENTION_SCHEDULE_WEEKDAY_KEY,
 )
 from models import AppSettingUpdate, RetentionLastRun
 from tests.base import DatabaseTestCase
@@ -66,37 +69,67 @@ class TestAppConfigService(DatabaseTestCase):
     def test_get_retention_schedule_uses_defaults_and_overrides(self):
         defaults = self.service.get_retention_schedule_config()
         self.assertFalse(defaults.enabled)
-        self.assertEqual(defaults.frequency, "daily")
-        self.assertEqual(defaults.run_at, "03:00")
+        self.assertEqual(defaults.preset, "daily")
+        self.assertEqual(defaults.hour, 3)
+        self.assertEqual(defaults.minute, 0)
+        self.assertEqual(defaults.weekday, 0)
+        self.assertEqual(defaults.month_day, 1)
+        self.assertEqual(defaults.timezone, "UTC")
 
         self.service.upsert_setting(
             RETENTION_SCHEDULE_ENABLED_KEY,
             AppSettingUpdate(value=True, value_type="boolean"),
         )
         self.service.upsert_setting(
-            RETENTION_SCHEDULE_FREQUENCY_KEY,
+            RETENTION_SCHEDULE_PRESET_KEY,
             AppSettingUpdate(value="weekly", value_type="string"),
         )
         self.service.upsert_setting(
-            RETENTION_SCHEDULE_RUN_AT_KEY,
-            AppSettingUpdate(value="04:30", value_type="string"),
+            RETENTION_SCHEDULE_HOUR_KEY,
+            AppSettingUpdate(value=4, value_type="number"),
+        )
+        self.service.upsert_setting(
+            RETENTION_SCHEDULE_MINUTE_KEY,
+            AppSettingUpdate(value=30, value_type="number"),
+        )
+        self.service.upsert_setting(
+            RETENTION_SCHEDULE_WEEKDAY_KEY,
+            AppSettingUpdate(value=2, value_type="number"),
+        )
+        self.service.upsert_setting(
+            RETENTION_SCHEDULE_MONTH_DAY_KEY,
+            AppSettingUpdate(value=16, value_type="number"),
         )
 
         updated = self.service.get_retention_schedule_config()
         self.assertTrue(updated.enabled)
-        self.assertEqual(updated.frequency, "weekly")
-        self.assertEqual(updated.run_at, "04:30")
+        self.assertEqual(updated.preset, "weekly")
+        self.assertEqual(updated.hour, 4)
+        self.assertEqual(updated.minute, 30)
+        self.assertEqual(updated.weekday, 2)
+        self.assertEqual(updated.month_day, 16)
+
+    def test_automatic_retention_cleanup_defaults_to_disabled_for_new_users(self):
+        setting = (
+            self.session.query(AppSettingDB)
+            .filter_by(key=RETENTION_SCHEDULE_ENABLED_KEY)
+            .first()
+        )
+        self.assertIsNotNone(setting)
+        self.assertIs(setting.value, False)
+        self.assertEqual(setting.value_type, "boolean")
+        self.assertFalse(self.service.get_retention_schedule_config().enabled)
 
     def test_retention_schedule_rejects_invalid_values(self):
         with self.assertRaises(ValueError):
             self.service.upsert_setting(
-                RETENTION_SCHEDULE_FREQUENCY_KEY,
-                AppSettingUpdate(value="hourly", value_type="string"),
+                RETENTION_SCHEDULE_PRESET_KEY,
+                AppSettingUpdate(value="yearly", value_type="string"),
             )
         with self.assertRaises(ValueError):
             self.service.upsert_setting(
-                RETENTION_SCHEDULE_RUN_AT_KEY,
-                AppSettingUpdate(value="25:00", value_type="string"),
+                RETENTION_SCHEDULE_HOUR_KEY,
+                AppSettingUpdate(value=24, value_type="number"),
             )
 
     def test_retention_last_run_round_trips(self):

--- a/agent/tests/unit/test_retention_scheduler_service.py
+++ b/agent/tests/unit/test_retention_scheduler_service.py
@@ -1,0 +1,36 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from models import RetentionLastRun
+from services.retention_scheduler_service import RetentionSchedulerService
+
+
+class TestRetentionSchedulerService(unittest.TestCase):
+    def test_daily_schedule_is_due_after_run_time_when_not_run_today(self):
+        now = datetime(2026, 5, 16, 4, 0, tzinfo=timezone.utc)
+        last_run = RetentionLastRun(
+            status="success",
+            finished_at=now - timedelta(days=1),
+            total_deleted=0,
+        )
+
+        self.assertTrue(RetentionSchedulerService.is_due("daily", "03:00", last_run, now))
+
+    def test_daily_schedule_is_not_due_before_run_time(self):
+        now = datetime(2026, 5, 16, 2, 59, tzinfo=timezone.utc)
+
+        self.assertFalse(RetentionSchedulerService.is_due("daily", "03:00", RetentionLastRun(), now))
+
+    def test_weekly_schedule_waits_seven_days(self):
+        now = datetime(2026, 5, 16, 4, 0, tzinfo=timezone.utc)
+        last_run = RetentionLastRun(
+            status="success",
+            finished_at=now - timedelta(days=6, hours=23),
+            total_deleted=0,
+        )
+
+        self.assertFalse(RetentionSchedulerService.is_due("weekly", "03:00", last_run, now))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent/tests/unit/test_retention_scheduler_service.py
+++ b/agent/tests/unit/test_retention_scheduler_service.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import datetime, timedelta, timezone
 
-from models import RetentionLastRun
+from models import RetentionLastRun, RetentionScheduleConfig
 from services.retention_scheduler_service import RetentionSchedulerService
 
 
@@ -14,22 +14,76 @@ class TestRetentionSchedulerService(unittest.TestCase):
             total_deleted=0,
         )
 
-        self.assertTrue(RetentionSchedulerService.is_due("daily", "03:00", last_run, now))
+        schedule = RetentionScheduleConfig(preset="daily", hour=3, minute=0)
+        self.assertTrue(RetentionSchedulerService.is_due(schedule, last_run, now))
 
     def test_daily_schedule_is_not_due_before_run_time(self):
         now = datetime(2026, 5, 16, 2, 59, tzinfo=timezone.utc)
+        schedule = RetentionScheduleConfig(preset="daily", hour=3, minute=0)
 
-        self.assertFalse(RetentionSchedulerService.is_due("daily", "03:00", RetentionLastRun(), now))
+        self.assertFalse(RetentionSchedulerService.is_due(schedule, RetentionLastRun(), now))
 
-    def test_weekly_schedule_waits_seven_days(self):
+    def test_daily_schedule_runs_only_once_per_scheduled_time(self):
         now = datetime(2026, 5, 16, 4, 0, tzinfo=timezone.utc)
         last_run = RetentionLastRun(
             status="success",
-            finished_at=now - timedelta(days=6, hours=23),
+            finished_at=datetime(2026, 5, 16, 3, 1, tzinfo=timezone.utc),
             total_deleted=0,
         )
+        schedule = RetentionScheduleConfig(preset="daily", hour=3, minute=0)
 
-        self.assertFalse(RetentionSchedulerService.is_due("weekly", "03:00", last_run, now))
+        self.assertFalse(RetentionSchedulerService.is_due(schedule, last_run, now))
+
+    def test_hourly_schedule_is_due_after_minute_when_not_run_this_hour(self):
+        now = datetime(2026, 5, 16, 4, 43, tzinfo=timezone.utc)
+        last_run = RetentionLastRun(
+            status="success",
+            finished_at=datetime(2026, 5, 16, 3, 50, tzinfo=timezone.utc),
+            total_deleted=0,
+        )
+        schedule = RetentionScheduleConfig(preset="hourly", minute=30)
+
+        self.assertTrue(RetentionSchedulerService.is_due(schedule, last_run, now))
+
+    def test_hourly_schedule_is_not_due_before_minute(self):
+        now = datetime(2026, 5, 16, 4, 29, tzinfo=timezone.utc)
+        schedule = RetentionScheduleConfig(preset="hourly", minute=30)
+
+        self.assertFalse(RetentionSchedulerService.is_due(schedule, RetentionLastRun(), now))
+
+    def test_weekly_schedule_requires_matching_weekday(self):
+        now = datetime(2026, 5, 16, 4, 0, tzinfo=timezone.utc)  # Saturday
+        schedule = RetentionScheduleConfig(preset="weekly", weekday=0, hour=3, minute=0)
+
+        self.assertFalse(RetentionSchedulerService.is_due(schedule, RetentionLastRun(), now))
+
+    def test_weekly_schedule_is_due_on_matching_weekday_after_time(self):
+        now = datetime(2026, 5, 18, 4, 0, tzinfo=timezone.utc)  # Monday
+        last_run = RetentionLastRun(
+            status="success",
+            finished_at=datetime(2026, 5, 11, 3, 1, tzinfo=timezone.utc),
+            total_deleted=0,
+        )
+        schedule = RetentionScheduleConfig(preset="weekly", weekday=0, hour=3, minute=0)
+
+        self.assertTrue(RetentionSchedulerService.is_due(schedule, last_run, now))
+
+    def test_monthly_schedule_is_due_on_configured_day_after_time(self):
+        now = datetime(2026, 5, 16, 4, 0, tzinfo=timezone.utc)
+        last_run = RetentionLastRun(
+            status="success",
+            finished_at=datetime(2026, 4, 16, 3, 1, tzinfo=timezone.utc),
+            total_deleted=0,
+        )
+        schedule = RetentionScheduleConfig(preset="monthly", month_day=16, hour=3, minute=0)
+
+        self.assertTrue(RetentionSchedulerService.is_due(schedule, last_run, now))
+
+    def test_monthly_schedule_clamps_day_to_last_day_of_month(self):
+        now = datetime(2026, 2, 28, 4, 0, tzinfo=timezone.utc)
+        schedule = RetentionScheduleConfig(preset="monthly", month_day=31, hour=3, minute=0)
+
+        self.assertTrue(RetentionSchedulerService.is_due(schedule, RetentionLastRun(), now))
 
 
 if __name__ == "__main__":

--- a/agent/tests/unit/test_retention_service.py
+++ b/agent/tests/unit/test_retention_service.py
@@ -11,7 +11,7 @@ from database import (
     UserSessionDB,
     WorkflowExecutionDB,
 )
-from services.retention_service import RetentionService
+from services.retention_service import RetentionService, _cleanup_lock
 from tests.base import DatabaseTestCase
 
 
@@ -60,6 +60,8 @@ class TestRetentionService(DatabaseTestCase):
         counts = {item.key: item.deleted for item in result.results}
 
         self.assertTrue(result.dry_run)
+        self.assertEqual(result.policy.task_successful_days, 14)
+        self.assertEqual(result.policy.task_unsuccessful_days, 30)
         self.assertEqual(counts["task_events_successful"], 1)
         self.assertEqual(counts["task_events_unsuccessful"], 0)
         self.assertEqual(counts["task_progress_successful"], 1)
@@ -89,6 +91,14 @@ class TestRetentionService(DatabaseTestCase):
         self.assertEqual(self.session.query(TaskProgressDB).count(), 1)
         self.assertEqual(self.session.query(UserSessionDB).count(), 1)
         self.assertGreaterEqual(result.total_deleted, 11)
+
+    def test_cleanup_rejects_overlapping_runs(self):
+        self.assertTrue(_cleanup_lock.acquire(blocking=False))
+        try:
+            with self.assertRaises(RuntimeError):
+                self.service.cleanup(dry_run=True)
+        finally:
+            _cleanup_lock.release()
 
 
 if __name__ == "__main__":

--- a/frontend/app/components/ui/input/Input.vue
+++ b/frontend/app/components/ui/input/Input.vue
@@ -1,10 +1,12 @@
 <template>
   <input
+    :value="model"
     :class="cn(
       'flex h-9 w-full rounded-md border border-border-subtle bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30 disabled:cursor-not-allowed disabled:opacity-50',
       props.class
     )"
     v-bind="$attrs"
+    @input="handleInput"
   />
 </template>
 
@@ -18,4 +20,17 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   class: ''
 })
+
+const [model, modifiers] = defineModel<string | number>({
+  set(value) {
+    if (modifiers.number) {
+      return value === '' ? '' : Number(value)
+    }
+    return value
+  },
+})
+
+function handleInput(event: Event) {
+  model.value = (event.target as HTMLInputElement).value
+}
 </script>

--- a/frontend/app/components/ui/input/Input.vue
+++ b/frontend/app/components/ui/input/Input.vue
@@ -24,7 +24,11 @@ const props = withDefaults(defineProps<Props>(), {
 const [model, modifiers] = defineModel<string | number>({
   set(value) {
     if (modifiers.number) {
-      return value === '' ? '' : Number(value)
+      if (value === '') {
+        return ''
+      }
+      const parsedValue = Number.parseFloat(String(value))
+      return Number.isNaN(parsedValue) ? value : parsedValue
     }
     return value
   },

--- a/frontend/app/pages/settings/workspace.vue
+++ b/frontend/app/pages/settings/workspace.vue
@@ -51,15 +51,15 @@
 
             <div class="md:col-span-3 grid gap-4 border-t border-border-subtle pt-4 md:grid-cols-3">
               <label
+                for="automatic-cleanup"
                 class="flex items-center gap-3 text-sm text-text-primary"
-                @click.prevent="toggleScheduleEnabled"
               >
                 <input
-                  :checked="scheduleEnabled"
+                  id="automatic-cleanup"
+                  v-model="scheduleEnabled"
                   type="checkbox"
                   class="h-4 w-4 rounded border-border-subtle text-brand-primary focus:ring-brand-primary"
                   :disabled="isSaving || isLoading"
-                  readonly
                 />
                 Automatic cleanup
               </label>
@@ -301,13 +301,6 @@ function resetRetentionForm() {
   syncFormFromStore()
   saveMessage.value = ''
   saveStatus.value = ''
-}
-
-function toggleScheduleEnabled() {
-  if (isSaving.value || isLoading.value) {
-    return
-  }
-  scheduleEnabled.value = !scheduleEnabled.value
 }
 
 async function saveRetention() {

--- a/frontend/app/pages/settings/workspace.vue
+++ b/frontend/app/pages/settings/workspace.vue
@@ -49,60 +49,93 @@
               <p class="text-xs text-text-secondary">{{ field.description }}</p>
             </div>
 
-            <div class="md:col-span-3 grid gap-4 border-t border-border-subtle pt-4 md:grid-cols-3">
-              <label
-                for="automatic-cleanup"
-                class="flex items-center gap-3 text-sm text-text-primary"
-              >
-                <input
-                  id="automatic-cleanup"
-                  v-model="scheduleEnabled"
-                  type="checkbox"
-                  class="h-4 w-4 rounded border-border-subtle text-brand-primary focus:ring-brand-primary"
-                  :disabled="isSaving || isLoading"
-                />
-                Automatic cleanup
-              </label>
-              <div class="space-y-2">
-                <Label for="cleanup-frequency">Frequency</Label>
-                <select
-                  id="cleanup-frequency"
-                  v-model="scheduleForm.frequency"
-                  class="w-full rounded-lg border border-border-subtle bg-background-surface px-3 py-2 text-sm text-text-primary focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/20"
-                  :disabled="isSaving || isLoading || !scheduleEnabled"
-                >
-                  <option value="daily">Daily</option>
-                  <option value="weekly">Weekly</option>
-                </select>
-              </div>
-              <div class="space-y-2">
-                <Label>Run time (UTC)</Label>
-                <div class="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-end gap-2">
-                  <div class="space-y-1">
-                    <Label for="cleanup-run-hour" class="text-xs text-text-secondary">Hour</Label>
+            <div class="md:col-span-3 border-t border-border-subtle pt-4">
+              <div class="space-y-4 rounded-lg border border-border-subtle bg-background-subtle p-4">
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                  <label
+                    for="automatic-cleanup"
+                    class="flex items-center gap-3 text-sm font-medium text-text-primary"
+                  >
+                    <input
+                      id="automatic-cleanup"
+                      v-model="scheduleEnabled"
+                      type="checkbox"
+                      class="h-4 w-4 rounded border-border-subtle text-brand-primary focus:ring-brand-primary"
+                      :disabled="isSaving || isLoading"
+                    />
+                    Automatic cleanup
+                  </label>
+                  <p class="text-xs text-text-secondary">{{ scheduleSummary }}</p>
+                </div>
+
+                <div class="grid gap-4 md:grid-cols-4">
+                  <div class="space-y-2">
+                    <Label for="cleanup-schedule">Schedule</Label>
                     <select
-                      id="cleanup-run-hour"
-                      v-model="runAtHour"
+                      id="cleanup-schedule"
+                      v-model="scheduleForm.preset"
                       class="w-full rounded-lg border border-border-subtle bg-background-surface px-3 py-2 text-sm text-text-primary focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/20"
                       :disabled="isSaving || isLoading || !scheduleEnabled"
                     >
-                      <option v-for="hour in hourOptions" :key="hour" :value="hour">{{ hour }}</option>
+                      <option value="hourly">Hourly</option>
+                      <option value="daily">Daily</option>
+                      <option value="weekly">Weekly</option>
+                      <option value="monthly">Monthly</option>
                     </select>
                   </div>
-                  <span class="pb-2 text-sm font-medium text-text-secondary">:</span>
-                  <div class="space-y-1">
-                    <Label for="cleanup-run-minute" class="text-xs text-text-secondary">Minute</Label>
+
+                  <div v-if="scheduleForm.preset === 'weekly'" class="space-y-2">
+                    <Label for="cleanup-run-weekday">Weekday</Label>
                     <select
-                      id="cleanup-run-minute"
-                      v-model="runAtMinute"
+                      id="cleanup-run-weekday"
+                      v-model.number="scheduleForm.weekday"
                       class="w-full rounded-lg border border-border-subtle bg-background-surface px-3 py-2 text-sm text-text-primary focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/20"
                       :disabled="isSaving || isLoading || !scheduleEnabled"
                     >
-                      <option v-for="minute in minuteOptions" :key="minute" :value="minute">{{ minute }}</option>
+                      <option v-for="day in weekdayOptions" :key="day.value" :value="day.value">{{ day.label }}</option>
+                    </select>
+                  </div>
+
+                  <div v-if="scheduleForm.preset === 'monthly'" class="space-y-2">
+                    <Label for="cleanup-run-month-day">Day of month</Label>
+                    <select
+                      id="cleanup-run-month-day"
+                      v-model.number="scheduleForm.month_day"
+                      class="w-full rounded-lg border border-border-subtle bg-background-surface px-3 py-2 text-sm text-text-primary focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/20"
+                      :disabled="isSaving || isLoading || !scheduleEnabled"
+                    >
+                      <option v-for="day in monthDayOptions" :key="day" :value="day">{{ day }}</option>
+                    </select>
+                  </div>
+
+                  <div v-if="scheduleForm.preset !== 'hourly'" class="space-y-2">
+                    <Label for="cleanup-run-hour">Hour</Label>
+                    <select
+                      id="cleanup-run-hour"
+                      v-model.number="scheduleForm.hour"
+                      class="w-full rounded-lg border border-border-subtle bg-background-surface px-3 py-2 text-sm text-text-primary focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/20"
+                      :disabled="isSaving || isLoading || !scheduleEnabled"
+                    >
+                      <option v-for="hour in hourOptions" :key="hour" :value="hour">{{ formatTwoDigit(hour) }}</option>
+                    </select>
+                  </div>
+
+                  <div class="space-y-2">
+                    <Label for="cleanup-run-minute">Minute</Label>
+                    <select
+                      id="cleanup-run-minute"
+                      v-model.number="scheduleForm.minute"
+                      class="w-full rounded-lg border border-border-subtle bg-background-surface px-3 py-2 text-sm text-text-primary focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/20"
+                      :disabled="isSaving || isLoading || !scheduleEnabled"
+                    >
+                      <option v-for="minute in minuteOptions" :key="minute" :value="minute">{{ formatTwoDigit(minute) }}</option>
                     </select>
                   </div>
                 </div>
-                <p class="text-xs text-text-secondary">24-hour UTC time: {{ scheduleForm.run_at }}</p>
+
+                <p v-if="scheduleForm.preset === 'monthly'" class="text-xs text-text-secondary">
+                  Days past the end of a month run on that month's final day.
+                </p>
               </div>
             </div>
 
@@ -174,7 +207,7 @@
                     </tr>
                   </thead>
                   <tbody>
-                    <tr v-for="result in cleanupResult.results" :key="result.key" class="border-b border-border-subtle/60 last:border-0">
+                    <tr v-for="result in cleanupResult.results" :key="result.key" class="border-b border-border-subtle last:border-0">
                       <td class="py-2 pr-4 text-text-primary">{{ result.label }}</td>
                       <td class="py-2 pr-4 text-text-secondary">{{ result.retention_days }}</td>
                       <td class="py-2 text-text-secondary">{{ result.deleted }}</td>
@@ -278,8 +311,12 @@ const retentionForm = reactive<DataRetentionConfigDTO>({
 })
 const scheduleForm = reactive<RetentionScheduleConfigDTO>({
   enabled: false,
-  frequency: 'daily',
-  run_at: '03:00',
+  preset: 'daily',
+  hour: 3,
+  minute: 0,
+  weekday: 0,
+  month_day: 1,
+  timezone: 'UTC',
 })
 const scheduleEnabled = ref(false)
 const isSaving = ref(false)
@@ -289,29 +326,37 @@ const cleanupRunning = ref(false)
 const cleanupMode = ref<'dry' | 'live' | null>(null)
 const cleanupResult = ref<RetentionCleanupResponseDTO | null>(null)
 const cleanupError = ref('')
-const hourOptions = Array.from({ length: 24 }, (_, index) => String(index).padStart(2, '0'))
-const minuteOptions = Array.from({ length: 60 }, (_, index) => String(index).padStart(2, '0'))
+const savedRetentionSnapshot = ref('')
+const savedScheduleSnapshot = ref('')
+const hourOptions = Array.from({ length: 24 }, (_, index) => index)
+const minuteOptions = Array.from({ length: 60 }, (_, index) => index)
+const monthDayOptions = Array.from({ length: 31 }, (_, index) => index + 1)
+const weekdayOptions = [
+  { value: 0, label: 'Monday' },
+  { value: 1, label: 'Tuesday' },
+  { value: 2, label: 'Wednesday' },
+  { value: 3, label: 'Thursday' },
+  { value: 4, label: 'Friday' },
+  { value: 5, label: 'Saturday' },
+  { value: 6, label: 'Sunday' },
+]
 
 const isLoading = computed(() => configStore.isLoading)
 const loadError = computed(() => configStore.error)
-const runAtParts = computed(() => {
-  const match = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(scheduleForm.run_at ?? '')
-  return {
-    hour: match?.[1] ?? '03',
-    minute: match?.[2] ?? '00',
+const scheduleSummary = computed(() => {
+  const minute = formatTwoDigit(scheduleForm.minute ?? 0)
+  const time = `${formatTwoDigit(scheduleForm.hour ?? 0)}:${minute}`
+  if (scheduleForm.preset === 'hourly') {
+    return `Runs every hour at minute ${minute} UTC.`
   }
-})
-const runAtHour = computed({
-  get: () => runAtParts.value.hour,
-  set: (hour: string) => {
-    scheduleForm.run_at = `${hour}:${runAtParts.value.minute}`
-  },
-})
-const runAtMinute = computed({
-  get: () => runAtParts.value.minute,
-  set: (minute: string) => {
-    scheduleForm.run_at = `${runAtParts.value.hour}:${minute}`
-  },
+  if (scheduleForm.preset === 'weekly') {
+    const weekday = weekdayOptions.find(day => day.value === scheduleForm.weekday)?.label ?? 'Monday'
+    return `Runs every ${weekday} at ${time} UTC.`
+  }
+  if (scheduleForm.preset === 'monthly') {
+    return `Runs on day ${scheduleForm.month_day ?? 1} of each month at ${time} UTC.`
+  }
+  return `Runs daily at ${time} UTC.`
 })
 const retentionLastRunSummary = computed(() => {
   const lastRun = configStore.retentionLastRun
@@ -328,20 +373,79 @@ const retentionLastRunSummary = computed(() => {
   return `${lastRun.total_deleted} rows removed at ${finishedAt}`
 })
 const hasUnsavedChanges = computed(() => {
-  return JSON.stringify(retentionForm) !== JSON.stringify(configStore.dataRetention)
-    || JSON.stringify({ ...scheduleForm, enabled: scheduleEnabled.value }) !== JSON.stringify(configStore.retentionSchedule)
+  return retentionSnapshot() !== savedRetentionSnapshot.value
+    || scheduleSnapshot() !== savedScheduleSnapshot.value
 })
 
 function syncFormFromStore() {
   Object.assign(retentionForm, configStore.dataRetention)
+  retentionForm.workflow_executions_days = retentionForm.worker_events_days
   Object.assign(scheduleForm, configStore.retentionSchedule)
   scheduleEnabled.value = configStore.retentionSchedule.enabled
+  markFormSaved()
 }
 
 function resetRetentionForm() {
   syncFormFromStore()
   saveMessage.value = ''
   saveStatus.value = ''
+}
+
+function formatTwoDigit(value: number) {
+  return String(value).padStart(2, '0')
+}
+
+function normalizeRetentionConfig(config: DataRetentionConfigDTO): Required<DataRetentionConfigDTO> {
+  const workerEventsDays = Number(config.worker_events_days ?? 30)
+  return {
+    task_successful_days: Number(config.task_successful_days ?? 14),
+    task_unsuccessful_days: Number(config.task_unsuccessful_days ?? 30),
+    worker_events_days: workerEventsDays,
+    workflow_executions_days: workerEventsDays,
+    task_daily_stats_days: Number(config.task_daily_stats_days ?? 365),
+    inactive_sessions_days: Number(config.inactive_sessions_days ?? 30),
+  }
+}
+
+function normalizeScheduleConfig(config: RetentionScheduleConfigDTO): Record<string, boolean | number | string> {
+  const enabled = Boolean(config.enabled)
+  const preset = config.preset ?? 'daily'
+  const normalized: Record<string, boolean | number | string> = {
+    enabled,
+  }
+
+  if (!enabled) {
+    return normalized
+  }
+
+  normalized.preset = preset
+  normalized.minute = Number(config.minute ?? 0)
+  normalized.timezone = config.timezone ?? 'UTC'
+
+  if (preset !== 'hourly') {
+    normalized.hour = Number(config.hour ?? 3)
+  }
+  if (preset === 'weekly') {
+    normalized.weekday = Number(config.weekday ?? 0)
+  }
+  if (preset === 'monthly') {
+    normalized.month_day = Number(config.month_day ?? 1)
+  }
+
+  return normalized
+}
+
+function retentionSnapshot() {
+  return JSON.stringify(normalizeRetentionConfig(retentionForm))
+}
+
+function scheduleSnapshot() {
+  return JSON.stringify(normalizeScheduleConfig({ ...scheduleForm, enabled: scheduleEnabled.value }))
+}
+
+function markFormSaved() {
+  savedRetentionSnapshot.value = retentionSnapshot()
+  savedScheduleSnapshot.value = scheduleSnapshot()
 }
 
 async function saveRetention() {
@@ -354,7 +458,7 @@ async function saveRetention() {
       workflow_executions_days: retentionForm.worker_events_days,
     })
     await configStore.updateRetentionSchedule({ ...scheduleForm, enabled: scheduleEnabled.value })
-    syncFormFromStore()
+    markFormSaved()
     saveMessage.value = 'Retention settings saved.'
     saveStatus.value = 'success'
   } catch (err) {
@@ -396,9 +500,5 @@ onMounted(async () => {
     await configStore.fetchConfig()
   }
   syncFormFromStore()
-})
-
-definePageMeta({
-  middleware: [],
 })
 </script>

--- a/frontend/app/pages/settings/workspace.vue
+++ b/frontend/app/pages/settings/workspace.vue
@@ -35,7 +35,7 @@
             <span>{{ loadError }}</span>
           </Alert>
 
-          <form class="grid gap-4 md:grid-cols-2" @submit.prevent="saveRetention">
+          <form class="grid gap-4 md:grid-cols-3" @submit.prevent="saveRetention">
             <div v-for="field in retentionFields" :key="field.key" class="space-y-2">
               <Label :for="field.key">{{ field.label }}</Label>
               <Input
@@ -49,14 +49,47 @@
               <p class="text-xs text-text-secondary">{{ field.description }}</p>
             </div>
 
-            <div class="md:col-span-2 flex flex-wrap items-center gap-3 pt-2">
+            <div class="md:col-span-3 grid gap-4 border-t border-border-subtle pt-4 md:grid-cols-3">
+              <label class="flex items-center gap-3 text-sm text-text-primary">
+                <input
+                  v-model="scheduleForm.enabled"
+                  type="checkbox"
+                  class="h-4 w-4 rounded border-border-subtle text-brand-primary focus:ring-brand-primary"
+                  :disabled="isSaving || isLoading"
+                />
+                Automatic cleanup
+              </label>
+              <div class="space-y-2">
+                <Label for="cleanup-frequency">Frequency</Label>
+                <select
+                  id="cleanup-frequency"
+                  v-model="scheduleForm.frequency"
+                  class="w-full rounded-lg border border-border-subtle bg-background-surface px-3 py-2 text-sm text-text-primary focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/20"
+                  :disabled="isSaving || isLoading || !scheduleForm.enabled"
+                >
+                  <option value="daily">Daily</option>
+                  <option value="weekly">Weekly</option>
+                </select>
+              </div>
+              <div class="space-y-2">
+                <Label for="cleanup-run-at">Run time (UTC)</Label>
+                <Input
+                  id="cleanup-run-at"
+                  v-model="scheduleForm.run_at"
+                  type="time"
+                  :disabled="isSaving || isLoading || !scheduleForm.enabled"
+                />
+              </div>
+            </div>
+
+            <div class="md:col-span-3 flex flex-wrap items-center gap-3 pt-2">
               <Button type="submit" :disabled="isSaving || isLoading">
                 {{ isSaving ? 'Saving…' : 'Save retention settings' }}
               </Button>
               <Button type="button" variant="outline" :disabled="isSaving || isLoading" @click="resetRetentionForm">
                 Reset
               </Button>
-              <span v-if="saveMessage" class="text-sm text-text-secondary">{{ saveMessage }}</span>
+              <span v-if="saveMessage" :class="['text-sm', saveStatus === 'error' ? 'text-red-500' : 'text-text-secondary']">{{ saveMessage }}</span>
             </div>
           </form>
 
@@ -64,12 +97,15 @@
             <div>
               <h3 class="text-sm font-semibold text-text-primary">Cleanup</h3>
               <p class="mt-1 text-sm text-text-secondary">
-                Preview what would be removed, then run cleanup when you are ready.
+                Preview cleanup using the persisted backend policy, then run cleanup when you are ready.
+              </p>
+              <p class="mt-2 text-xs text-text-secondary">
+                Last automatic cleanup: {{ retentionLastRunSummary }}
               </p>
             </div>
 
             <div class="flex flex-wrap items-center gap-3">
-              <Button variant="outline" :disabled="cleanupRunning" @click="previewCleanup">
+              <Button variant="outline" :disabled="cleanupRunning || hasUnsavedChanges" @click="previewCleanup">
                 {{ cleanupRunning && cleanupMode === 'dry' ? 'Running preview…' : 'Preview cleanup' }}
               </Button>
               <ConfirmationDialog
@@ -82,11 +118,12 @@
                 @confirm="runCleanup"
               >
                 <template #trigger>
-                  <Button :disabled="cleanupRunning">
+                  <Button :disabled="cleanupRunning || hasUnsavedChanges">
                     {{ cleanupRunning && cleanupMode === 'live' ? 'Running cleanup…' : 'Run cleanup now' }}
                   </Button>
                 </template>
               </ConfirmationDialog>
+              <span v-if="hasUnsavedChanges" class="text-sm text-text-secondary">Save changes before previewing cleanup.</span>
             </div>
 
             <Alert v-if="cleanupError" variant="destructive">
@@ -97,6 +134,11 @@
               <p class="text-sm text-text-primary">
                 {{ cleanupResult.dry_run ? 'Preview' : 'Cleanup complete' }} — {{ cleanupResult.total_deleted }} rows
                 {{ cleanupResult.dry_run ? 'would be removed' : 'removed' }}.
+              </p>
+              <p class="text-xs text-text-secondary">
+                Backend policy used: successful task history {{ cleanupResult.policy.task_successful_days }} days,
+                failed task history {{ cleanupResult.policy.task_unsuccessful_days }} days,
+                operational logs {{ cleanupResult.policy.worker_events_days }} days.
               </p>
               <div class="overflow-x-auto">
                 <table class="min-w-full text-sm">
@@ -180,40 +222,25 @@ import { Button } from '~/components/ui/button'
 import { Input } from '~/components/ui/input'
 import { Label } from '~/components/ui/label'
 import { useConfigStore } from '~/stores/config'
-import type { DataRetentionConfigDTO, RetentionCleanupResponseDTO } from '~/services/apiClient'
+import type { DataRetentionConfigDTO, RetentionCleanupResponseDTO, RetentionScheduleConfigDTO } from '~/services/apiClient'
 
 const configStore = useConfigStore()
 
 const retentionFields: Array<{ key: keyof DataRetentionConfigDTO; label: string; description: string }> = [
   {
     key: 'task_successful_days',
-    label: 'Successful tasks',
+    label: 'Successful task history',
     description: 'How long to keep successful task snapshots, events, progress, and steps.',
   },
   {
     key: 'task_unsuccessful_days',
-    label: 'Unsuccessful tasks',
+    label: 'Failed task history',
     description: 'How long to keep failed, retried, revoked, or orphaned task history.',
   },
   {
     key: 'worker_events_days',
-    label: 'Worker events',
-    description: 'How long to keep worker lifecycle and status events.',
-  },
-  {
-    key: 'workflow_executions_days',
-    label: 'Workflow executions',
-    description: 'How long to keep workflow execution records.',
-  },
-  {
-    key: 'task_daily_stats_days',
-    label: 'Daily task stats',
-    description: 'How long to keep aggregated daily task statistics.',
-  },
-  {
-    key: 'inactive_sessions_days',
-    label: 'Inactive sessions',
-    description: 'How long to keep inactive anonymous sessions before cleanup.',
+    label: 'Operational logs',
+    description: 'How long to keep worker events and workflow execution records.',
   },
 ]
 
@@ -225,8 +252,14 @@ const retentionForm = ref<DataRetentionConfigDTO>({
   task_daily_stats_days: 365,
   inactive_sessions_days: 30,
 })
+const scheduleForm = ref<RetentionScheduleConfigDTO>({
+  enabled: false,
+  frequency: 'daily',
+  run_at: '03:00',
+})
 const isSaving = ref(false)
 const saveMessage = ref('')
+const saveStatus = ref<'success' | 'error' | ''>('')
 const cleanupRunning = ref(false)
 const cleanupMode = ref<'dry' | 'live' | null>(null)
 const cleanupResult = ref<RetentionCleanupResponseDTO | null>(null)
@@ -234,30 +267,63 @@ const cleanupError = ref('')
 
 const isLoading = computed(() => configStore.isLoading)
 const loadError = computed(() => configStore.error)
+const retentionLastRunSummary = computed(() => {
+  const lastRun = configStore.retentionLastRun
+  if (lastRun.status === 'never') {
+    return 'never run'
+  }
+  if (lastRun.status === 'running') {
+    return 'running now'
+  }
+  const finishedAt = lastRun.finished_at ? new Date(lastRun.finished_at).toLocaleString() : 'unknown finish time'
+  if (lastRun.status === 'error') {
+    return `failed at ${finishedAt}${lastRun.error ? `: ${lastRun.error}` : ''}`
+  }
+  return `${lastRun.total_deleted} rows removed at ${finishedAt}`
+})
+const hasUnsavedChanges = computed(() => {
+  return JSON.stringify(retentionForm.value) !== JSON.stringify(configStore.dataRetention)
+    || JSON.stringify(scheduleForm.value) !== JSON.stringify(configStore.retentionSchedule)
+})
 
 function syncFormFromStore() {
   retentionForm.value = { ...configStore.dataRetention }
+  scheduleForm.value = { ...configStore.retentionSchedule }
 }
 
 function resetRetentionForm() {
   syncFormFromStore()
   saveMessage.value = ''
+  saveStatus.value = ''
 }
 
 async function saveRetention() {
   try {
     isSaving.value = true
     saveMessage.value = ''
-    await configStore.updateDataRetention(retentionForm.value)
+    saveStatus.value = ''
+    await configStore.updateDataRetention({
+      ...retentionForm.value,
+      workflow_executions_days: retentionForm.value.worker_events_days,
+    })
+    await configStore.updateRetentionSchedule(scheduleForm.value)
+    syncFormFromStore()
     saveMessage.value = 'Retention settings saved.'
+    saveStatus.value = 'success'
   } catch (err) {
     saveMessage.value = err instanceof Error ? err.message : 'Failed to save retention settings.'
+    saveStatus.value = 'error'
   } finally {
     isSaving.value = false
   }
 }
 
 async function executeCleanup(dryRun: boolean) {
+  if (hasUnsavedChanges.value) {
+    cleanupError.value = 'Save retention settings before previewing or running cleanup.'
+    return
+  }
+
   try {
     cleanupRunning.value = true
     cleanupMode.value = dryRun ? 'dry' : 'live'

--- a/frontend/app/pages/settings/workspace.vue
+++ b/frontend/app/pages/settings/workspace.vue
@@ -35,7 +35,7 @@
             <span>{{ loadError }}</span>
           </Alert>
 
-          <form class="grid gap-4 md:grid-cols-2" @submit.prevent="saveRetention">
+          <form class="grid gap-4 md:grid-cols-3" @submit.prevent="saveRetention">
             <div v-for="field in retentionFields" :key="field.key" class="space-y-2">
               <Label :for="field.key">{{ field.label }}</Label>
               <Input
@@ -49,14 +49,51 @@
               <p class="text-xs text-text-secondary">{{ field.description }}</p>
             </div>
 
-            <div class="md:col-span-2 flex flex-wrap items-center gap-3 pt-2">
+            <div class="md:col-span-3 grid gap-4 border-t border-border-subtle pt-4 md:grid-cols-3">
+              <label
+                class="flex items-center gap-3 text-sm text-text-primary"
+                @click.prevent="toggleScheduleEnabled"
+              >
+                <input
+                  :checked="scheduleEnabled"
+                  type="checkbox"
+                  class="h-4 w-4 rounded border-border-subtle text-brand-primary focus:ring-brand-primary"
+                  :disabled="isSaving || isLoading"
+                  readonly
+                />
+                Automatic cleanup
+              </label>
+              <div class="space-y-2">
+                <Label for="cleanup-frequency">Frequency</Label>
+                <select
+                  id="cleanup-frequency"
+                  v-model="scheduleForm.frequency"
+                  class="w-full rounded-lg border border-border-subtle bg-background-surface px-3 py-2 text-sm text-text-primary focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/20"
+                  :disabled="isSaving || isLoading || !scheduleEnabled"
+                >
+                  <option value="daily">Daily</option>
+                  <option value="weekly">Weekly</option>
+                </select>
+              </div>
+              <div class="space-y-2">
+                <Label for="cleanup-run-at">Run time (UTC)</Label>
+                <Input
+                  id="cleanup-run-at"
+                  v-model="scheduleForm.run_at"
+                  type="time"
+                  :disabled="isSaving || isLoading || !scheduleEnabled"
+                />
+              </div>
+            </div>
+
+            <div class="md:col-span-3 flex flex-wrap items-center gap-3 pt-2">
               <Button type="submit" :disabled="isSaving || isLoading">
                 {{ isSaving ? 'Saving…' : 'Save retention settings' }}
               </Button>
               <Button type="button" variant="outline" :disabled="isSaving || isLoading" @click="resetRetentionForm">
                 Reset
               </Button>
-              <span v-if="saveMessage" class="text-sm text-text-secondary">{{ saveMessage }}</span>
+              <span v-if="saveMessage" :class="['text-sm', saveStatus === 'error' ? 'text-red-500' : 'text-text-secondary']">{{ saveMessage }}</span>
             </div>
           </form>
 
@@ -64,12 +101,15 @@
             <div>
               <h3 class="text-sm font-semibold text-text-primary">Cleanup</h3>
               <p class="mt-1 text-sm text-text-secondary">
-                Preview what would be removed, then run cleanup when you are ready.
+                Preview cleanup using the persisted backend policy, then run cleanup when you are ready.
+              </p>
+              <p class="mt-2 text-xs text-text-secondary">
+                Last automatic cleanup: {{ retentionLastRunSummary }}
               </p>
             </div>
 
             <div class="flex flex-wrap items-center gap-3">
-              <Button variant="outline" :disabled="cleanupRunning" @click="previewCleanup">
+              <Button variant="outline" :disabled="cleanupRunning || hasUnsavedChanges" @click="previewCleanup">
                 {{ cleanupRunning && cleanupMode === 'dry' ? 'Running preview…' : 'Preview cleanup' }}
               </Button>
               <ConfirmationDialog
@@ -82,11 +122,12 @@
                 @confirm="runCleanup"
               >
                 <template #trigger>
-                  <Button :disabled="cleanupRunning">
+                  <Button :disabled="cleanupRunning || hasUnsavedChanges">
                     {{ cleanupRunning && cleanupMode === 'live' ? 'Running cleanup…' : 'Run cleanup now' }}
                   </Button>
                 </template>
               </ConfirmationDialog>
+              <span v-if="hasUnsavedChanges" class="text-sm text-text-secondary">Save changes before previewing cleanup.</span>
             </div>
 
             <Alert v-if="cleanupError" variant="destructive">
@@ -97,6 +138,11 @@
               <p class="text-sm text-text-primary">
                 {{ cleanupResult.dry_run ? 'Preview' : 'Cleanup complete' }} — {{ cleanupResult.total_deleted }} rows
                 {{ cleanupResult.dry_run ? 'would be removed' : 'removed' }}.
+              </p>
+              <p class="text-xs text-text-secondary">
+                Backend policy used: successful task history {{ cleanupResult.policy.task_successful_days }} days,
+                failed task history {{ cleanupResult.policy.task_unsuccessful_days }} days,
+                operational logs {{ cleanupResult.policy.worker_events_days }} days.
               </p>
               <div class="overflow-x-auto">
                 <table class="min-w-full text-sm">
@@ -171,7 +217,7 @@
 
 <script setup lang="ts">
 import { ArrowUpRight, Github, Sparkles } from 'lucide-vue-next'
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
 import Alert from '~/components/alert/Alert.vue'
 import ConfirmationDialog from '~/components/ConfirmationDialog.vue'
 import ThemeToggle from '~/components/ThemeToggle.vue'
@@ -180,44 +226,29 @@ import { Button } from '~/components/ui/button'
 import { Input } from '~/components/ui/input'
 import { Label } from '~/components/ui/label'
 import { useConfigStore } from '~/stores/config'
-import type { DataRetentionConfigDTO, RetentionCleanupResponseDTO } from '~/services/apiClient'
+import type { DataRetentionConfigDTO, RetentionCleanupResponseDTO, RetentionScheduleConfigDTO } from '~/services/apiClient'
 
 const configStore = useConfigStore()
 
 const retentionFields: Array<{ key: keyof DataRetentionConfigDTO; label: string; description: string }> = [
   {
     key: 'task_successful_days',
-    label: 'Successful tasks',
+    label: 'Successful task history',
     description: 'How long to keep successful task snapshots, events, progress, and steps.',
   },
   {
     key: 'task_unsuccessful_days',
-    label: 'Unsuccessful tasks',
+    label: 'Failed task history',
     description: 'How long to keep failed, retried, revoked, or orphaned task history.',
   },
   {
     key: 'worker_events_days',
-    label: 'Worker events',
-    description: 'How long to keep worker lifecycle and status events.',
-  },
-  {
-    key: 'workflow_executions_days',
-    label: 'Workflow executions',
-    description: 'How long to keep workflow execution records.',
-  },
-  {
-    key: 'task_daily_stats_days',
-    label: 'Daily task stats',
-    description: 'How long to keep aggregated daily task statistics.',
-  },
-  {
-    key: 'inactive_sessions_days',
-    label: 'Inactive sessions',
-    description: 'How long to keep inactive anonymous sessions before cleanup.',
+    label: 'Operational logs',
+    description: 'How long to keep worker events and workflow execution records.',
   },
 ]
 
-const retentionForm = ref<DataRetentionConfigDTO>({
+const retentionForm = reactive<DataRetentionConfigDTO>({
   task_successful_days: 14,
   task_unsuccessful_days: 30,
   worker_events_days: 30,
@@ -225,8 +256,15 @@ const retentionForm = ref<DataRetentionConfigDTO>({
   task_daily_stats_days: 365,
   inactive_sessions_days: 30,
 })
+const scheduleForm = reactive<RetentionScheduleConfigDTO>({
+  enabled: false,
+  frequency: 'daily',
+  run_at: '03:00',
+})
+const scheduleEnabled = ref(false)
 const isSaving = ref(false)
 const saveMessage = ref('')
+const saveStatus = ref<'success' | 'error' | ''>('')
 const cleanupRunning = ref(false)
 const cleanupMode = ref<'dry' | 'live' | null>(null)
 const cleanupResult = ref<RetentionCleanupResponseDTO | null>(null)
@@ -234,30 +272,71 @@ const cleanupError = ref('')
 
 const isLoading = computed(() => configStore.isLoading)
 const loadError = computed(() => configStore.error)
+const retentionLastRunSummary = computed(() => {
+  const lastRun = configStore.retentionLastRun
+  if (lastRun.status === 'never') {
+    return 'never run'
+  }
+  if (lastRun.status === 'running') {
+    return 'running now'
+  }
+  const finishedAt = lastRun.finished_at ? new Date(lastRun.finished_at).toLocaleString() : 'unknown finish time'
+  if (lastRun.status === 'error') {
+    return `failed at ${finishedAt}${lastRun.error ? `: ${lastRun.error}` : ''}`
+  }
+  return `${lastRun.total_deleted} rows removed at ${finishedAt}`
+})
+const hasUnsavedChanges = computed(() => {
+  return JSON.stringify(retentionForm) !== JSON.stringify(configStore.dataRetention)
+    || JSON.stringify({ ...scheduleForm, enabled: scheduleEnabled.value }) !== JSON.stringify(configStore.retentionSchedule)
+})
 
 function syncFormFromStore() {
-  retentionForm.value = { ...configStore.dataRetention }
+  Object.assign(retentionForm, configStore.dataRetention)
+  Object.assign(scheduleForm, configStore.retentionSchedule)
+  scheduleEnabled.value = configStore.retentionSchedule.enabled
 }
 
 function resetRetentionForm() {
   syncFormFromStore()
   saveMessage.value = ''
+  saveStatus.value = ''
+}
+
+function toggleScheduleEnabled() {
+  if (isSaving.value || isLoading.value) {
+    return
+  }
+  scheduleEnabled.value = !scheduleEnabled.value
 }
 
 async function saveRetention() {
   try {
     isSaving.value = true
     saveMessage.value = ''
-    await configStore.updateDataRetention(retentionForm.value)
+    saveStatus.value = ''
+    await configStore.updateDataRetention({
+      ...retentionForm,
+      workflow_executions_days: retentionForm.worker_events_days,
+    })
+    await configStore.updateRetentionSchedule({ ...scheduleForm, enabled: scheduleEnabled.value })
+    syncFormFromStore()
     saveMessage.value = 'Retention settings saved.'
+    saveStatus.value = 'success'
   } catch (err) {
     saveMessage.value = err instanceof Error ? err.message : 'Failed to save retention settings.'
+    saveStatus.value = 'error'
   } finally {
     isSaving.value = false
   }
 }
 
 async function executeCleanup(dryRun: boolean) {
+  if (hasUnsavedChanges.value) {
+    cleanupError.value = 'Save retention settings before previewing or running cleanup.'
+    return
+  }
+
   try {
     cleanupRunning.value = true
     cleanupMode.value = dryRun ? 'dry' : 'live'

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -3,8 +3,15 @@
  */
 import { Api } from '../src/types/api'
 import type {
+  AppConfigSnapshot,
+  DataRetentionConfig,
+  RetentionCleanupResponse,
+  RetentionCleanupResult,
+  RetentionLastRun,
+  RetentionScheduleConfig,
   TaskStats,
   TaskEventResponse,
+  TaskIssueConfig,
   WorkerInfo
 } from '../src/types/api'
 
@@ -61,55 +68,13 @@ export interface AppSettingInput {
   category?: string | null
 }
 
-export interface TaskIssueConfigDTO {
-  lookback_hours: number
-}
-
-export interface DataRetentionConfigDTO {
-  task_successful_days: number
-  task_unsuccessful_days: number
-  worker_events_days: number
-  workflow_executions_days: number
-  task_daily_stats_days: number
-  inactive_sessions_days: number
-}
-
-export interface RetentionCleanupResultDTO {
-  key: string
-  label: string
-  retention_days: number
-  deleted: number
-}
-
-export interface RetentionCleanupResponseDTO {
-  dry_run: boolean
-  total_deleted: number
-  policy: DataRetentionConfigDTO
-  results: RetentionCleanupResultDTO[]
-}
-
-export interface RetentionScheduleConfigDTO {
-  enabled: boolean
-  frequency: 'daily' | 'weekly'
-  run_at: string
-}
-
-export interface RetentionLastRunDTO {
-  status: 'never' | 'success' | 'error' | 'running'
-  started_at?: string | null
-  finished_at?: string | null
-  total_deleted: number
-  dry_run: boolean
-  error?: string | null
-  results: RetentionCleanupResultDTO[]
-}
-
-export interface AppConfigSnapshotDTO {
-  task_issue_summary: TaskIssueConfigDTO
-  data_retention: DataRetentionConfigDTO
-  retention_schedule: RetentionScheduleConfigDTO
-  retention_last_run: RetentionLastRunDTO
-}
+export type TaskIssueConfigDTO = TaskIssueConfig
+export type DataRetentionConfigDTO = DataRetentionConfig
+export type RetentionCleanupResultDTO = RetentionCleanupResult
+export type RetentionCleanupResponseDTO = RetentionCleanupResponse
+export type RetentionScheduleConfigDTO = RetentionScheduleConfig
+export type RetentionLastRunDTO = RetentionLastRun
+export type AppConfigSnapshotDTO = AppConfigSnapshot
 
 export interface TaskStepDefinition {
   key: string

--- a/frontend/app/services/apiClient.ts
+++ b/frontend/app/services/apiClient.ts
@@ -84,12 +84,31 @@ export interface RetentionCleanupResultDTO {
 export interface RetentionCleanupResponseDTO {
   dry_run: boolean
   total_deleted: number
+  policy: DataRetentionConfigDTO
+  results: RetentionCleanupResultDTO[]
+}
+
+export interface RetentionScheduleConfigDTO {
+  enabled: boolean
+  frequency: 'daily' | 'weekly'
+  run_at: string
+}
+
+export interface RetentionLastRunDTO {
+  status: 'never' | 'success' | 'error' | 'running'
+  started_at?: string | null
+  finished_at?: string | null
+  total_deleted: number
+  dry_run: boolean
+  error?: string | null
   results: RetentionCleanupResultDTO[]
 }
 
 export interface AppConfigSnapshotDTO {
   task_issue_summary: TaskIssueConfigDTO
   data_retention: DataRetentionConfigDTO
+  retention_schedule: RetentionScheduleConfigDTO
+  retention_last_run: RetentionLastRunDTO
 }
 
 export interface TaskStepDefinition {
@@ -765,7 +784,11 @@ export type {
   AppConfigSnapshotDTO,
   AppSettingDTO,
   AppSettingInput,
-  TaskIssueConfigDTO
+  TaskIssueConfigDTO,
+  DataRetentionConfigDTO,
+  RetentionCleanupResponseDTO,
+  RetentionScheduleConfigDTO,
+  RetentionLastRunDTO
 }
 
 // Re-export session types from auto-generated API

--- a/frontend/app/src/types/api.ts
+++ b/frontend/app/src/types/api.ts
@@ -556,16 +556,43 @@ export interface RetentionScheduleConfig {
    */
   enabled?: boolean;
   /**
-   * Frequency
+   * Preset
    * @default "daily"
    */
-  frequency?: "daily" | "weekly";
+  preset?: "hourly" | "daily" | "weekly" | "monthly";
   /**
-   * Run At
-   * @default "03:00"
-   * @pattern ^([01]\d|2[0-3]):[0-5]\d$
+   * Hour
+   * @min 0
+   * @max 23
+   * @default 3
    */
-  run_at?: string;
+  hour?: number;
+  /**
+   * Minute
+   * @min 0
+   * @max 59
+   * @default 0
+   */
+  minute?: number;
+  /**
+   * Weekday
+   * @min 0
+   * @max 6
+   * @default 0
+   */
+  weekday?: number;
+  /**
+   * Month Day
+   * @min 1
+   * @max 31
+   * @default 1
+   */
+  month_day?: number;
+  /**
+   * Timezone
+   * @default "UTC"
+   */
+  timezone?: "UTC";
 }
 
 /**

--- a/frontend/app/src/types/api.ts
+++ b/frontend/app/src/types/api.ts
@@ -39,7 +39,7 @@ export interface ActionConfig {
   /** Config Id */
   config_id?: string | null;
   /** Params */
-  params?: object;
+  params?: Record<string, any>;
   /**
    * Continue On Failure
    * @default true
@@ -59,7 +59,7 @@ export interface ActionConfigCreateRequest {
   /** Action Type */
   action_type: string;
   /** Config */
-  config: object;
+  config: Record<string, any>;
 }
 
 /**
@@ -76,7 +76,7 @@ export interface ActionConfigDefinition {
   /** Action Type */
   action_type: string;
   /** Config */
-  config: object;
+  config: Record<string, any>;
   /** Created At */
   created_at?: string | null;
   /** Updated At */
@@ -102,7 +102,71 @@ export interface ActionConfigUpdateRequest {
   /** Description */
   description?: string | null;
   /** Config */
-  config?: object | null;
+  config?: Record<string, any> | null;
+}
+
+/**
+ * AppConfigSnapshot
+ * Grouped configuration snapshot returned to clients.
+ */
+export interface AppConfigSnapshot {
+  /** Configuration for the task issue summary section. */
+  task_issue_summary: TaskIssueConfig;
+  /** Retention policy for stored operational data. */
+  data_retention: DataRetentionConfig;
+  /** Automatic retention cleanup schedule. */
+  retention_schedule?: RetentionScheduleConfig;
+  /** Last automatic retention cleanup run status. */
+  retention_last_run?: RetentionLastRun;
+}
+
+/**
+ * AppSetting
+ * Database-backed application setting.
+ */
+export interface AppSetting {
+  /** Key */
+  key: string;
+  /** Value */
+  value: any;
+  /**
+   * Value Type
+   * @default "string"
+   */
+  value_type?: "string" | "number" | "boolean" | "json";
+  /** Label */
+  label?: string | null;
+  /** Description */
+  description?: string | null;
+  /** Category */
+  category?: string | null;
+  /**
+   * Created At
+   * @format date-time
+   */
+  created_at: string;
+  /**
+   * Updated At
+   * @format date-time
+   */
+  updated_at: string;
+}
+
+/**
+ * AppSettingUpdate
+ * Create/update payload for an application setting.
+ */
+export interface AppSettingUpdate {
+  /** Value */
+  value: any;
+  /** Value Type */
+  value_type?: "string" | "number" | "boolean" | "json" | null;
+  /** Label */
+  label?: string | null;
+  /** Description */
+  description?: string | null;
+  /** Category */
+  category?: string | null;
 }
 
 /**
@@ -228,6 +292,55 @@ export interface ConditionGroupOutput {
 }
 
 /**
+ * DataRetentionConfig
+ * Retention policy for stored operational data.
+ */
+export interface DataRetentionConfig {
+  /**
+   * Task Successful Days
+   * @min 1
+   * @max 3650
+   * @default 14
+   */
+  task_successful_days?: number;
+  /**
+   * Task Unsuccessful Days
+   * @min 1
+   * @max 3650
+   * @default 30
+   */
+  task_unsuccessful_days?: number;
+  /**
+   * Worker Events Days
+   * @min 1
+   * @max 3650
+   * @default 30
+   */
+  worker_events_days?: number;
+  /**
+   * Workflow Executions Days
+   * @min 1
+   * @max 3650
+   * @default 30
+   */
+  workflow_executions_days?: number;
+  /**
+   * Task Daily Stats Days
+   * @min 1
+   * @max 3650
+   * @default 365
+   */
+  task_daily_stats_days?: number;
+  /**
+   * Inactive Sessions Days
+   * @min 1
+   * @max 3650
+   * @default 30
+   */
+  inactive_sessions_days?: number;
+}
+
+/**
  * EnvironmentCreate
  * Environment creation request model
  */
@@ -319,7 +432,7 @@ export interface LogEntry {
   /** Timestamp */
   timestamp?: string | null;
   /** Context */
-  context?: object | null;
+  context?: Record<string, any> | null;
 }
 
 /**
@@ -351,6 +464,125 @@ export interface LogoutRequest {
 export interface RefreshRequest {
   /** Refresh Token */
   refresh_token: string;
+}
+
+/** ResolveTaskRequest */
+export interface ResolveTaskRequest {
+  /** Resolved By */
+  resolved_by?: string | null;
+}
+
+/**
+ * RetentionCleanupResponse
+ * Summary of a retention cleanup run.
+ */
+export interface RetentionCleanupResponse {
+  /**
+   * Dry Run
+   * @default false
+   */
+  dry_run?: boolean;
+  /**
+   * Total Deleted
+   * @min 0
+   */
+  total_deleted: number;
+  /** Retention policy for stored operational data. */
+  policy: DataRetentionConfig;
+  /** Results */
+  results?: RetentionCleanupResult[];
+}
+
+/**
+ * RetentionCleanupResult
+ * Result for a single retention target cleanup.
+ */
+export interface RetentionCleanupResult {
+  /** Key */
+  key: string;
+  /** Label */
+  label: string;
+  /**
+   * Retention Days
+   * @min 1
+   */
+  retention_days: number;
+  /**
+   * Deleted
+   * @min 0
+   */
+  deleted: number;
+}
+
+/**
+ * RetentionLastRun
+ * Last automatic retention cleanup run status.
+ */
+export interface RetentionLastRun {
+  /**
+   * Status
+   * @default "never"
+   */
+  status?: "never" | "success" | "error" | "running";
+  /** Started At */
+  started_at?: string | null;
+  /** Finished At */
+  finished_at?: string | null;
+  /**
+   * Total Deleted
+   * @min 0
+   * @default 0
+   */
+  total_deleted?: number;
+  /**
+   * Dry Run
+   * @default false
+   */
+  dry_run?: boolean;
+  /** Error */
+  error?: string | null;
+  /** Results */
+  results?: RetentionCleanupResult[];
+}
+
+/**
+ * RetentionScheduleConfig
+ * Automatic retention cleanup schedule.
+ */
+export interface RetentionScheduleConfig {
+  /**
+   * Enabled
+   * @default false
+   */
+  enabled?: boolean;
+  /**
+   * Frequency
+   * @default "daily"
+   */
+  frequency?: "daily" | "weekly";
+  /**
+   * Run At
+   * @default "03:00"
+   * @pattern ^([01]\d|2[0-3]):[0-5]\d$
+   */
+  run_at?: string;
+}
+
+/**
+ * StepDefinition
+ * Single step definition for task progress.
+ */
+export interface StepDefinition {
+  /** Key */
+  key: string;
+  /** Label */
+  label: string;
+  /** Description */
+  description?: string | null;
+  /** Total */
+  total?: number | null;
+  /** Order */
+  order?: number | null;
 }
 
 /**
@@ -437,7 +669,7 @@ export interface TaskEvent {
   /** Args */
   args?: any[];
   /** Kwargs */
-  kwargs?: object;
+  kwargs?: Record<string, any>;
   /**
    * Retries
    * @default 0
@@ -500,6 +732,72 @@ export interface TaskEvent {
   is_orphan?: boolean;
   /** Orphaned At */
   orphaned_at?: string | null;
+  /**
+   * Resolved
+   * @default false
+   */
+  resolved?: boolean;
+  /** Resolved By */
+  resolved_by?: string | null;
+  /** Resolved At */
+  resolved_at?: string | null;
+}
+
+/**
+ * TaskIssueConfig
+ * Configuration for the task issue summary section.
+ */
+export interface TaskIssueConfig {
+  /**
+   * Lookback Hours
+   * @min 1
+   * @max 168
+   * @default 24
+   */
+  lookback_hours?: number;
+}
+
+/**
+ * TaskProgressEvent
+ * Task progress update event.
+ */
+export interface TaskProgressEvent {
+  /** Task Id */
+  task_id: string;
+  /** Task Name */
+  task_name: string;
+  /** Progress */
+  progress: number;
+  /**
+   * Timestamp
+   * @format date-time
+   */
+  timestamp: string;
+  /** Step Key */
+  step_key?: string | null;
+  /** Message */
+  message?: string | null;
+  /** Meta */
+  meta?: Record<string, any> | null;
+  /**
+   * Event Type
+   * @default "kanchi-task-progress"
+   */
+  event_type?: "kanchi-task-progress";
+}
+
+/**
+ * TaskProgressSnapshot
+ * Aggregate view of progress and steps for a task.
+ */
+export interface TaskProgressSnapshot {
+  /** Task Id */
+  task_id: string;
+  latest?: TaskProgressEvent | null;
+  /** Steps */
+  steps?: StepDefinition[];
+  /** History */
+  history?: TaskProgressEvent[];
 }
 
 /**
@@ -653,7 +951,7 @@ export interface TriggerConfig {
   /** Type */
   type: string;
   /** Config */
-  config?: object;
+  config?: Record<string, any>;
 }
 
 /**
@@ -683,7 +981,7 @@ export interface UserSessionResponse {
   /** Active Environment Id */
   active_environment_id?: string | null;
   /** Preferences */
-  preferences?: object;
+  preferences?: Record<string, any>;
   /**
    * Created At
    * @format date-time
@@ -704,7 +1002,7 @@ export interface UserSessionUpdate {
   /** Active Environment Id */
   active_environment_id?: string | null;
   /** Preferences */
-  preferences?: object | null;
+  preferences?: Record<string, any> | null;
 }
 
 /** ValidationError */
@@ -863,7 +1161,7 @@ export interface WorkflowExecutionRecord {
   /** Trigger Type */
   trigger_type: string;
   /** Trigger Event */
-  trigger_event: object;
+  trigger_event: Record<string, any>;
   /** Status */
   status:
     | "pending"
@@ -873,7 +1171,7 @@ export interface WorkflowExecutionRecord {
     | "rate_limited"
     | "circuit_open";
   /** Actions Executed */
-  actions_executed?: object[] | null;
+  actions_executed?: Record<string, any>[] | null;
   /** Error Message */
   error_message?: string | null;
   /** Stack Trace */
@@ -885,7 +1183,7 @@ export interface WorkflowExecutionRecord {
   /** Duration Ms */
   duration_ms?: number | null;
   /** Workflow Snapshot */
-  workflow_snapshot?: object | null;
+  workflow_snapshot?: Record<string, any> | null;
   /** Circuit Breaker Key */
   circuit_breaker_key?: string | null;
 }
@@ -1150,7 +1448,7 @@ export class Api<
       },
       params: RequestParams = {},
     ) =>
-      this.request<object, HTTPValidationError>({
+      this.request<Record<string, any>, HTTPValidationError>({
         path: `/api/events/recent`,
         method: "GET",
         query: query,
@@ -1172,6 +1470,25 @@ export class Api<
     ) =>
       this.request<TaskEvent[], HTTPValidationError>({
         path: `/api/events/${taskId}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Get latest progress, steps, and recent history for a task.
+     *
+     * @tags tasks
+     * @name GetTaskProgressApiTasksTaskIdProgressGet
+     * @summary Get Task Progress
+     * @request GET:/api/tasks/{task_id}/progress
+     */
+    getTaskProgressApiTasksTaskIdProgressGet: (
+      taskId: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<TaskProgressSnapshot, HTTPValidationError>({
+        path: `/api/tasks/${taskId}/progress`,
         method: "GET",
         format: "json",
         ...params,
@@ -1221,9 +1538,9 @@ export class Api<
       query?: {
         /**
          * Hours
-         * @default 24
+         * Lookback window in hours (defaults to configured value)
          */
-        hours?: number;
+        hours?: number | null;
         /**
          * Limit
          * @default 50
@@ -1241,6 +1558,47 @@ export class Api<
         path: `/api/tasks/failed/recent`,
         method: "GET",
         query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Manually mark a task as resolved without altering its state.
+     *
+     * @tags tasks
+     * @name ResolveTaskApiTasksTaskIdResolvePost
+     * @summary Resolve Task
+     * @request POST:/api/tasks/{task_id}/resolve
+     */
+    resolveTaskApiTasksTaskIdResolvePost: (
+      taskId: string,
+      data: ResolveTaskRequest | null,
+      params: RequestParams = {},
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/api/tasks/${taskId}/resolve`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Remove manual resolution mark from a task.
+     *
+     * @tags tasks
+     * @name ClearTaskResolutionApiTasksTaskIdResolveDelete
+     * @summary Clear Task Resolution
+     * @request DELETE:/api/tasks/{task_id}/resolve
+     */
+    clearTaskResolutionApiTasksTaskIdResolveDelete: (
+      taskId: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/api/tasks/${taskId}/resolve`,
+        method: "DELETE",
         format: "json",
         ...params,
       }),
@@ -1565,7 +1923,7 @@ export class Api<
       },
       params: RequestParams = {},
     ) =>
-      this.request<object, HTTPValidationError>({
+      this.request<Record<string, any>, HTTPValidationError>({
         path: `/api/registry/tasks/${taskName}/trend`,
         method: "GET",
         query: query,
@@ -1987,7 +2345,7 @@ export class Api<
      */
     testWorkflowApiWorkflowsWorkflowIdTestPost: (
       workflowId: string,
-      data: object,
+      data: Record<string, any>,
       params: RequestParams = {},
     ) =>
       this.request<any, HTTPValidationError>({
@@ -2263,6 +2621,139 @@ export class Api<
       }),
 
     /**
+     * @description Get grouped application configuration with defaults applied.
+     *
+     * @tags config
+     * @name GetConfigSnapshotApiConfigGet
+     * @summary Get Config Snapshot
+     * @request GET:/api/config
+     */
+    getConfigSnapshotApiConfigGet: (params: RequestParams = {}) =>
+      this.request<AppConfigSnapshot, any>({
+        path: `/api/config`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description List all application settings.
+     *
+     * @tags config
+     * @name ListSettingsApiConfigSettingsGet
+     * @summary List Settings
+     * @request GET:/api/config/settings
+     */
+    listSettingsApiConfigSettingsGet: (params: RequestParams = {}) =>
+      this.request<AppSetting[], any>({
+        path: `/api/config/settings`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Get a single application setting.
+     *
+     * @tags config
+     * @name GetSettingApiConfigSettingsKeyGet
+     * @summary Get Setting
+     * @request GET:/api/config/settings/{key}
+     */
+    getSettingApiConfigSettingsKeyGet: (
+      key: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<AppSetting, HTTPValidationError>({
+        path: `/api/config/settings/${key}`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Create or update an application setting.
+     *
+     * @tags config
+     * @name UpsertSettingApiConfigSettingsKeyPut
+     * @summary Upsert Setting
+     * @request PUT:/api/config/settings/{key}
+     */
+    upsertSettingApiConfigSettingsKeyPut: (
+      key: string,
+      data: AppSettingUpdate,
+      params: RequestParams = {},
+    ) =>
+      this.request<AppSetting, HTTPValidationError>({
+        path: `/api/config/settings/${key}`,
+        method: "PUT",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Delete a setting (falls back to default).
+     *
+     * @tags config
+     * @name DeleteSettingApiConfigSettingsKeyDelete
+     * @summary Delete Setting
+     * @request DELETE:/api/config/settings/{key}
+     */
+    deleteSettingApiConfigSettingsKeyDelete: (
+      key: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, HTTPValidationError>({
+        path: `/api/config/settings/${key}`,
+        method: "DELETE",
+        ...params,
+      }),
+
+    /**
+     * @description Get normalized data retention policy values.
+     *
+     * @tags config
+     * @name GetRetentionPolicyApiConfigRetentionGet
+     * @summary Get Retention Policy
+     * @request GET:/api/config/retention
+     */
+    getRetentionPolicyApiConfigRetentionGet: (params: RequestParams = {}) =>
+      this.request<DataRetentionConfig, any>({
+        path: `/api/config/retention`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Run retention cleanup, optionally as a dry-run preview.
+     *
+     * @tags config
+     * @name RunRetentionCleanupApiConfigRetentionCleanupPost
+     * @summary Run Retention Cleanup
+     * @request POST:/api/config/retention/cleanup
+     */
+    runRetentionCleanupApiConfigRetentionCleanupPost: (
+      query?: {
+        /**
+         * Dry Run
+         * @default true
+         */
+        dry_run?: boolean;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<RetentionCleanupResponse, HTTPValidationError>({
+        path: `/api/config/retention/cleanup`,
+        method: "POST",
+        query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
      * @description Public health endpoint without sensitive data.
      *
      * @name HealthCheckApiHealthGet
@@ -2287,6 +2778,22 @@ export class Api<
     healthDetailsApiHealthDetailsGet: (params: RequestParams = {}) =>
       this.request<any, any>({
         path: `/api/health/details`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+  };
+  metrics = {
+    /**
+     * No description
+     *
+     * @name MetricsMetricsGet
+     * @summary Metrics
+     * @request GET:/metrics
+     */
+    metricsMetricsGet: (params: RequestParams = {}) =>
+      this.request<any, any>({
+        path: `/metrics`,
         method: "GET",
         format: "json",
         ...params,

--- a/frontend/app/stores/config.ts
+++ b/frontend/app/stores/config.ts
@@ -31,13 +31,21 @@ const RETENTION_KEYS = {
 } as const
 const RETENTION_SCHEDULE_KEYS = {
   enabled: 'data_retention.schedule.enabled',
-  frequency: 'data_retention.schedule.frequency',
-  run_at: 'data_retention.schedule.run_at',
+  preset: 'data_retention.schedule.preset',
+  hour: 'data_retention.schedule.hour',
+  minute: 'data_retention.schedule.minute',
+  weekday: 'data_retention.schedule.weekday',
+  month_day: 'data_retention.schedule.month_day',
+  timezone: 'data_retention.schedule.timezone',
 } as const
 const RETENTION_SCHEDULE_DEFAULTS: RetentionScheduleConfigDTO = {
   enabled: false,
-  frequency: 'daily',
-  run_at: '03:00',
+  preset: 'daily',
+  hour: 3,
+  minute: 0,
+  weekday: 0,
+  month_day: 1,
+  timezone: 'UTC',
 }
 const RETENTION_LAST_RUN_DEFAULTS: RetentionLastRunDTO = {
   status: 'never',
@@ -86,8 +94,12 @@ export const useConfigStore = defineStore('config', () => {
   const retentionSchedule = computed<RetentionScheduleConfigDTO>(() => {
     return config.value?.retention_schedule ?? {
       enabled: Boolean(settingsMap.value[RETENTION_SCHEDULE_KEYS.enabled]?.value ?? RETENTION_SCHEDULE_DEFAULTS.enabled),
-      frequency: (settingsMap.value[RETENTION_SCHEDULE_KEYS.frequency]?.value as 'daily' | 'weekly' | undefined) ?? RETENTION_SCHEDULE_DEFAULTS.frequency,
-      run_at: String(settingsMap.value[RETENTION_SCHEDULE_KEYS.run_at]?.value ?? RETENTION_SCHEDULE_DEFAULTS.run_at),
+      preset: (settingsMap.value[RETENTION_SCHEDULE_KEYS.preset]?.value as 'hourly' | 'daily' | 'weekly' | 'monthly' | undefined) ?? RETENTION_SCHEDULE_DEFAULTS.preset,
+      hour: Number(settingsMap.value[RETENTION_SCHEDULE_KEYS.hour]?.value ?? RETENTION_SCHEDULE_DEFAULTS.hour),
+      minute: Number(settingsMap.value[RETENTION_SCHEDULE_KEYS.minute]?.value ?? RETENTION_SCHEDULE_DEFAULTS.minute),
+      weekday: Number(settingsMap.value[RETENTION_SCHEDULE_KEYS.weekday]?.value ?? RETENTION_SCHEDULE_DEFAULTS.weekday),
+      month_day: Number(settingsMap.value[RETENTION_SCHEDULE_KEYS.month_day]?.value ?? RETENTION_SCHEDULE_DEFAULTS.month_day),
+      timezone: String(settingsMap.value[RETENTION_SCHEDULE_KEYS.timezone]?.value ?? RETENTION_SCHEDULE_DEFAULTS.timezone) as 'UTC',
     }
   })
 
@@ -155,6 +167,9 @@ export const useConfigStore = defineStore('config', () => {
       const scheduleEntry = Object.entries(RETENTION_SCHEDULE_KEYS).find(([, settingKey]) => settingKey === key)
       if (scheduleEntry) {
         const [scheduleField] = scheduleEntry as [keyof RetentionScheduleConfigDTO, string]
+        const value = ['hour', 'minute', 'weekday', 'month_day'].includes(scheduleField)
+          ? Number(updated.value)
+          : updated.value
         config.value = {
           ...(config.value ?? {
             task_issue_summary: { lookback_hours: TASK_ISSUE_LOOKBACK_DEFAULT },
@@ -164,7 +179,7 @@ export const useConfigStore = defineStore('config', () => {
           }),
           retention_schedule: {
             ...retentionSchedule.value,
-            [scheduleField]: updated.value,
+            [scheduleField]: value,
           },
         }
       }
@@ -242,13 +257,33 @@ export const useConfigStore = defineStore('config', () => {
       value_type: 'boolean',
       category: 'data_retention'
     })
-    await upsertSetting(RETENTION_SCHEDULE_KEYS.frequency, {
-      value: values.frequency,
+    await upsertSetting(RETENTION_SCHEDULE_KEYS.preset, {
+      value: values.preset,
       value_type: 'string',
       category: 'data_retention'
     })
-    await upsertSetting(RETENTION_SCHEDULE_KEYS.run_at, {
-      value: values.run_at,
+    await upsertSetting(RETENTION_SCHEDULE_KEYS.hour, {
+      value: Number(values.hour),
+      value_type: 'number',
+      category: 'data_retention'
+    })
+    await upsertSetting(RETENTION_SCHEDULE_KEYS.minute, {
+      value: Number(values.minute),
+      value_type: 'number',
+      category: 'data_retention'
+    })
+    await upsertSetting(RETENTION_SCHEDULE_KEYS.weekday, {
+      value: Number(values.weekday),
+      value_type: 'number',
+      category: 'data_retention'
+    })
+    await upsertSetting(RETENTION_SCHEDULE_KEYS.month_day, {
+      value: Number(values.month_day),
+      value_type: 'number',
+      category: 'data_retention'
+    })
+    await upsertSetting(RETENTION_SCHEDULE_KEYS.timezone, {
+      value: values.timezone ?? 'UTC',
       value_type: 'string',
       category: 'data_retention'
     })

--- a/frontend/app/stores/config.ts
+++ b/frontend/app/stores/config.ts
@@ -7,6 +7,8 @@ import {
   type AppSettingInput,
   type DataRetentionConfigDTO,
   type RetentionCleanupResponseDTO,
+  type RetentionLastRunDTO,
+  type RetentionScheduleConfigDTO,
 } from '~/services/apiClient'
 
 const TASK_ISSUE_LOOKBACK_DEFAULT = 24
@@ -27,6 +29,22 @@ const RETENTION_KEYS = {
   task_daily_stats_days: 'data_retention.task_daily_stats_days',
   inactive_sessions_days: 'data_retention.inactive_sessions_days',
 } as const
+const RETENTION_SCHEDULE_KEYS = {
+  enabled: 'data_retention.schedule.enabled',
+  frequency: 'data_retention.schedule.frequency',
+  run_at: 'data_retention.schedule.run_at',
+} as const
+const RETENTION_SCHEDULE_DEFAULTS: RetentionScheduleConfigDTO = {
+  enabled: false,
+  frequency: 'daily',
+  run_at: '03:00',
+}
+const RETENTION_LAST_RUN_DEFAULTS: RetentionLastRunDTO = {
+  status: 'never',
+  total_deleted: 0,
+  dry_run: false,
+  results: [],
+}
 
 export const useConfigStore = defineStore('config', () => {
   const apiService = useApiService()
@@ -65,6 +83,18 @@ export const useConfigStore = defineStore('config', () => {
     return TASK_ISSUE_LOOKBACK_DEFAULT
   })
 
+  const retentionSchedule = computed<RetentionScheduleConfigDTO>(() => {
+    return config.value?.retention_schedule ?? {
+      enabled: Boolean(settingsMap.value[RETENTION_SCHEDULE_KEYS.enabled]?.value ?? RETENTION_SCHEDULE_DEFAULTS.enabled),
+      frequency: (settingsMap.value[RETENTION_SCHEDULE_KEYS.frequency]?.value as 'daily' | 'weekly' | undefined) ?? RETENTION_SCHEDULE_DEFAULTS.frequency,
+      run_at: String(settingsMap.value[RETENTION_SCHEDULE_KEYS.run_at]?.value ?? RETENTION_SCHEDULE_DEFAULTS.run_at),
+    }
+  })
+
+  const retentionLastRun = computed<RetentionLastRunDTO>(() => {
+    return config.value?.retention_last_run ?? RETENTION_LAST_RUN_DEFAULTS
+  })
+
   async function fetchConfig() {
     try {
       isLoading.value = true
@@ -98,6 +128,8 @@ export const useConfigStore = defineStore('config', () => {
           ...(config.value ?? {
             task_issue_summary: { lookback_hours: TASK_ISSUE_LOOKBACK_DEFAULT },
             data_retention: dataRetention.value,
+            retention_schedule: retentionSchedule.value,
+            retention_last_run: retentionLastRun.value,
           }),
           task_issue_summary: { lookback_hours: Number(updated.value) }
         }
@@ -110,10 +142,29 @@ export const useConfigStore = defineStore('config', () => {
           ...(config.value ?? {
             task_issue_summary: { lookback_hours: TASK_ISSUE_LOOKBACK_DEFAULT },
             data_retention: dataRetention.value,
+            retention_schedule: retentionSchedule.value,
+            retention_last_run: retentionLastRun.value,
           }),
           data_retention: {
             ...dataRetention.value,
             [retentionField]: Number(updated.value),
+          },
+        }
+      }
+
+      const scheduleEntry = Object.entries(RETENTION_SCHEDULE_KEYS).find(([, settingKey]) => settingKey === key)
+      if (scheduleEntry) {
+        const [scheduleField] = scheduleEntry as [keyof RetentionScheduleConfigDTO, string]
+        config.value = {
+          ...(config.value ?? {
+            task_issue_summary: { lookback_hours: TASK_ISSUE_LOOKBACK_DEFAULT },
+            data_retention: dataRetention.value,
+            retention_schedule: retentionSchedule.value,
+            retention_last_run: retentionLastRun.value,
+          }),
+          retention_schedule: {
+            ...retentionSchedule.value,
+            [scheduleField]: updated.value,
           },
         }
       }
@@ -147,6 +198,18 @@ export const useConfigStore = defineStore('config', () => {
           },
         }
       }
+
+      const scheduleEntry = Object.entries(RETENTION_SCHEDULE_KEYS).find(([, settingKey]) => settingKey === key)
+      if (scheduleEntry && config.value) {
+        const [scheduleField] = scheduleEntry as [keyof RetentionScheduleConfigDTO, string]
+        config.value = {
+          ...config.value,
+          retention_schedule: {
+            ...config.value.retention_schedule,
+            [scheduleField]: RETENTION_SCHEDULE_DEFAULTS[scheduleField],
+          },
+        }
+      }
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to delete setting'
       throw err
@@ -170,6 +233,26 @@ export const useConfigStore = defineStore('config', () => {
         category: 'data_retention'
       })
     }
+    await fetchConfig()
+  }
+
+  async function updateRetentionSchedule(values: RetentionScheduleConfigDTO) {
+    await upsertSetting(RETENTION_SCHEDULE_KEYS.enabled, {
+      value: values.enabled,
+      value_type: 'boolean',
+      category: 'data_retention'
+    })
+    await upsertSetting(RETENTION_SCHEDULE_KEYS.frequency, {
+      value: values.frequency,
+      value_type: 'string',
+      category: 'data_retention'
+    })
+    await upsertSetting(RETENTION_SCHEDULE_KEYS.run_at, {
+      value: values.run_at,
+      value_type: 'string',
+      category: 'data_retention'
+    })
+    await fetchConfig()
   }
 
   async function runRetentionCleanup(dryRun = true): Promise<RetentionCleanupResponseDTO> {
@@ -183,12 +266,15 @@ export const useConfigStore = defineStore('config', () => {
     error: readonly(error),
     taskIssueLookbackHours,
     dataRetention,
+    retentionSchedule,
+    retentionLastRun,
     settingsMap,
     fetchConfig,
     upsertSetting,
     deleteSetting,
     updateTaskIssueLookback,
     updateDataRetention,
+    updateRetentionSchedule,
     runRetentionCleanup,
   }
 })

--- a/frontend/app/stores/config.ts
+++ b/frontend/app/stores/config.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, computed, readonly } from 'vue'
+import { ref, computed } from 'vue'
 import {
   useApiService,
   type AppConfigSnapshotDTO,
@@ -7,6 +7,8 @@ import {
   type AppSettingInput,
   type DataRetentionConfigDTO,
   type RetentionCleanupResponseDTO,
+  type RetentionLastRunDTO,
+  type RetentionScheduleConfigDTO,
 } from '~/services/apiClient'
 
 const TASK_ISSUE_LOOKBACK_DEFAULT = 24
@@ -27,6 +29,22 @@ const RETENTION_KEYS = {
   task_daily_stats_days: 'data_retention.task_daily_stats_days',
   inactive_sessions_days: 'data_retention.inactive_sessions_days',
 } as const
+const RETENTION_SCHEDULE_KEYS = {
+  enabled: 'data_retention.schedule.enabled',
+  frequency: 'data_retention.schedule.frequency',
+  run_at: 'data_retention.schedule.run_at',
+} as const
+const RETENTION_SCHEDULE_DEFAULTS: RetentionScheduleConfigDTO = {
+  enabled: false,
+  frequency: 'daily',
+  run_at: '03:00',
+}
+const RETENTION_LAST_RUN_DEFAULTS: RetentionLastRunDTO = {
+  status: 'never',
+  total_deleted: 0,
+  dry_run: false,
+  results: [],
+}
 
 export const useConfigStore = defineStore('config', () => {
   const apiService = useApiService()
@@ -65,6 +83,18 @@ export const useConfigStore = defineStore('config', () => {
     return TASK_ISSUE_LOOKBACK_DEFAULT
   })
 
+  const retentionSchedule = computed<RetentionScheduleConfigDTO>(() => {
+    return config.value?.retention_schedule ?? {
+      enabled: Boolean(settingsMap.value[RETENTION_SCHEDULE_KEYS.enabled]?.value ?? RETENTION_SCHEDULE_DEFAULTS.enabled),
+      frequency: (settingsMap.value[RETENTION_SCHEDULE_KEYS.frequency]?.value as 'daily' | 'weekly' | undefined) ?? RETENTION_SCHEDULE_DEFAULTS.frequency,
+      run_at: String(settingsMap.value[RETENTION_SCHEDULE_KEYS.run_at]?.value ?? RETENTION_SCHEDULE_DEFAULTS.run_at),
+    }
+  })
+
+  const retentionLastRun = computed<RetentionLastRunDTO>(() => {
+    return config.value?.retention_last_run ?? RETENTION_LAST_RUN_DEFAULTS
+  })
+
   async function fetchConfig() {
     try {
       isLoading.value = true
@@ -98,6 +128,8 @@ export const useConfigStore = defineStore('config', () => {
           ...(config.value ?? {
             task_issue_summary: { lookback_hours: TASK_ISSUE_LOOKBACK_DEFAULT },
             data_retention: dataRetention.value,
+            retention_schedule: retentionSchedule.value,
+            retention_last_run: retentionLastRun.value,
           }),
           task_issue_summary: { lookback_hours: Number(updated.value) }
         }
@@ -110,10 +142,29 @@ export const useConfigStore = defineStore('config', () => {
           ...(config.value ?? {
             task_issue_summary: { lookback_hours: TASK_ISSUE_LOOKBACK_DEFAULT },
             data_retention: dataRetention.value,
+            retention_schedule: retentionSchedule.value,
+            retention_last_run: retentionLastRun.value,
           }),
           data_retention: {
             ...dataRetention.value,
             [retentionField]: Number(updated.value),
+          },
+        }
+      }
+
+      const scheduleEntry = Object.entries(RETENTION_SCHEDULE_KEYS).find(([, settingKey]) => settingKey === key)
+      if (scheduleEntry) {
+        const [scheduleField] = scheduleEntry as [keyof RetentionScheduleConfigDTO, string]
+        config.value = {
+          ...(config.value ?? {
+            task_issue_summary: { lookback_hours: TASK_ISSUE_LOOKBACK_DEFAULT },
+            data_retention: dataRetention.value,
+            retention_schedule: retentionSchedule.value,
+            retention_last_run: retentionLastRun.value,
+          }),
+          retention_schedule: {
+            ...retentionSchedule.value,
+            [scheduleField]: updated.value,
           },
         }
       }
@@ -147,6 +198,18 @@ export const useConfigStore = defineStore('config', () => {
           },
         }
       }
+
+      const scheduleEntry = Object.entries(RETENTION_SCHEDULE_KEYS).find(([, settingKey]) => settingKey === key)
+      if (scheduleEntry && config.value) {
+        const [scheduleField] = scheduleEntry as [keyof RetentionScheduleConfigDTO, string]
+        config.value = {
+          ...config.value,
+          retention_schedule: {
+            ...config.value.retention_schedule,
+            [scheduleField]: RETENTION_SCHEDULE_DEFAULTS[scheduleField],
+          },
+        }
+      }
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to delete setting'
       throw err
@@ -170,6 +233,26 @@ export const useConfigStore = defineStore('config', () => {
         category: 'data_retention'
       })
     }
+    await fetchConfig()
+  }
+
+  async function updateRetentionSchedule(values: RetentionScheduleConfigDTO) {
+    await upsertSetting(RETENTION_SCHEDULE_KEYS.enabled, {
+      value: values.enabled,
+      value_type: 'boolean',
+      category: 'data_retention'
+    })
+    await upsertSetting(RETENTION_SCHEDULE_KEYS.frequency, {
+      value: values.frequency,
+      value_type: 'string',
+      category: 'data_retention'
+    })
+    await upsertSetting(RETENTION_SCHEDULE_KEYS.run_at, {
+      value: values.run_at,
+      value_type: 'string',
+      category: 'data_retention'
+    })
+    await fetchConfig()
   }
 
   async function runRetentionCleanup(dryRun = true): Promise<RetentionCleanupResponseDTO> {
@@ -177,18 +260,21 @@ export const useConfigStore = defineStore('config', () => {
   }
 
   return {
-    config: readonly(config),
-    settings: readonly(settings),
-    isLoading: readonly(isLoading),
-    error: readonly(error),
+    config,
+    settings,
+    isLoading,
+    error,
     taskIssueLookbackHours,
     dataRetention,
+    retentionSchedule,
+    retentionLastRun,
     settingsMap,
     fetchConfig,
     upsertSetting,
     deleteSetting,
     updateTaskIssueLookback,
     updateDataRetention,
+    updateRetentionSchedule,
     runRetentionCleanup,
   }
 })

--- a/frontend/app/stores/failedTasks.ts
+++ b/frontend/app/stores/failedTasks.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, computed, readonly } from 'vue'
+import { ref, computed } from 'vue'
 import { useApiService } from '../services/apiClient'
 import type { TaskEventResponse } from '../services/apiClient'
 
@@ -190,11 +190,11 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
   }
 
   return {
-    failedTasks: readonly(failedTasks),
-    isLoading: readonly(isLoading),
-    error: readonly(error),
-    lastFetchedAt: readonly(lastFetchedAt),
-    lookbackHours: readonly(lookbackHours),
+    failedTasks,
+    isLoading,
+    error,
+    lastFetchedAt,
+    lookbackHours,
 
     totalFailedTasks,
     latestFailedTask,

--- a/frontend/app/stores/health.ts
+++ b/frontend/app/stores/health.ts
@@ -58,9 +58,9 @@ export const useHealthStore = defineStore('health', () => {
   }
 
   return {
-    health: readonly(health),
-    isLoading: readonly(isLoading),
-    error: readonly(error),
+    health,
+    isLoading,
+    error,
 
     fetchHealth,
     fetchHealthDetails,

--- a/frontend/app/stores/orphanTasks.ts
+++ b/frontend/app/stores/orphanTasks.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, computed, readonly } from 'vue'
+import { ref, computed } from 'vue'
 import { useApiService } from '../services/apiClient'
 import type { TaskEventResponse } from '../services/apiClient'
 
@@ -128,9 +128,9 @@ export const useOrphanTasksStore = defineStore('orphanTasks', () => {
   }
 
   return {
-    orphanedTasks: readonly(orphanedTasks),
-    isLoading: readonly(isLoading),
-    error: readonly(error),
+    orphanedTasks,
+    isLoading,
+    error,
 
     orphanedTasksCount,
     recentOrphanedTasks,

--- a/frontend/app/stores/tasks.ts
+++ b/frontend/app/stores/tasks.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, computed, readonly } from 'vue'
+import { ref, computed } from 'vue'
 import { useApiService } from '../services/apiClient'
 import type {
   TaskStats,
@@ -325,17 +325,17 @@ export const useTasksStore = defineStore('tasks', () => {
   }
 
   return {
-    stats: readonly(stats),
-    events: readonly(events),
-    activeTasks: readonly(activeTasks),
-    progressSnapshots: readonly(progressSnapshots),
-    pagination: readonly(pagination),
-    isLoading: readonly(isLoading),
-    error: readonly(error),
-    filters: readonly(filters),
-    paginationParams: readonly(paginationParams),
-    isLiveMode: readonly(isLiveMode),
-    lastRefreshTime: readonly(lastRefreshTime),
+    stats,
+    events,
+    activeTasks,
+    progressSnapshots,
+    pagination,
+    isLoading,
+    error,
+    filters,
+    paginationParams,
+    isLiveMode,
+    lastRefreshTime,
 
     hasNextPage,
     hasPrevPage,

--- a/frontend/app/stores/websocket.ts
+++ b/frontend/app/stores/websocket.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, computed, readonly, watch } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useAuthStore } from './auth'
 import { useTasksStore } from './tasks'
@@ -232,13 +232,13 @@ export const useWebSocketStore = defineStore('websocket', () => {
   }
 
   return {
-    isConnected: readonly(isConnected),
-    isConnecting: readonly(isConnecting),
-    connectionInfo: readonly(connectionInfo),
-    error: readonly(error),
-    reconnectAttempts: readonly(reconnectAttempts),
-    clientFilters: readonly(clientFilters),
-    clientMode: readonly(clientMode),
+    isConnected,
+    isConnecting,
+    connectionInfo,
+    error,
+    reconnectAttempts,
+    clientFilters,
+    clientMode,
 
     canReconnect,
 

--- a/frontend/app/stores/workers.ts
+++ b/frontend/app/stores/workers.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, computed, readonly } from 'vue'
+import { ref, computed } from 'vue'
 import { useApiService } from '../services/apiClient'
 import type { WorkerInfo } from '../services/apiClient'
 
@@ -119,10 +119,10 @@ export const useWorkersStore = defineStore('workers', () => {
   }
 
   return {
-    workers: readonly(workers),
-    recentWorkerEvents: readonly(recentWorkerEvents),
-    isLoading: readonly(isLoading),
-    error: readonly(error),
+    workers,
+    recentWorkerEvents,
+    isLoading,
+    error,
 
     activeWorkers,
     offlineWorkers,


### PR DESCRIPTION
## Summary
- simplify retention settings around high-volume task history and operational logs
- include the exact policy used in cleanup responses and surface grouped preview results
- add persisted automatic cleanup schedule settings, last-run status, scheduler runner, and overlap protection
- add focused backend tests for policy snapshots, schedule config, scheduler due logic, and cleanup locking

## Verification
- `PYTHONPATH=. python3 -m pytest tests/unit/test_retention_service.py tests/unit/test_app_config_service.py tests/unit/test_retention_scheduler_service.py -q`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic data-retention scheduling (hourly/daily/weekly/month-day) with enable/disable and UTC time presets; retention last-run tracking and scheduler start/stop.
  * Workspace settings: “Automatic cleanup” UI, 3-column layout, save/reset flow, and richer cleanup results including policy details.

* **Bug Fixes**
  * Prevent overlapping cleanup runs; concurrent-run attempts now return a clear error.
  * API now maps cleanup runtime errors to a 409 response.

* **Tests**
  * Added unit tests for scheduling logic and retention cleanup behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getkanchi/kanchi/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->