### PR TITLE
fix(api): keep synchronous database work off the event loop

### DIFF
--- a/agent/api/action_config_routes.py
+++ b/agent/api/action_config_routes.py
@@ -32,7 +32,7 @@ def create_router(app_state) -> APIRouter:
             yield session
 
     @router.post("", response_model=ActionConfigDefinition, status_code=201)
-    async def create_action_config(
+    def create_action_config(
         config_data: ActionConfigCreateRequest,
         session: Session = Depends(get_db)
     ):
@@ -42,7 +42,7 @@ def create_router(app_state) -> APIRouter:
         return config
 
     @router.get("", response_model=List[ActionConfigDefinition])
-    async def list_action_configs(
+    def list_action_configs(
         action_type: Optional[str] = None,
         limit: int = 100,
         offset: int = 0,
@@ -58,7 +58,7 @@ def create_router(app_state) -> APIRouter:
         return configs
 
     @router.get("/{config_id}", response_model=ActionConfigDefinition)
-    async def get_action_config(
+    def get_action_config(
         config_id: str,
         session: Session = Depends(get_db)
     ):
@@ -72,7 +72,7 @@ def create_router(app_state) -> APIRouter:
         return config
 
     @router.put("/{config_id}", response_model=ActionConfigDefinition)
-    async def update_action_config(
+    def update_action_config(
         config_id: str,
         updates: ActionConfigUpdateRequest,
         session: Session = Depends(get_db)
@@ -87,7 +87,7 @@ def create_router(app_state) -> APIRouter:
         return config
 
     @router.delete("/{config_id}", status_code=204)
-    async def delete_action_config(
+    def delete_action_config(
         config_id: str,
         session: Session = Depends(get_db)
     ):

--- a/agent/api/auth_routes.py
+++ b/agent/api/auth_routes.py
@@ -81,7 +81,7 @@ def create_router(app_state) -> APIRouter:
         )
 
     @router.post("/basic/login", response_model=LoginResponse)
-    async def basic_login(
+    def basic_login(
         payload: BasicLoginRequest,
         auth_service: AuthService = Depends(require_auth_service),
         config: Config = Depends(get_config),
@@ -102,7 +102,7 @@ def create_router(app_state) -> APIRouter:
         return _login_result_to_response(result)
 
     @router.post("/refresh", response_model=LoginResponse)
-    async def refresh_tokens(
+    def refresh_tokens(
         payload: RefreshRequest,
         auth_service: AuthService = Depends(require_auth_service),
     ):
@@ -114,7 +114,7 @@ def create_router(app_state) -> APIRouter:
         return _login_result_to_response(result)
 
     @router.post("/logout", status_code=204)
-    async def logout(
+    def logout(
         payload: LogoutRequest,
         auth_service: AuthService = Depends(require_auth_service),
         current_user: AuthenticatedUser | None = Depends(optional_authenticated_user),
@@ -127,7 +127,7 @@ def create_router(app_state) -> APIRouter:
         return Response(status_code=204)
 
     @router.get("/me", response_model=UserInfo)
-    async def get_current_user(
+    def get_current_user(
         db_session=Depends(get_db),
         current_user: AuthenticatedUser = Depends(require_authenticated_user),
     ):

--- a/agent/api/config_routes.py
+++ b/agent/api/config_routes.py
@@ -38,19 +38,19 @@ def create_router(app_state) -> APIRouter:
         return RetentionService(session)
 
     @router.get("", response_model=AppConfigSnapshot)
-    async def get_config_snapshot(
+    def get_config_snapshot(
         config_service: AppConfigService = Depends(get_config_service)
     ):
         """Get grouped application configuration with defaults applied."""
         return config_service.get_config_snapshot()
 
     @router.get("/settings", response_model=List[AppSetting])
-    async def list_settings(config_service: AppConfigService = Depends(get_config_service)):
+    def list_settings(config_service: AppConfigService = Depends(get_config_service)):
         """List all application settings."""
         return config_service.list_settings()
 
     @router.get("/settings/{key}", response_model=AppSetting)
-    async def get_setting(
+    def get_setting(
         key: str,
         config_service: AppConfigService = Depends(get_config_service)
     ):
@@ -61,7 +61,7 @@ def create_router(app_state) -> APIRouter:
         return setting
 
     @router.put("/settings/{key}", response_model=AppSetting)
-    async def upsert_setting(
+    def upsert_setting(
         key: str,
         payload: AppSettingUpdate,
         config_service: AppConfigService = Depends(get_config_service)
@@ -76,7 +76,7 @@ def create_router(app_state) -> APIRouter:
             raise HTTPException(status_code=500, detail="Failed to update setting") from exc
 
     @router.delete("/settings/{key}", status_code=204)
-    async def delete_setting(
+    def delete_setting(
         key: str,
         config_service: AppConfigService = Depends(get_config_service)
     ):
@@ -87,14 +87,14 @@ def create_router(app_state) -> APIRouter:
         return None
 
     @router.get("/retention", response_model=DataRetentionConfig)
-    async def get_retention_policy(
+    def get_retention_policy(
         retention_service: RetentionService = Depends(get_retention_service)
     ):
         """Get normalized data retention policy values."""
         return retention_service.get_policy()
 
     @router.post("/retention/cleanup", response_model=RetentionCleanupResponse)
-    async def run_retention_cleanup(
+    def run_retention_cleanup(
         dry_run: bool = Query(default=True),
         retention_service: RetentionService = Depends(get_retention_service)
     ):

--- a/agent/api/environment_routes.py
+++ b/agent/api/environment_routes.py
@@ -32,7 +32,7 @@ def create_router(app_state) -> APIRouter:
             yield session
 
     @router.post("", response_model=EnvironmentResponse, status_code=201)
-    async def create_environment(
+    def create_environment(
         env_create: EnvironmentCreate,
         session: Session = Depends(get_db)
     ):
@@ -45,7 +45,7 @@ def create_router(app_state) -> APIRouter:
             raise HTTPException(status_code=500, detail=str(e))
 
     @router.get("", response_model=List[EnvironmentResponse])
-    async def list_environments(session: Session = Depends(get_db)):
+    def list_environments(session: Session = Depends(get_db)):
         """List all environments."""
         try:
             service = EnvironmentService(session)
@@ -55,7 +55,7 @@ def create_router(app_state) -> APIRouter:
             raise HTTPException(status_code=500, detail=str(e))
 
     @router.get("/{env_id}", response_model=EnvironmentResponse)
-    async def get_environment(env_id: str, session: Session = Depends(get_db)):
+    def get_environment(env_id: str, session: Session = Depends(get_db)):
         """Get environment by ID."""
         try:
             service = EnvironmentService(session)
@@ -70,7 +70,7 @@ def create_router(app_state) -> APIRouter:
             raise HTTPException(status_code=500, detail=str(e))
 
     @router.patch("/{env_id}", response_model=EnvironmentResponse)
-    async def update_environment(
+    def update_environment(
         env_id: str,
         env_update: EnvironmentUpdate,
         session: Session = Depends(get_db)
@@ -89,7 +89,7 @@ def create_router(app_state) -> APIRouter:
             raise HTTPException(status_code=500, detail=str(e))
 
     @router.delete("/{env_id}", status_code=204)
-    async def delete_environment(env_id: str, session: Session = Depends(get_db)):
+    def delete_environment(env_id: str, session: Session = Depends(get_db)):
         """Delete an environment."""
         try:
             service = EnvironmentService(session)

--- a/agent/api/metrics_routes.py
+++ b/agent/api/metrics_routes.py
@@ -9,7 +9,7 @@ def create_router(app_state) -> APIRouter:  # noqa: ARG001 - signature kept for 
     router = APIRouter()
 
     @router.get("/metrics")
-    async def metrics():
+    def metrics():
         return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
     return router

--- a/agent/api/registry_routes.py
+++ b/agent/api/registry_routes.py
@@ -36,7 +36,7 @@ def create_router(app_state) -> APIRouter:
         with app_state.db_manager.get_session() as session:
             yield session
 
-    async def get_active_env(
+    def get_active_env(
         session: Session = Depends(get_db),
         x_session_id: Optional[str] = Header(None),
         current_user: Optional[AuthenticatedUser] = Depends(optional_user_dep)
@@ -59,7 +59,7 @@ def create_router(app_state) -> APIRouter:
         return env_service.get_environment(env_id)
 
     @router.get("/tasks", response_model=List[TaskRegistryResponse])
-    async def list_tasks(
+    def list_tasks(
         tag: Optional[str] = None,
         name: Optional[str] = None,
         session: Session = Depends(get_db),
@@ -76,7 +76,7 @@ def create_router(app_state) -> APIRouter:
         return registry_service.list_tasks(tag=tag, name_filter=name)
 
     @router.get("/tasks/{task_name}", response_model=TaskRegistryResponse)
-    async def get_task(
+    def get_task(
         task_name: str,
         session: Session = Depends(get_db),
         active_env = Depends(get_active_env)
@@ -96,7 +96,7 @@ def create_router(app_state) -> APIRouter:
         return task
 
     @router.put("/tasks/{task_name}", response_model=TaskRegistryResponse)
-    async def update_task(
+    def update_task(
         task_name: str,
         update_data: TaskRegistryUpdate,
         session: Session = Depends(get_db),
@@ -118,7 +118,7 @@ def create_router(app_state) -> APIRouter:
         return updated_task
 
     @router.get("/tasks/{task_name}/stats", response_model=TaskRegistryStats)
-    async def get_task_stats(
+    def get_task_stats(
         task_name: str,
         hours: int = 24,
         session: Session = Depends(get_db),
@@ -141,7 +141,7 @@ def create_router(app_state) -> APIRouter:
         return registry_service.get_task_stats(task_name, hours=hours)
 
     @router.get("/tasks/{task_name}/timeline", response_model=TaskTimelineResponse)
-    async def get_task_timeline(
+    def get_task_timeline(
         task_name: str,
         hours: int = Query(24, description="Number of hours to look back"),
         bucket_size_minutes: int = Query(60, description="Bucket size in minutes (e.g., 60 for 1-hour buckets)"),
@@ -170,7 +170,7 @@ def create_router(app_state) -> APIRouter:
         )
 
     @router.get("/tags", response_model=List[str])
-    async def get_all_tags(
+    def get_all_tags(
         session: Session = Depends(get_db),
         active_env = Depends(get_active_env)
     ):
@@ -179,7 +179,7 @@ def create_router(app_state) -> APIRouter:
         return registry_service.get_all_tags()
 
     @router.get("/tasks/{task_name}/daily-stats", response_model=List[TaskDailyStatsResponse])
-    async def get_task_daily_stats(
+    def get_task_daily_stats(
         task_name: str,
         start_date: Optional[date] = Query(None, description="Start date (YYYY-MM-DD)"),
         end_date: Optional[date] = Query(None, description="End date (YYYY-MM-DD)"),
@@ -216,7 +216,7 @@ def create_router(app_state) -> APIRouter:
         )
 
     @router.get("/tasks/{task_name}/trend", response_model=dict)
-    async def get_task_trend(
+    def get_task_trend(
         task_name: str,
         days: int = Query(7, description="Number of days to analyze"),
         session: Session = Depends(get_db),
@@ -237,7 +237,7 @@ def create_router(app_state) -> APIRouter:
         return daily_stats_service.get_task_trend_summary(task_name, days=days)
 
     @router.get("/daily-stats/{target_date}", response_model=List[TaskDailyStatsResponse])
-    async def get_all_tasks_stats_for_date(
+    def get_all_tasks_stats_for_date(
         target_date: date,
         session: Session = Depends(get_db)
     ):

--- a/agent/api/session_routes.py
+++ b/agent/api/session_routes.py
@@ -35,7 +35,7 @@ def create_router(app_state) -> APIRouter:
         return x_session_id
 
     @router.post("/init", response_model=UserSessionResponse, status_code=200)
-    async def initialize_session(
+    def initialize_session(
         session_id: str = Depends(get_session_id),
         db_session: Session = Depends(get_db),
         current_user: Optional[AuthenticatedUser] = Depends(optional_user_dep)
@@ -64,7 +64,7 @@ def create_router(app_state) -> APIRouter:
             raise HTTPException(status_code=500, detail=str(e))
 
     @router.get("/me", response_model=UserSessionResponse)
-    async def get_current_session(
+    def get_current_session(
         session_id: str = Depends(get_session_id),
         db_session: Session = Depends(get_db),
         current_user: Optional[AuthenticatedUser] = Depends(optional_user_dep)
@@ -95,7 +95,7 @@ def create_router(app_state) -> APIRouter:
             raise HTTPException(status_code=500, detail=str(e))
 
     @router.patch("/me", response_model=UserSessionResponse)
-    async def update_current_session(
+    def update_current_session(
         session_update: UserSessionUpdate,
         session_id: str = Depends(get_session_id),
         db_session: Session = Depends(get_db),
@@ -127,7 +127,7 @@ def create_router(app_state) -> APIRouter:
             raise HTTPException(status_code=500, detail=str(e))
 
     @router.post("/me/environment/{environment_id}", response_model=UserSessionResponse)
-    async def set_session_environment(
+    def set_session_environment(
         environment_id: str,
         session_id: str = Depends(get_session_id),
         db_session: Session = Depends(get_db),
@@ -159,7 +159,7 @@ def create_router(app_state) -> APIRouter:
             raise HTTPException(status_code=500, detail=str(e))
 
     @router.delete("/me/environment", response_model=UserSessionResponse)
-    async def clear_session_environment(
+    def clear_session_environment(
         session_id: str = Depends(get_session_id),
         db_session: Session = Depends(get_db),
         current_user: Optional[AuthenticatedUser] = Depends(optional_user_dep)

--- a/agent/api/task_action_routes.py
+++ b/agent/api/task_action_routes.py
@@ -43,7 +43,7 @@ def create_router(app_state) -> APIRouter:
         with app_state.db_manager.get_session() as session:
             yield session
 
-    async def get_active_env(
+    def get_active_env(
         session: Session = Depends(get_db),
         x_session_id: Optional[str] = Header(None),
         current_user: Optional[AuthenticatedUser] = Depends(optional_user_dep),
@@ -82,7 +82,7 @@ def create_router(app_state) -> APIRouter:
         response_model=RerunPreflightResponse,
         include_in_schema=False,
     )
-    async def preflight_rerun_review(
+    def preflight_rerun_review(
         payload: RerunPreflightRequest,
         session: Session = Depends(get_db),
         active_env=Depends(get_active_env),
@@ -98,7 +98,7 @@ def create_router(app_state) -> APIRouter:
         response_model=RerunPreflightResponse,
         include_in_schema=False,
     )
-    async def preflight_task_action(
+    def preflight_task_action(
         payload: RerunPreflightRequest,
         session: Session = Depends(get_db),
         active_env=Depends(get_active_env),
@@ -114,7 +114,7 @@ def create_router(app_state) -> APIRouter:
         response_model=TaskActionDetail,
         include_in_schema=False,
     )
-    async def submit_rerun_review(
+    def submit_rerun_review(
         payload: RerunSubmitRequest,
         session: Session = Depends(get_db),
         x_session_id: Optional[str] = Header(None),
@@ -136,7 +136,7 @@ def create_router(app_state) -> APIRouter:
         response_model=TaskActionDetail,
         include_in_schema=False,
     )
-    async def create_task_action(
+    def create_task_action(
         payload: TaskActionCreateRequest,
         session: Session = Depends(get_db),
         x_session_id: Optional[str] = Header(None),
@@ -159,7 +159,7 @@ def create_router(app_state) -> APIRouter:
         response_model=TaskActionListResponse,
         include_in_schema=False,
     )
-    async def list_task_actions(
+    def list_task_actions(
         limit: int = Query(default=20, ge=1, le=100),
         session: Session = Depends(get_db),
         active_env=Depends(get_active_env),
@@ -183,7 +183,7 @@ def create_router(app_state) -> APIRouter:
         response_model=TaskActionDetail,
         include_in_schema=False,
     )
-    async def get_task_action(
+    def get_task_action(
         action_id: str,
         session: Session = Depends(get_db),
         active_env=Depends(get_active_env),
@@ -199,7 +199,7 @@ def create_router(app_state) -> APIRouter:
         response_model=RerunPreflightResponse,
         include_in_schema=False,
     )
-    async def preflight_single_rerun(
+    def preflight_single_rerun(
         task_id: str,
         session: Session = Depends(get_db),
         active_env=Depends(get_active_env),
@@ -212,7 +212,7 @@ def create_router(app_state) -> APIRouter:
         response_model=TaskActionDetail,
         include_in_schema=False,
     )
-    async def rerun_single_task(
+    def rerun_single_task(
         task_id: str,
         session: Session = Depends(get_db),
         x_session_id: Optional[str] = Header(None),

--- a/agent/api/task_routes.py
+++ b/agent/api/task_routes.py
@@ -41,7 +41,7 @@ def create_router(app_state) -> APIRouter:
         with app_state.db_manager.get_session() as session:
             yield session
 
-    async def get_active_env(
+    def get_active_env(
         session: Session = Depends(get_db),
         x_session_id: Optional[str] = Header(None),
         current_user: Optional[AuthenticatedUser] = Depends(optional_user_dep)
@@ -65,7 +65,7 @@ def create_router(app_state) -> APIRouter:
 
 
     @router.get("/events/recent", response_model=Dict[str, Any])
-    async def get_recent_events(
+    def get_recent_events(
         limit: int = 100,
         page: int = 0,
         aggregate: bool = True,
@@ -104,7 +104,7 @@ def create_router(app_state) -> APIRouter:
 
 
     @router.get("/events/{task_id}", response_model=List[TaskEvent])
-    async def get_task_events(task_id: str, session: Session = Depends(get_db)):
+    def get_task_events(task_id: str, session: Session = Depends(get_db)):
         """Get all events for a specific task."""
         task_service = TaskService(session)
         task_events = task_service.get_task_events(task_id)
@@ -115,7 +115,7 @@ def create_router(app_state) -> APIRouter:
         return task_events
 
     @router.get("/tasks/{task_id}/progress", response_model=TaskProgressSnapshot)
-    async def get_task_progress(task_id: str, session: Session = Depends(get_db)):
+    def get_task_progress(task_id: str, session: Session = Depends(get_db)):
         """Get latest progress, steps, and recent history for a task."""
         progress_service = ProgressService(session)
         latest = progress_service.get_latest_progress(task_id)
@@ -131,7 +131,7 @@ def create_router(app_state) -> APIRouter:
 
 
     @router.get("/tasks/active", response_model=List[TaskEvent])
-    async def get_active_tasks(
+    def get_active_tasks(
         session: Session = Depends(get_db),
         active_env = Depends(get_active_env)
     ):
@@ -142,7 +142,7 @@ def create_router(app_state) -> APIRouter:
 
 
     @router.get("/tasks/orphaned", response_model=List[TaskEvent])
-    async def get_orphaned_tasks(
+    def get_orphaned_tasks(
         session: Session = Depends(get_db),
         active_env = Depends(get_active_env)
     ):
@@ -151,7 +151,7 @@ def create_router(app_state) -> APIRouter:
         return task_service.get_unretried_orphaned_tasks()
 
     @router.get("/tasks/failed/recent", response_model=List[TaskEvent])
-    async def get_recent_failed_tasks(
+    def get_recent_failed_tasks(
         hours: Optional[int] = Query(
             default=None,
             ge=1,
@@ -176,7 +176,7 @@ def create_router(app_state) -> APIRouter:
 
 
     @router.post("/tasks/{task_id}/resolve")
-    async def resolve_task(
+    def resolve_task(
         task_id: str,
         payload: Optional[ResolveTaskRequest] = None,
         session: Session = Depends(get_db),
@@ -202,7 +202,7 @@ def create_router(app_state) -> APIRouter:
 
 
     @router.delete("/tasks/{task_id}/resolve")
-    async def clear_task_resolution(
+    def clear_task_resolution(
         task_id: str,
         session: Session = Depends(get_db),
     ):
@@ -222,7 +222,7 @@ def create_router(app_state) -> APIRouter:
 
 
     @router.post("/tasks/{task_id}/retry")
-    async def retry_task(task_id: str, session: Session = Depends(get_db)):
+    def retry_task(task_id: str, session: Session = Depends(get_db)):
         """Retry a failed task by creating a new task with the same parameters."""
         if not app_state.monitor_instance:
             raise HTTPException(status_code=500, detail="Monitor not initialized")

--- a/agent/api/worker_routes.py
+++ b/agent/api/worker_routes.py
@@ -82,7 +82,7 @@ def create_router(app_state) -> APIRouter:
 
 
     @router.get("/workers/events/recent")
-    async def get_recent_worker_events(limit: int = 50, session: Session = Depends(get_db)):
+    def get_recent_worker_events(limit: int = 50, session: Session = Depends(get_db)):
         """Get recent worker events."""
         worker_service = WorkerService(session)
         return worker_service.get_recent_worker_events(limit)

--- a/agent/api/workflow_routes.py
+++ b/agent/api/workflow_routes.py
@@ -45,7 +45,7 @@ def create_router(app_state) -> APIRouter:
     # ==================== Workflow CRUD ====================
 
     @router.post("", response_model=WorkflowDefinition, status_code=201)
-    async def create_workflow(
+    def create_workflow(
         workflow_data: WorkflowCreateRequest,
         session: Session = Depends(get_db)
     ):
@@ -58,7 +58,7 @@ def create_router(app_state) -> APIRouter:
         return workflow
 
     @router.get("", response_model=List[WorkflowDefinition])
-    async def list_workflows(
+    def list_workflows(
         enabled_only: bool = False,
         trigger_type: Optional[str] = None,
         limit: int = 100,
@@ -76,7 +76,7 @@ def create_router(app_state) -> APIRouter:
         return workflows
 
     @router.get("/{workflow_id}", response_model=WorkflowDefinition)
-    async def get_workflow(
+    def get_workflow(
         workflow_id: str,
         session: Session = Depends(get_db)
     ):
@@ -90,7 +90,7 @@ def create_router(app_state) -> APIRouter:
         return workflow
 
     @router.put("/{workflow_id}", response_model=WorkflowDefinition)
-    async def update_workflow(
+    def update_workflow(
         workflow_id: str,
         updates: WorkflowUpdateRequest,
         session: Session = Depends(get_db)
@@ -108,7 +108,7 @@ def create_router(app_state) -> APIRouter:
         return workflow
 
     @router.delete("/{workflow_id}", status_code=204)
-    async def delete_workflow(
+    def delete_workflow(
         workflow_id: str,
         session: Session = Depends(get_db)
     ):
@@ -122,7 +122,7 @@ def create_router(app_state) -> APIRouter:
     # ==================== Workflow Executions ====================
 
     @router.get("/{workflow_id}/executions", response_model=List[WorkflowExecutionRecord])
-    async def get_workflow_executions(
+    def get_workflow_executions(
         workflow_id: str,
         limit: int = 100,
         offset: int = 0,
@@ -145,7 +145,7 @@ def create_router(app_state) -> APIRouter:
         return executions
 
     @router.get("/executions/recent", response_model=List[WorkflowExecutionRecord])
-    async def get_recent_executions(
+    def get_recent_executions(
         status: Optional[str] = None,
         limit: int = 100,
         offset: int = 0,
@@ -163,7 +163,7 @@ def create_router(app_state) -> APIRouter:
     # ==================== Workflow Testing ====================
 
     @router.post("/{workflow_id}/test")
-    async def test_workflow(
+    def test_workflow(
         workflow_id: str,
         test_context: dict,
         session: Session = Depends(get_db)


### PR DESCRIPTION
## What changed

- Declare synchronous SQLAlchemy-backed REST handlers and dependencies with `def`.
- Declare `/metrics` with `def` because Prometheus rendering is synchronous.
- Keep health checks, WebSockets, and OAuth network flows asynchronous.

No queries, response schemas, database settings, or API contracts changed.

## Why

FastAPI executes `async def` handlers on the event-loop thread. These handlers call Kanchi's synchronous SQLAlchemy session directly, so a slow query or connection-pool wait blocks that event loop and prevents `/api/health` from responding.

FastAPI executes `def` handlers in its worker thread pool. A blocked database request can therefore remain slow without freezing health checks, WebSockets, or unrelated asynchronous requests.

In an isolated PostgreSQL pool-exhaustion reproduction using the v2.0.1 pool settings, the existing handler blocked a concurrent health request for 11.8 seconds. Changing only the handler to `def` kept the same database request blocked for about 12 seconds while health responded in about 1 ms.

This addresses a concrete event-loop blocking mechanism related to #140. It does not claim that PostgreSQL pool exhaustion is the confirmed trigger in the reporter's deployment.

## Verification

- `python -m pytest -q` — 212 passed
- `python -m compileall -q api`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated API route handling across action configurations, authentication, environments, metrics, registries, sessions, tasks, workers, and workflows.
  * Existing endpoints, responses, parameters, authentication checks, and error handling remain unchanged.
  * Requests now use consistent synchronous processing across the affected API operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->