### PR TITLE
[codex] Treat manual reruns as addressed failures

### DIFF
--- a/agent/services/task_registry_service.py
+++ b/agent/services/task_registry_service.py
@@ -1,21 +1,26 @@
 """Task registry service for auto-discovery and management of Celery tasks."""
 
 import logging
-import uuid
 import threading
-from datetime import datetime, timezone, timedelta
-from typing import List, Optional, Dict, Any
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
 
+from sqlalchemy import String, and_, case, cast, func
 from sqlalchemy.orm import Session
-from sqlalchemy import func, and_, or_, cast, String, case
 
-from database import TaskRegistryDB, TaskEventDB, RetryRelationshipDB
+from database import (
+    RetryRelationshipDB,
+    TaskEventDB,
+    TaskRegistryDB,
+    TaskRerunRelationshipDB,
+)
 from models import (
     TaskRegistryResponse,
-    TaskRegistryUpdate,
     TaskRegistryStats,
+    TaskRegistryUpdate,
     TaskTimelineResponse,
-    TimelineBucket
+    TimelineBucket,
 )
 from services.utils import EnvironmentFilter
 
@@ -256,7 +261,18 @@ class TaskRegistryService:
                 rel.task_id for rel in retry_relationships if rel.total_retries > 0
             }
 
-            unretried_failures = len(failed_task_ids - retried_task_ids)
+            rerun_task_ids = {
+                row[0]
+                for row in (
+                    self.session.query(TaskRerunRelationshipDB.original_task_id)
+                    .filter(TaskRerunRelationshipDB.original_task_id.in_(failed_task_ids))
+                    .distinct()
+                    .all()
+                )
+            }
+
+            addressed_task_ids = retried_task_ids | rerun_task_ids
+            unretried_failures = len(failed_task_ids - addressed_task_ids)
 
         return TaskRegistryStats(
             task_name=task_name,
@@ -318,7 +334,7 @@ class TaskRegistryService:
 
         base_query = EnvironmentFilter.apply(base_query, self.active_env)
 
-        from sqlalchemy import cast, Integer, literal
+        from sqlalchemy import Integer, cast, literal
         from sqlalchemy.types import DateTime as SADateTime
 
         dialect_name = getattr(getattr(self.session.bind, "dialect", None), "name", "sqlite")

--- a/agent/services/task_service.py
+++ b/agent/services/task_service.py
@@ -2,25 +2,34 @@
 
 import json
 import logging
-from datetime import datetime, timezone, timedelta
-from typing import List, Dict, Any, Optional, Tuple, Union
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple, Union
 
-from sqlalchemy.orm import Session
-from sqlalchemy import desc, asc, or_, and_, func, String, cast, Integer, literal, inspect, case
-from sqlalchemy.dialects.sqlite import insert as sqlite_insert
-from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy import (
+    String,
+    and_,
+    asc,
+    case,
+    desc,
+    func,
+    or_,
+    select,
+)
 from sqlalchemy.dialects.mysql import insert as mysql_insert
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.orm import Session
 
+from constants import ACTIVE_EVENT_TYPES, STATE_TO_EVENT_MAP, EventType, TaskState
 from database import (
+    RetryRelationshipDB,
     TaskActionItemDB,
     TaskEventDB,
-    RetryRelationshipDB,
     TaskLatestDB,
-    TaskResolutionDB,
     TaskRerunRelationshipDB,
+    TaskResolutionDB,
 )
 from models import TaskEvent
-from constants import TaskState, EventType, STATE_TO_EVENT_MAP, ACTIVE_EVENT_TYPES
 from services.utils import EnvironmentFilter, GenericFilter, parse_filter_string
 from utils.payload_sanitizer import find_placeholder_paths
 
@@ -358,8 +367,10 @@ class TaskService:
         )
 
         if exclude_retried:
+            rerun_original_ids = select(TaskRerunRelationshipDB.original_task_id)
             query = query.filter(
-                or_(TaskEventDB.has_retries.is_(False), TaskEventDB.has_retries.is_(None))
+                or_(TaskEventDB.has_retries.is_(False), TaskEventDB.has_retries.is_(None)),
+                TaskEventDB.task_id.not_in(rerun_original_ids)
             )
 
         query = query.order_by(TaskEventDB.timestamp.desc())

--- a/agent/tests/unit/test_task_registry_service.py
+++ b/agent/tests/unit/test_task_registry_service.py
@@ -1,0 +1,91 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from database import RetryRelationshipDB, TaskRerunRelationshipDB
+from services.task_registry_service import TaskRegistryService
+from tests.base import DatabaseTestCase
+
+
+class TestTaskRegistryServiceStats(DatabaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.service = TaskRegistryService(self.session)
+        self.now = datetime.now(timezone.utc)
+
+    def test_failed_stat_counts_unaddressed_failures(self):
+        self.create_task_event_db(
+            task_id="failed-unaddressed",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=30),
+        )
+
+        stats = self.service.get_task_stats("tasks.example", hours=24)
+
+        self.assertEqual(stats.failed, 1)
+
+    def test_failed_stat_excludes_celery_retried_failures(self):
+        self.create_task_event_db(
+            task_id="failed-retried",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=30),
+        )
+        self.session.add(RetryRelationshipDB(
+            task_id="failed-retried",
+            original_id="failed-retried",
+            retry_chain=["retry-child"],
+            total_retries=1,
+        ))
+        self.session.commit()
+
+        stats = self.service.get_task_stats("tasks.example", hours=24)
+
+        self.assertEqual(stats.failed, 0)
+
+    def test_failed_stat_excludes_manually_rerun_failures(self):
+        self.create_task_event_db(
+            task_id="failed-rerun",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=30),
+        )
+        self.session.add(TaskRerunRelationshipDB(
+            original_task_id="failed-rerun",
+            rerun_task_id="rerun-child",
+            created_by="tester",
+        ))
+        self.session.commit()
+
+        stats = self.service.get_task_stats("tasks.example", hours=24)
+
+        self.assertEqual(stats.failed, 0)
+
+    def test_failed_rerun_child_counts_as_its_own_unaddressed_failure(self):
+        self.create_task_event_db(
+            task_id="failed-rerun",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=30),
+        )
+        self.create_task_event_db(
+            task_id="rerun-child",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=self.now - timedelta(minutes=20),
+        )
+        self.session.add(TaskRerunRelationshipDB(
+            original_task_id="failed-rerun",
+            rerun_task_id="rerun-child",
+            created_by="tester",
+        ))
+        self.session.commit()
+
+        stats = self.service.get_task_stats("tasks.example", hours=24)
+
+        self.assertEqual(stats.failed, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent/tests/unit/test_task_service_recent_failures.py
+++ b/agent/tests/unit/test_task_service_recent_failures.py
@@ -1,6 +1,7 @@
 import unittest
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 
+from database import TaskRerunRelationshipDB
 from services.task_service import TaskService
 from tests.base import DatabaseTestCase
 
@@ -73,6 +74,42 @@ class TestTaskServiceRecentFailedTasks(DatabaseTestCase):
         task_ids_including = {task.task_id for task in results_including_retried}
 
         self.assertIn("failed-retried", task_ids_including)
+
+    def test_excludes_manually_rerun_failures_by_default(self):
+        recent_time = self.now - timedelta(minutes=30)
+
+        self.create_task_event_db(
+            task_id="failed-unrerun",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=recent_time,
+        )
+        self.create_task_event_db(
+            task_id="failed-rerun",
+            task_name="tasks.example",
+            event_type="task-failed",
+            timestamp=recent_time - timedelta(minutes=1),
+        )
+        self.session.add(TaskRerunRelationshipDB(
+            original_task_id="failed-rerun",
+            rerun_task_id="rerun-task",
+            created_by="tester",
+        ))
+        self.session.commit()
+
+        results = self.service.get_recent_failed_tasks(hours=24)
+        task_ids = {task.task_id for task in results}
+
+        self.assertIn("failed-unrerun", task_ids)
+        self.assertNotIn("failed-rerun", task_ids)
+
+        results_including_rerun = self.service.get_recent_failed_tasks(
+            hours=24,
+            exclude_retried=False
+        )
+        task_ids_including = {task.task_id for task in results_including_rerun}
+
+        self.assertIn("failed-rerun", task_ids_including)
 
     def test_results_respect_limit_and_order(self):
         for index in range(3):

--- a/frontend/app/stores/failedTasks.ts
+++ b/frontend/app/stores/failedTasks.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { useApiService } from '../services/apiClient'
-import type { TaskEventResponse } from '../services/apiClient'
+import type { TaskActionDetailDTO, TaskEventResponse } from '../services/apiClient'
 
 const DEFAULT_LOOKBACK_HOURS = 24
 const MIN_LOOKBACK_HOURS = 1
@@ -86,6 +86,12 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
       return true
     }
     if (task.retried_by && Array.isArray(task.retried_by) && task.retried_by.length > 0) {
+      return true
+    }
+    if (task.has_reruns) {
+      return true
+    }
+    if (task.rerun_by && Array.isArray(task.rerun_by) && task.rerun_by.length > 0) {
       return true
     }
     return false
@@ -189,6 +195,18 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     }
   }
 
+  function updateFromTaskAction(action: TaskActionDetailDTO) {
+    if (action.action_type !== 'rerun' || !Array.isArray(action.items)) {
+      return
+    }
+
+    for (const item of action.items) {
+      if (item.outcome === 'created') {
+        removeFailedTask(item.original_task_id)
+      }
+    }
+  }
+
   return {
     failedTasks,
     isLoading,
@@ -202,6 +220,7 @@ export const useFailedTasksStore = defineStore('failedTasks', () => {
     fetchFailedTasks,
     setLookbackHours,
     updateFromLiveEvent,
+    updateFromTaskAction,
     pruneExpired,
     removeFailedTask,
     applyResolutionState,

--- a/frontend/app/stores/websocket.ts
+++ b/frontend/app/stores/websocket.ts
@@ -176,6 +176,7 @@ export const useWebSocketStore = defineStore('websocket', () => {
         }
         else if (eventType === 'kanchi-task-action') {
           taskActionsStore.handleLiveEvent(message)
+          failedTasksStore.updateFromTaskAction(message)
         }
         else if (eventType.startsWith('worker-')) {
           workersStore.updateFromLiveEvent(message)


### PR DESCRIPTION
## Summary

- Treat manually rerun task failures as addressed in registry stats and recent failed-task queries.
- Keep Celery retry lineage and Kanchi manual rerun lineage separate.
- Remove failed originals from the dashboard immediately when a rerun action is created over WebSocket.
- Add regression tests for recent failed tasks and task registry stats.

## Root Cause

Kanchi records user-initiated restart/rerun actions in `TaskRerunRelationshipDB`, but the active/unretried failure surfaces only checked Celery retry data (`RetryRelationshipDB`, `has_retries`, and `retried_by`). That left the original failed task visible as an unresolved failure after a manual restart.

Fixes #134

## Validation

- `poetry run python -m unittest tests.unit.test_task_service_recent_failures tests.unit.test_task_registry_service`
- `poetry run python -m unittest discover -s tests/unit`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed tasks that have been rerun are now properly excluded from the failed tasks list.
  * Task reruns are automatically removed from the failed tasks view when created.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getkanchi/kanchi/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->